### PR TITLE
Application Insights Live Metrics: Secure the control channel

### DIFF
--- a/VirtoCommerce.Platform.Web/Startup.cs
+++ b/VirtoCommerce.Platform.Web/Startup.cs
@@ -16,6 +16,8 @@ using CacheManager.Redis;
 using Common.Logging;
 using Hangfire;
 using Microsoft.ApplicationInsights.Extensibility;
+using Microsoft.ApplicationInsights.Extensibility.Implementation;
+using Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse;
 using Microsoft.AspNet.Identity;
 using Microsoft.AspNet.SignalR;
 using Microsoft.AspNet.SignalR.Infrastructure;
@@ -330,11 +332,23 @@ namespace VirtoCommerce.Platform.Web
             }
 
             // Initialize InstrumentationKey from EnvironmentVariable
-            var appInsightKey = Environment.GetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY");
-
-            if (!string.IsNullOrEmpty(appInsightKey))
+            var applicationInsightsInstrumentationKey = Environment.GetEnvironmentVariable("APPINSIGHTS_INSTRUMENTATIONKEY");
+            if (!string.IsNullOrEmpty(applicationInsightsInstrumentationKey))
             {
-                TelemetryConfiguration.Active.InstrumentationKey = appInsightKey;
+                TelemetryConfiguration.Active.InstrumentationKey = applicationInsightsInstrumentationKey;
+            }
+
+            // https://docs.microsoft.com/en-us/azure/application-insights/app-insights-live-stream#secure-the-control-channel
+            // https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/733#issuecomment-349752497
+            // https://github.com/Azure/azure-webjobs-sdk/issues/1349
+            var applicationInsightsAuthApiKey = Environment.GetEnvironmentVariable("APPINSIGHTS_QUICKPULSEAUTHAPIKEY");
+            if (!string.IsNullOrEmpty(applicationInsightsAuthApiKey))
+            {
+                var module = TelemetryModules.Instance.Modules.OfType<QuickPulseTelemetryModule>().Single();
+                if (module != null)
+                {
+                    module.AuthenticationApiKey = applicationInsightsAuthApiKey;
+                }
             }
         }
 


### PR DESCRIPTION
### Problem
We can't use filters in AI Live Metrics because we have no API Key configured for that. We can't put it directly to applicationinsights.config because it's not secure & will cause problems on deployment.

### Solution
Add code which allow you to specify this settings in app settings using special key.

### Additional context (optional)
1. Instruction from Microsoft: https://docs.microsoft.com/en-us/azure/application-insights/app-insights-live-stream#secure-the-control-channel
2. Why different code used and what it mean (we don't want to reinitialize all processors because of that single simple task): https://github.com/Microsoft/ApplicationInsights-dotnet-server/issues/733#issuecomment-349752497
3. Why this name of key used (Microsoft has plans to have built-in mechanism to specify it in the future):  https://github.com/Azure/azure-webjobs-sdk/issues/1349