### PR TITLE
Change URI when open blob for read using CDN

### DIFF
--- a/VirtoCommerce.Platform.Data.Azure/AzureBlobProvider.cs
+++ b/VirtoCommerce.Platform.Data.Azure/AzureBlobProvider.cs
@@ -72,7 +72,22 @@ namespace VirtoCommerce.Platform.Data.Azure
             if (string.IsNullOrEmpty(url))
                 throw new ArgumentNullException(nameof(url));
 
-            var uri = url.IsAbsoluteUrl() ? new Uri(url) : new Uri(_cloudBlobClient.BaseUri, url.TrimStart('/'));
+            var isAbsoluteUrl = url.IsAbsoluteUrl();
+            Uri uri = null;
+
+            if (isAbsoluteUrl)
+            {
+                uri = new Uri(url);
+                if (!string.IsNullOrWhiteSpace(_cdnUrl))
+                {
+                    uri = new Uri(_cloudBlobClient.BaseUri, uri.AbsolutePath.TrimStart('/'));
+                }
+            }
+            else
+            {
+                uri = new Uri(_cloudBlobClient.BaseUri, url.TrimStart('/'));
+            }
+
             var cloudBlob = _cloudBlobClient.GetBlobReferenceFromServer(uri);
             return cloudBlob.OpenRead();
         }

--- a/VirtoCommerce.Platform.Data.Azure/AzureBlobProvider.cs
+++ b/VirtoCommerce.Platform.Data.Azure/AzureBlobProvider.cs
@@ -72,23 +72,8 @@ namespace VirtoCommerce.Platform.Data.Azure
             if (string.IsNullOrEmpty(url))
                 throw new ArgumentNullException(nameof(url));
 
-            var isAbsoluteUrl = url.IsAbsoluteUrl();
-            Uri uri = null;
-
-            if (isAbsoluteUrl)
-            {
-                uri = new Uri(url);
-                if (!string.IsNullOrWhiteSpace(_cdnUrl))
-                {
-                    uri = new Uri(_cloudBlobClient.BaseUri, uri.AbsolutePath.TrimStart('/'));
-                }
-            }
-            else
-            {
-                uri = new Uri(_cloudBlobClient.BaseUri, url.TrimStart('/'));
-            }
-
-            var cloudBlob = _cloudBlobClient.GetBlobReferenceFromServer(uri);
+            var uri = url.IsAbsoluteUrl() ? new Uri(url) : new Uri(_cloudBlobClient.BaseUri, url.TrimStart('/'));
+            var cloudBlob = _cloudBlobClient.GetBlobReferenceFromServer(new Uri(_cloudBlobClient.BaseUri, uri.AbsolutePath.TrimStart('/')));
             return cloudBlob.OpenRead();
         }
 


### PR DESCRIPTION
We get an error in ImageTools module when trying to generate thumbnails for uploaded images. Azure CloudBlobClient does not work correctly when accessing the image via CDN Url. So, in this fix, we replace CDN Url with base storage Url when open blob for reading.