### PR TITLE
#1507 Added appSettings parameter to control using of VC cache instances

### DIFF
--- a/VirtoCommerce.Platform.Web/Startup.cs
+++ b/VirtoCommerce.Platform.Web/Startup.cs
@@ -419,13 +419,13 @@ namespace VirtoCommerce.Platform.Web
                 var defaultCacheManager = cacheManagerSection.CacheManagers.FirstOrDefault(p => p.Name.EqualsInvariant("defaultPlatformCache"));
                 if (defaultCacheManager != null)
                 {
-                    configuration = ConfigurationBuilder.LoadConfiguration("defaultPlatformCache");
+                    configuration = ConfigurationBuilder.LoadConfiguration(defaultCacheManager.Name);
                 }
 
                 var redisCacheManager = cacheManagerSection.CacheManagers.FirstOrDefault(p => p.Name.EqualsInvariant("redisPlatformCache"));
                 if (cacheScaleUpEnabled && redisCacheManager != null)
                 {
-                    configuration = ConfigurationBuilder.LoadConfiguration("redisPlatformCache");
+                    configuration = ConfigurationBuilder.LoadConfiguration(redisCacheManager.Name);
                 }
 
                 if (configuration != null)

--- a/VirtoCommerce.Platform.Web/Startup.cs
+++ b/VirtoCommerce.Platform.Web/Startup.cs
@@ -406,7 +406,7 @@ namespace VirtoCommerce.Platform.Web
             app.SanitizeThreadCulture();
             ICacheManager<object> cacheManager = null;
 
-            var redisConnectionString = ConfigurationManager.ConnectionStrings["RedisConnectionString"];
+            var redisConnectionString = ConfigurationHelper.GetConnectionStringValue("RedisConnectionString");
 
             //Try to load cache configuration from web.config first
             //Should be aware to using Web cache cache handle because it not worked in native threads. (Hangfire jobs)
