### PR TITLE
#1582 Support using the same Redis server by multiple platform instances belonging to different tenants:

### DIFF
--- a/VirtoCommerce.Platform.Web/Startup.cs
+++ b/VirtoCommerce.Platform.Web/Startup.cs
@@ -455,6 +455,7 @@ namespace VirtoCommerce.Platform.Web
                 if (redisConnectionString != null && redisCacheManager != null)
                 {
                     configuration = ConfigurationBuilder.LoadConfiguration(redisCacheManager.Name);
+                    configuration.BackplaneChannelName = ConfigurationHelper.GetAppSettingsValue("VirtoCommerce:Cache:Redis:ChannelName");
                 }
 
                 if (configuration != null)

--- a/VirtoCommerce.Platform.Web/Web.config
+++ b/VirtoCommerce.Platform.Web/Web.config
@@ -111,6 +111,8 @@
         <!-- This setting controls the setup behavior after  the first user login, where the system suggest to change the default credentials -->
         <add key="VirtoCommerce:Security:SuppressForcingCredentialsChange" value="false" />
         <!--<add key="GoogleTagManager:ContainerId" value="SECRET" />-->
+        <!--Use this setting to specify redis channel name to be used by cache. Only instances with the same channel name will recieve messages. -->
+        <!--<add key="VirtoCommerce:Cache:Redis:ChannelName" value="(Place name of desired channel here)" />-->
     </appSettings>
     <system.net>
         <connectionManagement>


### PR DESCRIPTION
- Added "VirtoCommerce:Cache:Redis:ChannelName" option for specifying redis channel name different from default;
