### PR TITLE
Memory leak in vc-platform was eliminated

### DIFF
--- a/VirtoCommerce.Platform.Tests/app.config
+++ b/VirtoCommerce.Platform.Tests/app.config
@@ -91,7 +91,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-2.8.1.0" newVersion="2.8.1.0" />
+                <bindingRedirect oldVersion="0.0.0.0-2.9.1.0" newVersion="2.9.1.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />

--- a/VirtoCommerce.Platform.Web/ApplicationInsights.config
+++ b/VirtoCommerce.Platform.Web/ApplicationInsights.config
@@ -1,10 +1,19 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings">
     <TelemetrySinks>
         <Add Name="default">
             <TelemetryProcessors>
                 <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector"/>
                 <Add Type="VirtoCommerce.Platform.Web.SignalR.IgnoreSignarRTelemetryProcessor, VirtoCommerce.Platform.Web"/>
+                <Add Type="Microsoft.ApplicationInsights.Extensibility.AutocollectedMetricsExtractor, Microsoft.ApplicationInsights"/>
+                <Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
+                    <MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
+                    <ExcludedTypes>Event</ExcludedTypes>
+                </Add>
+                <Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
+                    <MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
+                    <IncludedTypes>Event</IncludedTypes>
+                </Add>
                 <Add Type="Microsoft.ApplicationInsights.SnapshotCollector.SnapshotCollectorTelemetryProcessor, Microsoft.ApplicationInsights.SnapshotCollector">
                     <!-- The default is true, but you can disable Snapshot Debugging by setting it to false -->
                     <IsEnabled>true</IsEnabled>
@@ -31,15 +40,6 @@
                     <ProvideAnonymousTelemetry>true</ProvideAnonymousTelemetry>
                     <!-- The limit on the number of failed requests to request snapshots before the telemetry processor is disabled. -->
                     <FailedRequestLimit>3</FailedRequestLimit>
-                </Add>
-                <Add Type="Microsoft.ApplicationInsights.Extensibility.AutocollectedMetricsExtractor, Microsoft.ApplicationInsights"/>
-                <Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
-                    <MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
-                    <ExcludedTypes>Event</ExcludedTypes>
-                </Add>
-                <Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
-                    <MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
-                    <IncludedTypes>Event</IncludedTypes>
                 </Add>
             </TelemetryProcessors>
             <TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel"/>
@@ -76,6 +76,8 @@
                 <Add>core.chinacloudapi.cn</Add>
                 <Add>core.cloudapi.de</Add>
                 <Add>core.usgovcloudapi.net</Add>
+                <Add>localhost</Add>
+                <Add>127.0.0.1</Add>
             </ExcludeComponentCorrelationHttpHeadersOnDomains>
             <IncludeDiagnosticSourceActivities>
                 <Add>Microsoft.Azure.EventHubs</Add>
@@ -159,10 +161,10 @@
         <Add Type="Microsoft.ApplicationInsights.Web.AspNetDiagnosticTelemetryModule, Microsoft.AI.Web"/>
     </TelemetryModules>
     <ApplicationIdProvider Type="Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId.ApplicationInsightsApplicationIdProvider, Microsoft.ApplicationInsights"/>
-
 <!-- 
     Learn more about Application Insights configuration with ApplicationInsights.config here: 
     http://go.microsoft.com/fwlink/?LinkID=513840
     
     Note: If not present, please add <InstrumentationKey>Your Key</InstrumentationKey> to the top of this file.
-  --></ApplicationInsights>
+  -->
+</ApplicationInsights>

