### PR TITLE
Allow unregistering of notification types.

### DIFF
--- a/VirtoCommerce.Platform.Core/Notifications/INotificationManager.cs
+++ b/VirtoCommerce.Platform.Core/Notifications/INotificationManager.cs
@@ -21,6 +21,7 @@ namespace VirtoCommerce.Platform.Core.Notifications
         SearchNotificationsResult SearchNotifications(SearchNotificationCriteria criteria);
         void OverrideNotificationType<T>(Func<Notification> notification);
         void RegisterNotificationType(Func<Notification> notification);
+        void UnregisterNotificationType<T>();
         Notification[] GetNotifications();
     }
 }


### PR DESCRIPTION
Allows unregistering of notifications: for example when you don't want to send several mails while creating an order.

Related to https://github.com/VirtoCommerce/vc-module-order/pull/33

As discussed on Gitter: lots of changes are coming to the notification module, so this is a fix until that has been done. It will be better if 'IsActive' is actually used or there is another property to use for it, as that could then be used in the search notifications criteria. Right now, if you used to have a notification of a certain type, but it has been unregistered, it will show as an empty row in the notification history.. That could be fixed by using IsActive.