### PR TITLE
1610: registering default SMS gateway for any gateway name unknown by the platform

### DIFF
--- a/VirtoCommerce.Platform.Web/Startup.cs
+++ b/VirtoCommerce.Platform.Web/Startup.cs
@@ -751,11 +751,7 @@ namespace VirtoCommerce.Platform.Web
             ISmsNotificationSendingGateway smsNotificationSendingGateway = null;
             var smsNotificationSendingGatewayName = ConfigurationHelper.GetAppSettingsValue("VirtoCommerce:Notifications:SmsGateway", "Default");
 
-            if (smsNotificationSendingGatewayName.EqualsInvariant("Default"))
-            {
-                smsNotificationSendingGateway = new DefaultSmsNotificationSendingGateway();
-            }
-            else if (smsNotificationSendingGatewayName.EqualsInvariant("Twilio"))
+            if (smsNotificationSendingGatewayName.EqualsInvariant("Twilio"))
             {
                 smsNotificationSendingGateway = new TwilioSmsNotificationSendingGateway(new TwilioSmsGatewayOptions
                 {
@@ -774,11 +770,12 @@ namespace VirtoCommerce.Platform.Web
                     JsonApiUri = ConfigurationHelper.GetAppSettingsValue("VirtoCommerce:Notifications:SmsGateway:ASPSMS:JsonApiUri"),
                 });
             }
-
-            if (smsNotificationSendingGateway != null)
+            else
             {
-                container.RegisterInstance(smsNotificationSendingGateway);
+                smsNotificationSendingGateway = new DefaultSmsNotificationSendingGateway();
             }
+
+            container.RegisterInstance(smsNotificationSendingGateway);
 
             #endregion
 


### PR DESCRIPTION
Motifvation for this PR is described in #1610. Now the platform will always have some implementation of the SMS gateway, so that:
1. If `VirtoCommerce:Notifications:SmsGateway` is set to `Default`, default SMS gateway will be used;
2. If `...SmsGateway` is set to `Twilio` or `ASPSMS`, the platform will instantiate, register and use that SMS provider;
3. If `...SmsGateway` is set to some value unknown by the platform and any of installed modules, default SMS gateway will be registered and used. This way, the platform will successfully start, but won't send any SMS notifications, because default SMS gateway can't do that.
4. If `...SmsGateway` value is unknown by the platform, but known by some installed module, then the platform will register default SMS gateway, and that module will then replace default SMS gateway with some custom implementation. That implementation will then be used by the platform and any of installed modules.
