### PR TITLE
Added web.config setting VirtoCommerce:ModulesDataSources as input parameter

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -54,6 +54,10 @@
                 "2"
             ],
             "defaultValue": "0"
+        },
+        "modulesDataSources": {
+            "type": "string",
+            "defaultValue": "https://raw.githubusercontent.com/VirtoCommerce/vc-modules/master/modules.json"
         }
     },
     "variables": {
@@ -204,7 +208,8 @@
                         "[resourceId('Microsoft.Web/Sites', parameters('siteName'))]"
                     ],
                     "properties": {
-                        "VirtoCommerce:AutoInstallModuleBundles": "[variables('moduleBundles')[parameters('installModuleBundle')].configValue]"
+                        "VirtoCommerce:AutoInstallModuleBundles": "[variables('moduleBundles')[parameters('installModuleBundle')].configValue]",
+                        "VirtoCommerce:ModulesDataSources": "[parameters('modulesDataSources')]"
                     }
                 },
                 {


### PR DESCRIPTION
This commit makes it possible to control which version of the modules.json file (containing module versions) is being used for module installation after an Azure deployment. 
Currently, the latest version of the file is used by default, which is OK if you always deploy and install the latest version of VC. But if you need to deploy a particular version of VC platform + storefront + modules to your environments, you need to be able to "freeze" module versions as well. Since modules are installed after Azure deployment and do not have their own ARM template, I figured this commit was the easiest way to introduce proper module versioning. 
For instance, I will give the following value to the modulesDataSources input parameter if I need the module versions available on July 28th of this year:
https://raw.githubusercontent.com/VirtoCommerce/vc-modules/288b8717bd512bb826981c03bf33f533ee853206/modules.json