### PR TITLE
'FileSystemBlobStorage.OpenRead()' should return read-only stream

### DIFF
--- a/VirtoCommerce.Platform.Data/Assets/FileSystemBlobProvider.cs
+++ b/VirtoCommerce.Platform.Data/Assets/FileSystemBlobProvider.cs
@@ -73,7 +73,7 @@ namespace VirtoCommerce.Platform.Data.Assets
 
             ValidatePath(filePath);
 
-            return File.Open(filePath, FileMode.Open);
+            return File.Open(filePath, FileMode.Open, FileAccess.Read);
         }
 
         /// <summary>


### PR DESCRIPTION
### Problem
At now this method returns stream with ReadWrite permissions. Inspired by #845 

### Solution
Fix 'File.Open()' params.

### Proposed of changes
Nothing here.

