### PR TITLE
Use GetAbsoluteUrl for blob URLs to respect CDN URL config

### DIFF
--- a/VirtoCommerce.Platform.Data.Azure/AzureBlobProvider.cs
+++ b/VirtoCommerce.Platform.Data.Azure/AzureBlobProvider.cs
@@ -50,7 +50,7 @@ namespace VirtoCommerce.Platform.Data.Azure
                 var cloudBlob = _cloudBlobClient.GetBlobReferenceFromServer(uri);
                 retVal = new BlobInfo
                 {
-                    Url = Uri.EscapeUriString(cloudBlob.Uri.ToString()),
+                    Url = Uri.EscapeUriString(GetAbsoluteUrl(cloudBlob.Uri.PathAndQuery)),
                     FileName = Path.GetFileName(Uri.UnescapeDataString(cloudBlob.Uri.ToString())),
                     ContentType = cloudBlob.Properties.ContentType,
                     Size = cloudBlob.Properties.Length,
@@ -172,7 +172,7 @@ namespace VirtoCommerce.Platform.Data.Azure
                         {
                             var blobInfo = new BlobInfo
                             {
-                                Url = Uri.EscapeUriString(block.Uri.ToString()),
+                                Url = Uri.EscapeUriString(GetAbsoluteUrl(block.Uri.PathAndQuery)),
                                 FileName = Path.GetFileName(Uri.UnescapeDataString(block.Uri.ToString())),
                                 ContentType = block.Properties.ContentType,
                                 Size = block.Properties.Length,


### PR DESCRIPTION
This is the first work on #1509 

There are no tests due to the tight coupling with `CloudBlobClient` and `CloudStorageAccount` classes used directly in `AzureBlobProvider`. We should write wrappers with interfaces and mock them for tests.
