### PR TITLE
CartModule, 28: Swagger JSON validation issues

### DIFF
--- a/VirtoCommerce.Platform.Web/Swagger/SwaggerConfig.cs
+++ b/VirtoCommerce.Platform.Web/Swagger/SwaggerConfig.cs
@@ -1,7 +1,8 @@
-﻿using System;
+using System;
 using System.Collections.Generic;
 using System.IO;
 using System.Linq;
+using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Web.Hosting;
@@ -48,6 +49,19 @@ namespace VirtoCommerce.Platform.Web.Swagger
                 c.UseFullTypeNameInSchemaIds();
                 c.DocumentFilter(tagsFilterFactory);
                 c.OperationFilter(tagsFilterFactory);
+
+                // TECHDEBT: this is a workaround for the Swashbuckle issue: https://github.com/domaindrivendev/Swashbuckle.AspNetCore/issues/752
+                // By default, Swashbuckle encodes generic types like this: System.Func[VirtoCommerce.Domain.Common.IEvaluationContext,System.Boolean]
+                // and uses that string to reference the type. It contains URL-incompatible characters like '[' or ']', and Swagger validation doesn't accept it.
+                // So, to overcome this, we replace these characters with URL compatible characters like '-' or '_', and the result will look like this:
+                // System.Func_2_VirtoCommerce.Domain.Common.IEvaluationContext-System.Boolean_
+                c.SchemaId(type => type.ToString()
+                    .Replace('[', '_')
+                    .Replace(']', '_')
+                    .Replace('`', '_')
+                    .Replace(',', '-')
+                );
+
                 ApplyCommonSwaggerConfiguration(c, container, string.Empty, xmlCommentsFilePaths);
             })
             .EnableSwaggerUi(routePrefix + "docs/ui/{*assetPath}", c =>

--- a/VirtoCommerce.Platform.Web/Swagger/SwaggerConfig.cs
+++ b/VirtoCommerce.Platform.Web/Swagger/SwaggerConfig.cs
@@ -1,8 +1,6 @@
 using System;
-using System.Collections.Generic;
 using System.IO;
 using System.Linq;
-using System.Net;
 using System.Net.Http;
 using System.Reflection;
 using System.Web.Hosting;


### PR DESCRIPTION
This PR is a part of the VirtoCommerce/vc-module-cart#28. It helps to solve Swagger validation errors like `$ref values must be RFC3986-compliant percent-encoded URIs` and contains a workaround for the way Swashbuckle handles generic types. Please see the comment in the code for explanation of why it was added and how it works.

P.S. I tried to use the `WebHelper.UrlEncode(...)` method instead of replaces - it seems to be a more correct solution. But it causes the Swagger Editor to fail to resolve any generic type references. So, `UrlEncode` probably can't be used here.