### PR TITLE
Target Pack: added property UpdateVersionProperties for modules

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -138,7 +138,9 @@ class Build : NukeBuild
                   .SetPackageRequireLicenseAcceptance(false)
                   .SetDescription(ModuleManifest.Description)
                   .SetCopyright(ModuleManifest.Copyright);
-              settings = settings.SetProperty("UpdateVersionProperties", false);
+                  
+              //Fix for dotnet pack which ignores Version property because of GitVersionTask    
+              settings = settings.SetProperty("UpdateVersionProperties", false); 
           }
           DotNetPack(settings);
       });

--- a/build/Build.cs
+++ b/build/Build.cs
@@ -138,6 +138,7 @@ class Build : NukeBuild
                   .SetPackageRequireLicenseAcceptance(false)
                   .SetDescription(ModuleManifest.Description)
                   .SetCopyright(ModuleManifest.Copyright);
+              settings = settings.SetProperty("UpdateVersionProperties", false);
           }
           DotNetPack(settings);
       });


### PR DESCRIPTION
### Problem
dotnet pack ignores Version property because of GitVersionTask dependency

### Solution
added property UpdateVersionProperties=false to vc-build's pack target
