### PR TITLE
Fixed problem with security:api_call permission checking

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Security/ClaimsPrincipalExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/ClaimsPrincipalExtensions.cs
@@ -27,7 +27,7 @@ namespace VirtoCommerce.Platform.Core.Security
 
             if (!result)
             {
-                result = principal.IsInRole(PlatformConstants.Security.SystemRoles.Customer) ||
+                result = !principal.IsInRole(PlatformConstants.Security.SystemRoles.Customer) &&
                          permissionName == PlatformConstants.Security.Permissions.SecurityCallApi;
                 if (!result)
                 {

--- a/src/VirtoCommerce.Platform.Core/Security/ClaimsPrincipalExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/ClaimsPrincipalExtensions.cs
@@ -29,7 +29,7 @@ namespace VirtoCommerce.Platform.Core.Security
             {
                 // Breaking change in v3:
                 // Do not allow users with Customer role login into platform
-                result = principal.IsInRole(PlatformConstants.Security.SystemRoles.Customer);
+                result = !principal.IsInRole(PlatformConstants.Security.SystemRoles.Customer);
                 if (result)
                 {
                     result = principal.HasClaim(PlatformConstants.Security.Claims.PermissionClaimType, permissionName);

--- a/src/VirtoCommerce.Platform.Core/Security/ClaimsPrincipalExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/ClaimsPrincipalExtensions.cs
@@ -27,8 +27,9 @@ namespace VirtoCommerce.Platform.Core.Security
 
             if (!result)
             {
-                result = !principal.IsInRole(PlatformConstants.Security.SystemRoles.Customer) && principal.HasClaim(PlatformConstants.Security.Claims.PermissionClaimType, PlatformConstants.Security.Permissions.SecurityCallApi);
-                if (result)
+                result = principal.IsInRole(PlatformConstants.Security.SystemRoles.Customer) ||
+                         permissionName == PlatformConstants.Security.Permissions.SecurityCallApi;
+                if (!result)
                 {
                     result = principal.HasClaim(PlatformConstants.Security.Claims.PermissionClaimType, permissionName);
                 }

--- a/src/VirtoCommerce.Platform.Core/Security/ClaimsPrincipalExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/ClaimsPrincipalExtensions.cs
@@ -22,14 +22,15 @@ namespace VirtoCommerce.Platform.Core.Security
 
         public static bool HasGlobalPermission(this ClaimsPrincipal principal, string permissionName)
         {
-            //TODO: Check cases with locked user
+            // TODO: Check cases with locked user
             var result = principal.IsInRole(PlatformConstants.Security.SystemRoles.Administrator);
 
             if (!result)
             {
-                result = !principal.IsInRole(PlatformConstants.Security.SystemRoles.Customer) &&
-                         permissionName == PlatformConstants.Security.Permissions.SecurityCallApi;
-                if (!result)
+                // Breaking change in v3:
+                // Do not allow users with Customer role login into platform
+                result = principal.IsInRole(PlatformConstants.Security.SystemRoles.Customer);
+                if (result)
                 {
                     result = principal.HasClaim(PlatformConstants.Security.Claims.PermissionClaimType, permissionName);
                 }


### PR DESCRIPTION
### Problem
security:api_call permission is required

### Solution
How it working on v2:
https://github.com/VirtoCommerce/vc-platform/blob/414fd969bfa1568f294c1d302b985ab308ba4058/VirtoCommerce.Platform.Data.Security/SecurityService.cs#L474-L479
This permission isn't required

### Proposed of changes
If user has type manager or administrator and checking permission is security:api_call, then allow action

