### PR TITLE
ToNullable should return null instead of default(T)

### DIFF
--- a/VirtoCommerce.Platform.Core/Common/ObjectExtension.cs
+++ b/VirtoCommerce.Platform.Core/Common/ObjectExtension.cs
@@ -95,7 +95,7 @@ namespace VirtoCommerce.Platform.Core.Common
         {
             if (obj == null)
             {
-                return default(T);
+                return null;
             }
             var objString = obj as string;
             if (objString != null)


### PR DESCRIPTION
### Problem
When trying to save `null` value for a dynamic property value of type `DateTime` the `null` value is converted to `0001-01-01T00:00:00.0000000`, which cannot be saved to the database.

### Solution
Don't convert `null` to `default(T)`
