### PR TITLE
Multiple host names fix

### DIFF
--- a/src/Extensions/Client/CommerceWebClient/CommerceWebClient.csproj
+++ b/src/Extensions/Client/CommerceWebClient/CommerceWebClient.csproj
@@ -122,6 +122,7 @@
     <Reference Include="System.Runtime.Caching" />
     <Reference Include="System.Runtime.Serialization" />
     <Reference Include="System.ServiceModel" />
+    <Reference Include="System.ServiceModel.Web" />
     <Reference Include="System.Web" />
     <Reference Include="System.Web.ApplicationServices" />
     <Reference Include="System.Web.Extensions">

--- a/src/Extensions/Client/CommerceWebClient/Services/Security/OAuthAuthorizationManager.cs
+++ b/src/Extensions/Client/CommerceWebClient/Services/Security/OAuthAuthorizationManager.cs
@@ -33,7 +33,9 @@ namespace VirtoCommerce.Web.Client.Services.Security
                 // Extract authorization data.
                 var requestMessage = operationContext.RequestContext.RequestMessage;
                 var httpDetails = requestMessage.Properties[HttpRequestMessageProperty.Name] as HttpRequestMessageProperty;
-                var requestUri = requestMessage.Headers.To;
+               
+                // var requestUri = requestMessage.Headers.To; //if IIS has multiple hostnames for this website then a Uri with the first hostname is returned.
+                var requestUri = System.ServiceModel.Web.WebOperationContext.Current.IncomingRequest.UriTemplateMatch.BaseUri; //Here the proper Uri of the requset is returned.
 
                 token = ReadAuthToken(httpDetails);
                 retVal = token != null && IsValidToken(token, requestUri);


### PR DESCRIPTION
If your website has multiple hostnames then you can have problems connecting the Manager to the Website.
You can only connect to the First (default) hostname.

E.g.
Hostname 1: testname
Hostname 2: virtotest

You can connect Virto Manager to 'testname' but not to 'virtotest'
I have made a small change that makes the code work for any host name including I.P. addresses.

Changed Namespace = VirtoCommerce.Web.Client.Services.Security
Changed File name = OAuthAuthorizationManager.cs
Changed Method Name = CheckAccessCore

The current way we get 'requestUri' only gets the default url of the service (i.e. the url using the first hostname).
I have changed way we get 'requestUri' to get the url of the incoming request.

I understand that the code checks the Audience(Scope) and the RequestUri in order to make the service more secure but I am not 100% about this mechanism.
I am hoping that my change is not opening the service up to any attacks.

What do you guys think about my code change?

Also I have seen that there is a problem if you use an upper case host name.
This could easily be fixed but setting the two urls to lower case before they are compaired.
I can add that code if you think it is a good idea?
