### PR TITLE
Added widget container to the settings detail blade

### DIFF
--- a/VirtoCommerce.Platform.Web/Scripts/app/settings/blades/settings-detail.tpl.html
+++ b/VirtoCommerce.Platform.Web/Scripts/app/settings/blades/settings-detail.tpl.html
@@ -12,6 +12,7 @@
                     </div>
                 </fieldset>
             </form>
+            <va-widget-container group="settingsDetail" blade="blade"></va-widget-container>
         </div>
     </div>
 </div>


### PR DESCRIPTION
This PR is a part of the AvaTax module refactoring. It adds the widget container to the settings detail blade (`settings-detail.tpl.html` template), so that the AvaTax module could insert the "Test connection with AvaTax" widget to its settings. This, in turn, will allow AvaTax module users to check their platform-wide AvaTax settings before saving them and potentially breaking the tax calculation.