@@ -414,7 +414,7 @@ namespace VirtoCommerce.Platform.Web
             {
                 CacheManagerConfiguration configuration = null;
 
-                var defaultCacheManager = cacheManagerSection.CacheManagers.FirstOrDefault(p => p.Name.EqualsInvariant("defaultPlatformCache"));
+                var defaultCacheManager = cacheManagerSection.CacheManagers.FirstOrDefault(p => p.Name.EqualsInvariant("platformCache"));
                 if (defaultCacheManager != null)
                 {
                     configuration = ConfigurationBuilder.LoadConfiguration(defaultCacheManager.Name);
@@ -437,7 +437,7 @@ namespace VirtoCommerce.Platform.Web
             // Create a default cache manager if there is no any others
             if (cacheManager == null)
             {
-                cacheManager = CacheFactory.Build("defaultPlatformCache", settings =>
+                cacheManager = CacheFactory.Build("platformCache", settings =>
                 {
                     settings.WithUpdateMode(CacheUpdateMode.Up)
                             .WithSystemRuntimeCacheHandle("memCacheHandle")
@@ -661,14 +661,14 @@ namespace VirtoCommerce.Platform.Web
             #region Notifications
 
             // Redis
-            if (redisConnectionString != null && !string.IsNullOrEmpty(redisConnectionString.ConnectionString))
+            if (!string.IsNullOrEmpty(redisConnectionString))
             {
                 // Cache
-                RedisConfigurations.AddConfiguration(new RedisConfiguration("redisConnectionString", redisConnectionString.ConnectionString));
+                RedisConfigurations.AddConfiguration(new RedisConfiguration("redisConnectionString", redisConnectionString));
 
                 // SignalR
                 // https://stackoverflow.com/questions/29885470/signalr-scaleout-on-azure-rediscache-connection-issues
-                GlobalHost.DependencyResolver.UseRedis(new RedisScaleoutConfiguration(redisConnectionString.ConnectionString, "VirtoCommerce.Platform.SignalR"));
+                GlobalHost.DependencyResolver.UseRedis(new RedisScaleoutConfiguration(redisConnectionString, "VirtoCommerce.Platform.SignalR"));
             }
 
             // SignalR 

--- a/VirtoCommerce.Platform.Web/Startup.cs
+++ b/VirtoCommerce.Platform.Web/Startup.cs
@@ -406,9 +406,7 @@ namespace VirtoCommerce.Platform.Web
             app.SanitizeThreadCulture();
             ICacheManager<object> cacheManager = null;
 
-            // Try to find app setting which controls using of scaled up VC cache instances
-            var cacheScaleUpSetting = ConfigurationManager.AppSettings["VirtoCommerce:Cache:ScaleUpEnabled"];
-            var cacheScaleUpEnabled = cacheScaleUpSetting != null && bool.TryParse(cacheScaleUpSetting, out var useCacheScaleUp) && useCacheScaleUp;
+            var redisConnectionString = ConfigurationManager.ConnectionStrings["RedisConnectionString"];
 
             //Try to load cache configuration from web.config first
             //Should be aware to using Web cache cache handle because it not worked in native threads. (Hangfire jobs)
@@ -423,7 +421,7 @@ namespace VirtoCommerce.Platform.Web
                 }
 
                 var redisCacheManager = cacheManagerSection.CacheManagers.FirstOrDefault(p => p.Name.EqualsInvariant("redisPlatformCache"));
-                if (cacheScaleUpEnabled && redisCacheManager != null)
+                if (redisConnectionString != null && redisCacheManager != null)
                 {
                     configuration = ConfigurationBuilder.LoadConfiguration(redisCacheManager.Name);
                 }
@@ -661,8 +659,6 @@ namespace VirtoCommerce.Platform.Web
             #endregion
 
             #region Notifications
-
-            var redisConnectionString = ConfigurationManager.ConnectionStrings["RedisConnectionString"];
 
             // Redis
             if (redisConnectionString != null && !string.IsNullOrEmpty(redisConnectionString.ConnectionString))

--- a/VirtoCommerce.Platform.Web/Web.config
+++ b/VirtoCommerce.Platform.Web/Web.config
@@ -131,7 +131,7 @@
             <namedCaches>
                 <!--For some cases, this setting physicalMemoryLimitPercentage = "memory usage threshold in percents",
                 leads to a complete stop of the cache working even after the current physical memory usage returns less that set's threshold--> 
-                <add name="memCacheHandle" physicalMemoryLimitPercentage="80" pollingInterval="00:00:30" />
+                <add name="memCacheHandle"/>
             </namedCaches>
         </memoryCache>
     </system.runtime.caching>   

--- a/VirtoCommerce.Platform.Web/Web.config
+++ b/VirtoCommerce.Platform.Web/Web.config
@@ -104,6 +104,7 @@
         <add key="VirtoCommerce:Notifications:Gateway" value="Default" />
         <!-- This setting controls the setup behavior after  the first user login, where the system suggest to change the default credentials -->
         <add key="VirtoCommerce:Security:SuppressForcingCredentialsChange" value="false" />
+        <add key="VirtoCommerce:Cache:ScaleUpEnabled" value="false" />
         <!--<add key="GoogleTagManager:ContainerId" value="SECRET" />-->
     </appSettings>
     <system.net>
@@ -112,22 +113,43 @@
         </connectionManagement>
     </system.net>
 
+    <cacheManager.Redis>
+        <connections>
+            <connection id="redisConnectionString" database="0" connectionString="SECRET" />
+        </connections>
+    </cacheManager.Redis>
+
     <cacheManager>
         <managers>
+            <cache name="defaultPlatformCache" updateMode="None" enableStatistics="false" enablePerformanceCounters="false">
+                <handle name="memCacheHandle" ref="memCacheHandle" expirationMode="Sliding" timeout="10m" />
+            </cache>
+            <cache name="redisPlatformCache" enableStatistics="true" backplaneName="redisConnectionString" backplaneType="VirtoCommerce.Platform.Web.Cache.RedisCacheBackplane2, VirtoCommerce.Platform.Web">
+                <handle name="memCacheHandle" ref="memCacheHandle" expirationMode="Sliding" timeout="10m" />
+                <handle name="redisConnectionString" ref="redisHandle" isBackplaneSource="true" />
+            </cache>
+        </managers>
+        <cacheHandles>
+            <handleDef id="redisHandle" type="VirtoCommerce.Platform.Web.Cache.RedisCacheHandle2`1, VirtoCommerce.Platform.Web" />
+            <handleDef id="memCacheHandle" type="CacheManager.SystemRuntimeCaching.MemoryCacheHandle`1, CacheManager.SystemRuntimeCaching" />
+        </cacheHandles>
+
+        <!--<managers>
             <cache name="platformCache" updateMode="None" enableStatistics="false" enablePerformanceCounters="false">
                 <handle name="memCacheHandle" ref="memCacheHandle" expirationMode="Sliding" timeout="10m" />
             </cache>
         </managers>
         <cacheHandles>
             <handleDef id="memCacheHandle" type="CacheManager.SystemRuntimeCaching.MemoryCacheHandle`1, CacheManager.SystemRuntimeCaching" />
-        </cacheHandles>
+        </cacheHandles>-->
     </cacheManager>
     <system.runtime.caching>
         <memoryCache>
             <namedCaches>
                 <!--For some cases, this setting physicalMemoryLimitPercentage = "memory usage threshold in percents",
                 leads to a complete stop of the cache working even after the current physical memory usage returns less that set's threshold--> 
-                <add name="memCacheHandle" />
+                <!--<add name="memCacheHandle" />-->
+                <add name="memCacheHandle" physicalMemoryLimitPercentage="80" pollingInterval="00:00:30" />
             </namedCaches>
         </memoryCache>
     </system.runtime.caching>   

--- a/VirtoCommerce.Platform.Web/Web.config
+++ b/VirtoCommerce.Platform.Web/Web.config
@@ -39,7 +39,7 @@
             <add name="AssetsConnectionString" connectionString="provider=AzureBlobStorage;DefaultEndpointsProtocol=https;AccountName=yourAccountName;AccountKey=yourAccountKey;cdnUrl=yourStorageName.azureedge.net" />-->
         <add name="AssetsConnectionString" connectionString="provider=LocalStorage;rootPath=~/App_Data/Assets;publicUrl=http://localhost/admin/assets" />
         <!--Redis Connection String -->
-        <!--<add name="RedisConnectionString" connectionString="yourRedisConnection,password=yourRedisPassword,ssl=True,abortConnect=False,allowAdmin=true" />-->
+        <add name="RedisConnectionString" connectionString="SECRET" />
     </connectionStrings>
     <appSettings>
         <add key="vs:EnableBrowserLink" value="false" />
@@ -104,7 +104,7 @@
         <add key="VirtoCommerce:Notifications:Gateway" value="Default" />
         <!-- This setting controls the setup behavior after  the first user login, where the system suggest to change the default credentials -->
         <add key="VirtoCommerce:Security:SuppressForcingCredentialsChange" value="false" />
-        <add key="VirtoCommerce:Cache:ScaleUpEnabled" value="false" />
+        <add key="VirtoCommerce:Cache:ScaleUpEnabled" value="true" />
         <!--<add key="GoogleTagManager:ContainerId" value="SECRET" />-->
     </appSettings>
     <system.net>
@@ -113,35 +113,20 @@
         </connectionManagement>
     </system.net>
 
-    <cacheManager.Redis>
-        <connections>
-            <connection id="redisConnectionString" database="0" connectionString="SECRET" />
-        </connections>
-    </cacheManager.Redis>
-
     <cacheManager>
         <managers>
             <cache name="defaultPlatformCache" updateMode="None" enableStatistics="false" enablePerformanceCounters="false">
                 <handle name="memCacheHandle" ref="memCacheHandle" expirationMode="Sliding" timeout="10m" />
             </cache>
-            <cache name="redisPlatformCache" enableStatistics="true" backplaneName="redisConnectionString" backplaneType="VirtoCommerce.Platform.Web.Cache.RedisCacheBackplane2, VirtoCommerce.Platform.Web">
+            <cache name="redisPlatformCache" enableStatistics="true" backplaneName="RedisConnectionString" backplaneType="VirtoCommerce.Platform.Web.Cache.RedisCacheBackplane2, VirtoCommerce.Platform.Web">
                 <handle name="memCacheHandle" ref="memCacheHandle" expirationMode="Sliding" timeout="10m" />
-                <handle name="redisConnectionString" ref="redisHandle" isBackplaneSource="true" />
+                <handle name="RedisConnectionString" ref="redisHandle" isBackplaneSource="true" />
             </cache>
         </managers>
         <cacheHandles>
             <handleDef id="redisHandle" type="VirtoCommerce.Platform.Web.Cache.RedisCacheHandle2`1, VirtoCommerce.Platform.Web" />
             <handleDef id="memCacheHandle" type="CacheManager.SystemRuntimeCaching.MemoryCacheHandle`1, CacheManager.SystemRuntimeCaching" />
         </cacheHandles>
-
-        <!--<managers>
-            <cache name="platformCache" updateMode="None" enableStatistics="false" enablePerformanceCounters="false">
-                <handle name="memCacheHandle" ref="memCacheHandle" expirationMode="Sliding" timeout="10m" />
-            </cache>
-        </managers>
-        <cacheHandles>
-            <handleDef id="memCacheHandle" type="CacheManager.SystemRuntimeCaching.MemoryCacheHandle`1, CacheManager.SystemRuntimeCaching" />
-        </cacheHandles>-->
     </cacheManager>
     <system.runtime.caching>
         <memoryCache>

--- a/VirtoCommerce.Platform.Web/Web.config
+++ b/VirtoCommerce.Platform.Web/Web.config
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
         <section name="cacheManager" type="CacheManager.Core.Configuration.CacheManagerSection, CacheManager.Core" />
@@ -38,7 +38,7 @@
             <add name="AssetsConnectionString" connectionString="provider=AzureBlobStorage;DefaultEndpointsProtocol=https;AccountName=yourAccountName;AccountKey=yourAccountKey;cdnUrl=yourStorageName.azureedge.net" />-->
         <add name="AssetsConnectionString" connectionString="provider=LocalStorage;rootPath=~/App_Data/Assets;publicUrl=http://localhost/admin/assets" />
         <!--Redis Connection String -->
-        <add name="RedisConnectionString" connectionString="SECRET" />
+        <!--<add name="RedisConnectionString" connectionString="SECRET" />-->
     </connectionStrings>
     <appSettings>
         <add key="vs:EnableBrowserLink" value="false" />

--- a/VirtoCommerce.Platform.Web/Web.config
+++ b/VirtoCommerce.Platform.Web/Web.config
@@ -113,7 +113,7 @@
 
     <cacheManager>
         <managers>
-            <cache name="defaultPlatformCache" updateMode="None" enableStatistics="false" enablePerformanceCounters="false">
+            <cache name="platformCache" updateMode="None" enableStatistics="false" enablePerformanceCounters="false">
                 <handle name="memCacheHandle" ref="memCacheHandle" expirationMode="Sliding" timeout="10m" />
             </cache>
             <cache name="redisPlatformCache" enableStatistics="true" backplaneName="RedisConnectionString" backplaneType="VirtoCommerce.Platform.Web.Cache.RedisCacheBackplane2, VirtoCommerce.Platform.Web">

--- a/VirtoCommerce.Platform.Web/Web.config
+++ b/VirtoCommerce.Platform.Web/Web.config
@@ -133,7 +133,6 @@
             <namedCaches>
                 <!--For some cases, this setting physicalMemoryLimitPercentage = "memory usage threshold in percents",
                 leads to a complete stop of the cache working even after the current physical memory usage returns less that set's threshold--> 
-                <!--<add name="memCacheHandle" />-->
                 <add name="memCacheHandle" physicalMemoryLimitPercentage="80" pollingInterval="00:00:30" />
             </namedCaches>
         </memoryCache>

--- a/VirtoCommerce.Platform.Web/Web.config
+++ b/VirtoCommerce.Platform.Web/Web.config
@@ -104,7 +104,7 @@
         <add key="VirtoCommerce:Notifications:Gateway" value="Default" />
         <!-- This setting controls the setup behavior after  the first user login, where the system suggest to change the default credentials -->
         <add key="VirtoCommerce:Security:SuppressForcingCredentialsChange" value="false" />
-        <add key="VirtoCommerce:Cache:ScaleUpEnabled" value="true" />
+        <add key="VirtoCommerce:Cache:ScaleUpEnabled" value="false" />
         <!--<add key="GoogleTagManager:ContainerId" value="SECRET" />-->
     </appSettings>
     <system.net>

--- a/VirtoCommerce.Platform.Web/Web.config
+++ b/VirtoCommerce.Platform.Web/Web.config
@@ -2,7 +2,6 @@
 <configuration>
     <configSections>
         <section name="cacheManager" type="CacheManager.Core.Configuration.CacheManagerSection, CacheManager.Core" />
-        <section name="cacheManager.Redis" type="CacheManager.Redis.RedisConfigurationSection, CacheManager.StackExchange.Redis" />
         <section name="entityFramework" type="System.Data.Entity.Internal.ConfigFile.EntityFrameworkSection, EntityFramework, Version=6.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089" requirePermission="false" />
         <sectionGroup name="common">
             <section name="logging" type="Common.Logging.ConfigurationSectionHandler, Common.Logging" />

--- a/VirtoCommerce.Platform.Web/Web.config
+++ b/VirtoCommerce.Platform.Web/Web.config
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <configSections>
         <section name="cacheManager" type="CacheManager.Core.Configuration.CacheManagerSection, CacheManager.Core" />
@@ -103,7 +103,6 @@
         <add key="VirtoCommerce:Notifications:Gateway" value="Default" />
         <!-- This setting controls the setup behavior after  the first user login, where the system suggest to change the default credentials -->
         <add key="VirtoCommerce:Security:SuppressForcingCredentialsChange" value="false" />
-        <add key="VirtoCommerce:Cache:ScaleUpEnabled" value="false" />
         <!--<add key="GoogleTagManager:ContainerId" value="SECRET" />-->
     </appSettings>
     <system.net>


### PR DESCRIPTION
### Problem
Need to have possibility switch the platform cache configuration to work with Redis server by change only one application setting (probably add connection Redis string).

### Solution
Added a new setting in appSettings to control using of scaled up VC cache instances

### Proposed of changes
- Added a new parameter `VirtoCommerce:Cache:ScaleUpEnabled` to appSettings
- Added new cache manager to switch
- Added checks to decide which cache manager should be chosen (default mem cache or scaled up within Redis) or create a default mem cache manager if nothing was found