### PR TITLE
fix height grid

### DIFF
--- a/VirtoCommerce.Platform.Web/Scripts/common/uiGridUtils.js
+++ b/VirtoCommerce.Platform.Web/Scripts/common/uiGridUtils.js
@@ -234,19 +234,35 @@
     }])
 
     // auto height and additional class for ui-grid
-    .directive('uiGridHeight', ['$timeout', '$window', function ($timeout, $window) {
+    // attr =  the selector in which the part of the grid is located
+    .directive('uiGridHeight', ['$timeout', '$window', '$rootScope', function ($timeout, $window, $rootScope) {
         return {
             restrict: 'A',
             link: {
-                pre: function (scope, element) {
+                pre: function (scope, element, attrs) {
+                    //If the blade is not only grid.
+                    var nonGridPart;
+                    var heightAttr = attrs["uiGridHeight"];
+                    if (heightAttr)
+                        nonGridPart = $(heightAttr).siblings();
+
                     var bladeInner = $(element).parents('.blade-inner');
-                    bladeInner.addClass('ui-grid-no-scroll');
+
+                    if (!heightAttr)
+                        bladeInner.addClass('ui-grid-no-scroll');
 
                     var setGridHeight = function () {
                         $timeout(function () {
-                            $(element).height(bladeInner.height());
+                            if (heightAttr) {
+                                var result = nonGridPart.height() / bladeInner.height();
+                                //values selected by experience
+                                $(element).height(result < 0.7 ? bladeInner.height() * 0.3 : nonGridPart.height() * 0.5);
+                            } else {
+                                $(element).height(bladeInner.height());
+                            }
                         });
                     };
+
                     scope.$watch('blade.isExpanded', setGridHeight);
                     scope.$watch('pageSettings.totalItems', setGridHeight);
                     angular.element($window).bind('resize', setGridHeight);


### PR DESCRIPTION
![ytdxvdsjs2](https://user-images.githubusercontent.com/13115017/36736371-1ce8d23c-1be1-11e8-8821-83d0fdb96209.gif)
If the directive does not pass the attribute, it is still used,
If you pass the attribute, then the height of the grid is calculated depending on the space occupied in the blade.
In the directive, we pass the selector in which the grid is located
```
<div class="blade-content __medium-wide">
    <div class="blade-inner">
        <div class="inner-block">
            <div class="part-1"></div>
            <div class="part-2">Here UI-GRID <div ui-grid="gridOptions" ... ui-grid-height=".part-2"</div>
        </div>
     </div>
</div>
```