--- a/VirtoCommerce.Platform.Web/ApplicationInsights.config
+++ b/VirtoCommerce.Platform.Web/ApplicationInsights.config
@@ -1,19 +1,10 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <ApplicationInsights xmlns="http://schemas.microsoft.com/ApplicationInsights/2013/Settings">
     <TelemetrySinks>
         <Add Name="default">
             <TelemetryProcessors>
                 <Add Type="Microsoft.ApplicationInsights.Extensibility.PerfCounterCollector.QuickPulse.QuickPulseTelemetryProcessor, Microsoft.AI.PerfCounterCollector"/>
                 <Add Type="VirtoCommerce.Platform.Web.SignalR.IgnoreSignarRTelemetryProcessor, VirtoCommerce.Platform.Web"/>
-                <Add Type="Microsoft.ApplicationInsights.Extensibility.AutocollectedMetricsExtractor, Microsoft.ApplicationInsights"/>
-                <Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
-                    <MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
-                    <ExcludedTypes>Event</ExcludedTypes>
-                </Add>
-                <Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
-                    <MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
-                    <IncludedTypes>Event</IncludedTypes>
-                </Add>
                 <Add Type="Microsoft.ApplicationInsights.SnapshotCollector.SnapshotCollectorTelemetryProcessor, Microsoft.ApplicationInsights.SnapshotCollector">
                     <!-- The default is true, but you can disable Snapshot Debugging by setting it to false -->
                     <IsEnabled>true</IsEnabled>
@@ -40,6 +31,15 @@
                     <ProvideAnonymousTelemetry>true</ProvideAnonymousTelemetry>
                     <!-- The limit on the number of failed requests to request snapshots before the telemetry processor is disabled. -->
                     <FailedRequestLimit>3</FailedRequestLimit>
+                </Add>
+                <Add Type="Microsoft.ApplicationInsights.Extensibility.AutocollectedMetricsExtractor, Microsoft.ApplicationInsights"/>
+                <Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
+                    <MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
+                    <ExcludedTypes>Event</ExcludedTypes>
+                </Add>
+                <Add Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.AdaptiveSamplingTelemetryProcessor, Microsoft.AI.ServerTelemetryChannel">
+                    <MaxTelemetryItemsPerSecond>5</MaxTelemetryItemsPerSecond>
+                    <IncludedTypes>Event</IncludedTypes>
                 </Add>
             </TelemetryProcessors>
             <TelemetryChannel Type="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.ServerTelemetryChannel, Microsoft.AI.ServerTelemetryChannel"/>
@@ -76,8 +76,6 @@
                 <Add>core.chinacloudapi.cn</Add>
                 <Add>core.cloudapi.de</Add>
                 <Add>core.usgovcloudapi.net</Add>
-                <Add>localhost</Add>
-                <Add>127.0.0.1</Add>
             </ExcludeComponentCorrelationHttpHeadersOnDomains>
             <IncludeDiagnosticSourceActivities>
                 <Add>Microsoft.Azure.EventHubs</Add>
@@ -161,10 +159,10 @@
         <Add Type="Microsoft.ApplicationInsights.Web.AspNetDiagnosticTelemetryModule, Microsoft.AI.Web"/>
     </TelemetryModules>
     <ApplicationIdProvider Type="Microsoft.ApplicationInsights.Extensibility.Implementation.ApplicationId.ApplicationInsightsApplicationIdProvider, Microsoft.ApplicationInsights"/>
+
 <!-- 
     Learn more about Application Insights configuration with ApplicationInsights.config here: 
     http://go.microsoft.com/fwlink/?LinkID=513840
     
     Note: If not present, please add <InstrumentationKey>Your Key</InstrumentationKey> to the top of this file.
-  -->
-</ApplicationInsights>
+  --></ApplicationInsights>

--- a/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
+++ b/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
@@ -102,23 +102,23 @@
     <Reference Include="Microsoft.AI.Agent.Intercept, Version=2.4.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.Agent.Intercept.2.4.0\lib\net45\Microsoft.AI.Agent.Intercept.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.DependencyCollector, Version=2.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.8.1\lib\net45\Microsoft.AI.DependencyCollector.dll</HintPath>
