### PR TITLE
Fix retrieval of notification template for overriden notification.

### DIFF
--- a/VirtoCommerce.Platform.Data/Notifications/NotificationManager.cs
+++ b/VirtoCommerce.Platform.Data/Notifications/NotificationManager.cs
@@ -119,7 +119,9 @@ namespace VirtoCommerce.Platform.Data.Notifications
             retVal.ObjectTypeId = objectTypeId;
             retVal.Language = language;
 
-            var template = _notificationTemplateService.GetByNotification(type, objectId, objectTypeId, language);
+            var notificationTypeName = retVal.GetType().Name;
+            var template = _notificationTemplateService.GetByNotification(notificationTypeName, objectId, objectTypeId, language);
+
             if (template != null)
             {
                 retVal.NotificationTemplate = template;


### PR DESCRIPTION
I created a new notification type that overrides the Order Paid Notification Email:

notificationManager.OverrideNotificationType(
() => new MoreOrderPaidEmail(memberService, _container.Resolve())
{
NotificationTemplate = new NotificationTemplate
{
Body = OrderPaid.MoreOrderPaidNotificationBody,
Subject = OrderPaid.MoreOrderPaidNotificationSubject
}
});

This means that in the virto front end: I can modify the MoreOrderPaidEmail but not the OrderPaidEmailNotification, as expected, but of course the NotificationTypeId is MoreOrderPaidEmail as well.

When the email is sent, triggered by the OrderNotificationObserver, it looks for a notification template OrderPaidEmailNotification, even when overriden, so it doesn't find the template.

I think this can be fixed as below, as we should use the type of retval in GetNewNotification which is not necessarily the parameter type.

cfr https://github.com/VirtoCommerce/vc-platform/pull/1265