### PR TITLE
#1594: Default Outbound Network Connection Limit increased to 8064

### DIFF
--- a/VirtoCommerce.Platform.Web/Web.config
+++ b/VirtoCommerce.Platform.Web/Web.config
@@ -116,7 +116,7 @@
     </appSettings>
     <system.net>
         <connectionManagement>
-            <add address="*" maxconnection="96" />
+            <add address="*" maxconnection="8064" />
         </connectionManagement>
     </system.net>
 


### PR DESCRIPTION
 Default Outbound Network Connection Limit increased to 8064 to meet Standard S3 1 Instance connection limit: 8064