+    <Reference Include="Microsoft.AI.DependencyCollector, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.9.0\lib\net45\Microsoft.AI.DependencyCollector.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.PerfCounterCollector, Version=2.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.8.1\lib\net45\Microsoft.AI.PerfCounterCollector.dll</HintPath>
+    <Reference Include="Microsoft.AI.PerfCounterCollector, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.9.0\lib\net45\Microsoft.AI.PerfCounterCollector.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.8.1\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
+    <Reference Include="Microsoft.AI.ServerTelemetryChannel, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.9.0\lib\net45\Microsoft.AI.ServerTelemetryChannel.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.Web, Version=2.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.Web.2.8.1\lib\net45\Microsoft.AI.Web.dll</HintPath>
+    <Reference Include="Microsoft.AI.Web, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.Web.2.9.0\lib\net45\Microsoft.AI.Web.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AI.WindowsServer, Version=2.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.WindowsServer.2.8.1\lib\net45\Microsoft.AI.WindowsServer.dll</HintPath>
+    <Reference Include="Microsoft.AI.WindowsServer, Version=2.9.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.WindowsServer.2.9.0\lib\net45\Microsoft.AI.WindowsServer.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.ApplicationInsights, Version=2.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.ApplicationInsights.2.8.1\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
+    <Reference Include="Microsoft.ApplicationInsights, Version=2.9.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.ApplicationInsights.2.9.1\lib\net46\Microsoft.ApplicationInsights.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.ApplicationInsights.NLogTarget, Version=2.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.ApplicationInsights.NLogTarget.2.8.1\lib\net45\Microsoft.ApplicationInsights.NLogTarget.dll</HintPath>
@@ -141,8 +141,8 @@
     <Reference Include="Microsoft.AspNet.SignalR.Redis, Version=2.3.0.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.SignalR.Redis.2.3.0\lib\net45\Microsoft.AspNet.SignalR.Redis.dll</HintPath>
     </Reference>
-    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.4.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
-      <HintPath>..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.4\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
+    <Reference Include="Microsoft.AspNet.TelemetryCorrelation, Version=1.0.5.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
+      <HintPath>..\packages\Microsoft.AspNet.TelemetryCorrelation.1.0.5\lib\net45\Microsoft.AspNet.TelemetryCorrelation.dll</HintPath>
     </Reference>
     <Reference Include="Microsoft.CSharp" />
     <Reference Include="Microsoft.Data.Edm, Version=5.8.1.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
@@ -247,6 +247,7 @@
       <HintPath>..\packages\System.IdentityModel.Tokens.Jwt.5.1.2\lib\net451\System.IdentityModel.Tokens.Jwt.dll</HintPath>
     </Reference>
     <Reference Include="System.IO.Compression" />
+    <Reference Include="System.Management" />
     <Reference Include="System.Net.Http.Formatting, Version=5.2.7.0, Culture=neutral, PublicKeyToken=31bf3856ad364e35, processorArchitecture=MSIL">
       <HintPath>..\packages\Microsoft.AspNet.WebApi.Client.5.2.7\lib\net45\System.Net.Http.Formatting.dll</HintPath>
     </Reference>
@@ -1291,6 +1292,21 @@
     <TransformXml Source="$(TransformInputFile)" Transform="$(TransformFile)" Destination="$(TransformOutputFile)" StackTrace="$(StackTraceEnabled)" />
     <Delete Files="$(TransformInputFile)" />
   </Target>
