### PR TITLE
fix: Bug on non-Windows systems using backslash

### DIFF
--- a/src/VirtoCommerce.Platform.Modules/Local/LocalStorageModuleCatalog.cs
+++ b/src/VirtoCommerce.Platform.Modules/Local/LocalStorageModuleCatalog.cs
@@ -52,7 +52,7 @@ namespace VirtoCommerce.Platform.Modules
                 var moduleInfo = AbstractTypeFactory<ManifestModuleInfo>.TryCreateInstance();
                 moduleInfo.LoadFromManifest(manifest);
                 moduleInfo.FullPhysicalPath = Path.GetDirectoryName(manifestPath);
-             
+
                 // Modules without assembly file don't need initialization
                 if (string.IsNullOrEmpty(manifest.AssemblyFile))
                 {
@@ -60,7 +60,7 @@ namespace VirtoCommerce.Platform.Modules
                 }
                 else
                 {
-                    //Set module assembly physical path for future loading by IModuleTypeLoader instance 
+                    //Set module assembly physical path for future loading by IModuleTypeLoader instance
                     moduleInfo.Ref = GetFileAbsoluteUri(_options.ProbingPath, manifest.AssemblyFile);
                 }
 
@@ -174,7 +174,7 @@ namespace VirtoCommerce.Platform.Modules
         {
             if (sourceParentPath != null)
             {
-                var sourceDirectoryPath = Path.Combine(sourceParentPath, "bin\\");
+                var sourceDirectoryPath = Path.Combine(sourceParentPath, "bin");
 
                 if (Directory.Exists(sourceDirectoryPath))
                 {


### PR DESCRIPTION
### Problem
This bug prevented platform modules from being copied to the module discovery folder on Mac and Linux

### Solution
Platform modules need to be copied from the probe module folder to discovery folder

### Proposed of changes
Remove the hard-coded backslash path separator: it's unneeded with Path.Combine and not valid on Mac and Linux
