### PR TITLE
1433: added password confirmation placeholder on password change dialog

### DIFF
--- a/VirtoCommerce.Platform.Web/Scripts/app/security/dialogs/changePasswordDialog.tpl.html
+++ b/VirtoCommerce.Platform.Web/Scripts/app/security/dialogs/changePasswordDialog.tpl.html
@@ -19,7 +19,7 @@
             <div class="form-group">
                 <label class="form-label">{{ 'platform.blades.change-password.confirm' | translate }}</label>
                 <div class="form-input">
-                    <input name="confirm" type="password" ng-model="confirm" ng-class="{'error': password != confirm}" required ui-validate=" '$value==password' " ui-validate-watch=" 'password' ">
+                    <input name="confirm" type="password" ng-model="confirm" ng-class="{'error': password != confirm}" required placeholder="{{ 'platform.blades.account-resetPassword.placeholders.repeat-password' | translate }}" ui-validate=" '$value==password' " ui-validate-watch=" 'password' ">
                 </div>
                 <div class="form-error" ng-if="!changePasswordForm.confirm.$pristine && password != confirm">
                     <span>{{ 'platform.blades.account-resetPassword.validations.repeat-password' | translate }}</span>


### PR DESCRIPTION
The password confirmation placeholder on the password change dialog was missing (I probably broke it while working on #1433). So this PR restores it.
![image](https://user-images.githubusercontent.com/1835759/46071575-85e86080-c1aa-11e8-990c-cbf946baa8dc.png)

(Sorry, looks like the `dev` branch is protected, so I don't have a permission to push this change directly to `dev`).