+  <Import Project="..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.9.0\build\Microsoft.ApplicationInsights.DependencyCollector.targets" Condition="Exists('..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.9.0\build\Microsoft.ApplicationInsights.DependencyCollector.targets')" />
+  <Target Name="EnsureNuGetPackageBuildImports" BeforeTargets="PrepareForBuild">
+    <PropertyGroup>
+      <ErrorText>This project references NuGet package(s) that are missing on this computer. Use NuGet Package Restore to download them.  For more information, see http://go.microsoft.com/fwlink/?LinkID=322105. The missing file is {0}.</ErrorText>
+    </PropertyGroup>
+    <Error Condition="!Exists('..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.9.0\build\Microsoft.ApplicationInsights.DependencyCollector.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ApplicationInsights.DependencyCollector.2.9.0\build\Microsoft.ApplicationInsights.DependencyCollector.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.9.0\build\Microsoft.ApplicationInsights.PerfCounterCollector.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.9.0\build\Microsoft.ApplicationInsights.PerfCounterCollector.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.9.0\build\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.9.0\build\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.ApplicationInsights.WindowsServer.2.9.0\build\Microsoft.ApplicationInsights.WindowsServer.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ApplicationInsights.WindowsServer.2.9.0\build\Microsoft.ApplicationInsights.WindowsServer.targets'))" />
+    <Error Condition="!Exists('..\packages\Microsoft.ApplicationInsights.Web.2.9.0\build\Microsoft.ApplicationInsights.Web.targets')" Text="$([System.String]::Format('$(ErrorText)', '..\packages\Microsoft.ApplicationInsights.Web.2.9.0\build\Microsoft.ApplicationInsights.Web.targets'))" />
+  </Target>
+  <Import Project="..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.9.0\build\Microsoft.ApplicationInsights.PerfCounterCollector.targets" Condition="Exists('..\packages\Microsoft.ApplicationInsights.PerfCounterCollector.2.9.0\build\Microsoft.ApplicationInsights.PerfCounterCollector.targets')" />
+  <Import Project="..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.9.0\build\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.targets" Condition="Exists('..\packages\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.2.9.0\build\Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel.targets')" />
+  <Import Project="..\packages\Microsoft.ApplicationInsights.WindowsServer.2.9.0\build\Microsoft.ApplicationInsights.WindowsServer.targets" Condition="Exists('..\packages\Microsoft.ApplicationInsights.WindowsServer.2.9.0\build\Microsoft.ApplicationInsights.WindowsServer.targets')" />
+  <Import Project="..\packages\Microsoft.ApplicationInsights.Web.2.9.0\build\Microsoft.ApplicationInsights.Web.targets" Condition="Exists('..\packages\Microsoft.ApplicationInsights.Web.2.9.0\build\Microsoft.ApplicationInsights.Web.targets')" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.
   <Target Name="BeforeBuild">

--- a/VirtoCommerce.Platform.Web/Web.config
+++ b/VirtoCommerce.Platform.Web/Web.config
@@ -104,7 +104,7 @@
         <!-- Supported sms gateways: Twilio and ASPSMS. "Default" means non-implemented gateway. -->
         <add key="VirtoCommerce:Notifications:SmsGateway" value="Default" />
         <add key="VirtoCommerce:Notifications:SmsGateway:AccountId" value="(Replace with your sms gateway account id)" />
-        <add key="VirtoCommerce:Notifications:SmsGateway:AccountPassword" value="(Replace with your sms gateway account password or auth token)"/>
+        <add key="VirtoCommerce:Notifications:SmsGateway:AccountPassword" value="(Replace with your sms gateway account password or auth token)" />
         <add key="VirtoCommerce:Notifications:SmsGateway:Sender" value="(Replace with sms sender phone number or name)" />
         <!-- This setting could change ASPSMS REST Json API endpoint -->
         <add key="VirtoCommerce:Notifications:SmsGateway:ASPSMS:JsonApiUri" value="https://json.aspsms.com/SendSimpleTextSMS" />
