### PR TITLE
VirtoCommerce.Platform.Web: removed a reference with incorrect path

### DIFF
--- a/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
+++ b/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
@@ -154,9 +154,6 @@
     <Reference Include="Microsoft.IdentityModel.Protocol.Extensions, Version=1.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.IdentityModel.Protocol.Extensions.1.0.0\lib\net45\Microsoft.IdentityModel.Protocol.Extensions.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.IdentityModel.Protocols">
-      <HintPath>C:\Users\A_Vas\.nuget\packages\microsoft.identitymodel.protocols\5.2.0\lib\net451\Microsoft.IdentityModel.Protocols.dll</HintPath>
-    </Reference>
     <Reference Include="Microsoft.Owin, Version=4.0.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.Owin.4.0.0\lib\net451\Microsoft.Owin.dll</HintPath>
     </Reference>


### PR DESCRIPTION
There was a reference in the `VirtoCommerce.Platform.Web` project that [referred to a library on my PC](https://github.com/VirtoCommerce/vc-platform/blob/master/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj#L158):
![image](https://user-images.githubusercontent.com/1835759/48195152-659eea80-e381-11e8-93f2-a0941553c9fb.png)

I've probably added it by mistake while working on the issue #1388. The `Microsoft.IdentityModel.Protocols` library itself was not used by this project (it uses `System.IdentityModel.Tokens.Jwt` library instead), so this reference can be safely removed.

/cc @priboltik