### PR TITLE
Update inheritance of *SearchCriteria classes.

### DIFF
--- a/VirtoCommerce.Platform.Core/Notifications/SearchNotificationCriteria.cs
+++ b/VirtoCommerce.Platform.Core/Notifications/SearchNotificationCriteria.cs
@@ -1,13 +1,9 @@
-﻿using System;
-using System.Collections.Generic;
 using System.Linq;
-using System.Text;
-using System.Threading.Tasks;
 using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.Platform.Core.Notifications
 {
-	public class SearchNotificationCriteria
+	public class SearchNotificationCriteria : ValueObject
     {
         public SearchNotificationCriteria()
         {

--- a/VirtoCommerce.Platform.Core/PushNotifications/PushNotificationSearchCriteria.cs
+++ b/VirtoCommerce.Platform.Core/PushNotifications/PushNotificationSearchCriteria.cs
@@ -1,8 +1,9 @@
-﻿using System;
+using System;
+using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.Platform.Core.PushNotifications
 {
-	public class PushNotificationSearchCriteria
+	public class PushNotificationSearchCriteria : ValueObject
 	{
 		public PushNotificationSearchCriteria()
 		{
@@ -16,6 +17,5 @@ namespace VirtoCommerce.Platform.Core.PushNotifications
 		public int Start { get; set; }
 		public int Count { get; set; }
 		public string OrderBy { get; set; }
-		
 	}
 }


### PR DESCRIPTION
### Problem
For fix issue [#7](https://github.com/VirtoCommerce/vc-module-cache/issues/7) in vc-platform all *SearchCriteria classes should realize method 'ICacheKey.GetCacheKey()' which implemented in ValueObject class.

### Solution
Inherit all *SearchCriteria classes from ValueObject.

### Proposed of changes
Nothing