@@ -299,7 +299,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="Microsoft.ApplicationInsights" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-2.8.1.0" newVersion="2.8.1.0" />
+                <bindingRedirect oldVersion="0.0.0.0-2.9.1.0" newVersion="2.9.1.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="System.Diagnostics.DiagnosticSource" publicKeyToken="cc7b13ffcd2ddd51" culture="neutral" />
@@ -311,7 +311,7 @@
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="System.IdentityModel.Tokens.Jwt" publicKeyToken="31bf3856ad364e35" culture="neutral" />
-                <bindingRedirect oldVersion="0.0.0.0-4.0.0.0" newVersion="4.0.0.0" />
+                <bindingRedirect oldVersion="0.0.0.0-5.1.2.0" newVersion="5.1.2.0" />
             </dependentAssembly>
             <dependentAssembly>
                 <assemblyIdentity name="System.Web.Helpers" publicKeyToken="31bf3856ad364e35" />

--- a/VirtoCommerce.Platform.Web/packages.config
+++ b/VirtoCommerce.Platform.Web/packages.config
@@ -14,16 +14,16 @@
   <package id="Hangfire.Core" version="1.6.17" targetFramework="net461" />
   <package id="Hangfire.MemoryStorage" version="1.5.2" targetFramework="net461" />
   <package id="Hangfire.SqlServer" version="1.6.17" targetFramework="net461" />
-  <package id="Microsoft.ApplicationInsights" version="2.8.1" targetFramework="net461" />
+  <package id="Microsoft.ApplicationInsights" version="2.9.1" targetFramework="net461" />
   <package id="Microsoft.ApplicationInsights.Agent.Intercept" version="2.4.0" targetFramework="net461" />
-  <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.8.1" targetFramework="net461" />
+  <package id="Microsoft.ApplicationInsights.DependencyCollector" version="2.9.0" targetFramework="net461" />
   <package id="Microsoft.ApplicationInsights.JavaScript" version="0.22.19-build00125" targetFramework="net461" />
   <package id="Microsoft.ApplicationInsights.NLogTarget" version="2.8.1" targetFramework="net461" />
-  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.8.1" targetFramework="net461" />
+  <package id="Microsoft.ApplicationInsights.PerfCounterCollector" version="2.9.0" targetFramework="net461" />
   <package id="Microsoft.ApplicationInsights.SnapshotCollector" version="1.3.2" targetFramework="net461" />
-  <package id="Microsoft.ApplicationInsights.Web" version="2.8.1" targetFramework="net461" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.8.1" targetFramework="net461" />
-  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.8.1" targetFramework="net461" />
+  <package id="Microsoft.ApplicationInsights.Web" version="2.9.0" targetFramework="net461" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer" version="2.9.0" targetFramework="net461" />
+  <package id="Microsoft.ApplicationInsights.WindowsServer.TelemetryChannel" version="2.9.0" targetFramework="net461" />
   <package id="Microsoft.AspNet.Cors" version="5.2.7" targetFramework="net461" />
   <package id="Microsoft.AspNet.Identity.Core" version="2.2.1" targetFramework="net461" />
   <package id="Microsoft.AspNet.Identity.EntityFramework" version="2.2.1" targetFramework="net461" />
@@ -32,7 +32,7 @@
   <package id="Microsoft.AspNet.Razor" version="3.2.7" targetFramework="net461" />
   <package id="Microsoft.AspNet.SignalR.Core" version="2.3.0" targetFramework="net461" />
   <package id="Microsoft.AspNet.SignalR.Redis" version="2.3.0" targetFramework="net461" />
-  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.4" targetFramework="net461" />
+  <package id="Microsoft.AspNet.TelemetryCorrelation" version="1.0.5" targetFramework="net461" />
   <package id="Microsoft.AspNet.Web.Optimization" version="1.1.3" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi" version="5.2.7" targetFramework="net461" />
   <package id="Microsoft.AspNet.WebApi.Client" version="5.2.7" targetFramework="net461" />


### PR DESCRIPTION
Memory leackage was related to bug that existe in AI of version 2.8.1. That version have critical bug https://github.com/microsoft/ApplicationInsights-dotnet-server/issues/1090. This error is not in the latest version of AI 2.9.1. 