### PR TITLE
Fix the error of the opening the content editing blade

### DIFF
--- a/VirtoCommerce.Platform.Data.Azure/AzureBlobProvider.cs
+++ b/VirtoCommerce.Platform.Data.Azure/AzureBlobProvider.cs
@@ -358,7 +358,7 @@ namespace VirtoCommerce.Platform.Data.Azure
 
         private BlobInfo ConvertCloudBlobToBlobInfo(ICloudBlob cloudBlob)
         {
-            var relativeUrl = cloudBlob.Uri.LocalPath; // blobInfo.RelativeUrl = blobInfo.Url.Replace(_cloudBlobClient.BaseUri.ToString(), string.Empty);
+            var relativeUrl = cloudBlob.Uri.LocalPath;
             var absoluteUrl = GetAbsoluteUrl(cloudBlob.Uri.PathAndQuery);
             var fileName = Path.GetFileName(Uri.UnescapeDataString(cloudBlob.Uri.ToString()));
             var contentType = MimeTypeResolver.ResolveContentType(fileName);

--- a/VirtoCommerce.Platform.Web/Converters/Asset/AssetSearchResultConverter.cs
+++ b/VirtoCommerce.Platform.Web/Converters/Asset/AssetSearchResultConverter.cs
@@ -1,6 +1,5 @@
-﻿using System.Collections.Generic;
+using System.Collections.Generic;
 using System.Linq;
-using VirtoCommerce.Platform.Core.Common;
 using coreModel = VirtoCommerce.Platform.Core.Assets;
 using webModel = VirtoCommerce.Platform.Web.Model.Asset;
 


### PR DESCRIPTION
https://github.com/VirtoCommerce/vc-platform/issues/1760#?repos=60280313&search=1060
To avoid case with the wrong content type of the blob, when it
uses AzureBlobProvider for CMS content, better get content type
on a fly at BlobInfo returning. The wrong type can be formed
when CMS data imported direct to Azure Blob Storage.