### PR TITLE
Fix caching issue after confirming user email.

### DIFF
--- a/VirtoCommerce.Platform.Core/Security/ISecurityService.cs
+++ b/VirtoCommerce.Platform.Core/Security/ISecurityService.cs
@@ -1,4 +1,4 @@
-using System.Threading.Tasks;
+﻿using System.Threading.Tasks;
 
 namespace VirtoCommerce.Platform.Core.Security
 {
@@ -23,5 +23,6 @@ namespace VirtoCommerce.Platform.Core.Security
         Permission[] GetUserPermissions(string userName);
         Task<bool> IsUserLockedAsync(string userId);
         Task<SecurityResult> UnlockUserAsync(string userId);
+        Task<SecurityResult> ConfirmUserEmailAsync(string userId, string token);
     }
 }

--- a/VirtoCommerce.Platform.Data.Security/SecurityService.cs
+++ b/VirtoCommerce.Platform.Data.Security/SecurityService.cs
@@ -437,6 +437,23 @@ namespace VirtoCommerce.Platform.Data.Security
             }
         }
 
+        public virtual async Task<SecurityResult> ConfirmUserEmailAsync(string userId, string token)
+        {
+            using (var userManager = _userManagerFactory())
+            {
+                var user = await GetApplicationUserByIdAsync(userId);
+
+                var result = await userManager.ConfirmEmailAsync(userId, token);
+
+                if (user != null)
+                {
+                    ResetCache(userId, user.UserName);
+                }
+
+                return result.ToCoreModel();
+            }
+        }
+
         #endregion
 
         protected virtual ApplicationUserExtended FindByName(string userName, UserDetails detailsLevel)


### PR DESCRIPTION
If the user confirms his/her email address, and that user is then again retrieved, then emailConfirmed is false because we still get the cached value.

Fix also needs: VirtoCommerce/vc-module-core#58