### PR TITLE
1780: Preserve default token handler for Azure AD

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -192,6 +192,9 @@ namespace VirtoCommerce.Platform.Web
                 options.ForwardedHeaders = Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedProto | Microsoft.AspNetCore.HttpOverrides.ForwardedHeaders.XForwardedFor;
             });
 
+            //Create backup of token handler before default claim maps are cleared
+            var defaultTokenHandler = new JwtSecurityTokenHandler();
+
             JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
             JwtSecurityTokenHandler.DefaultOutboundClaimTypeMap.Clear();
             authBuilder.AddJwtBearer(options =>
@@ -241,6 +244,7 @@ namespace VirtoCommerce.Platform.Web
                             openIdConnectOptions.UseTokenLifetime = true;
                             openIdConnectOptions.RequireHttpsMetadata = false;
                             openIdConnectOptions.SignInScheme = IdentityConstants.ExternalScheme;
+                            openIdConnectOptions.SecurityTokenValidator = defaultTokenHandler;
                         });
                 }
             }


### PR DESCRIPTION
### Problem
Clearing the global default claim maps breaks claim mapping for azure ad

### Solution
Backup token handling and pass that in as a parameter to open id connect options

### Proposed of changes
Creating a new token handler before the maps are cleared will preserve default behavior. 

### Additional context (optional)

