### PR TITLE
Added retry interval setting for failed notifications.

### DIFF
--- a/VirtoCommerce.Platform.Core/Notifications/SearchNotificationCriteria.cs
+++ b/VirtoCommerce.Platform.Core/Notifications/SearchNotificationCriteria.cs
@@ -6,6 +6,10 @@ namespace VirtoCommerce.Platform.Core.Notifications
 {
 	public class SearchNotificationCriteria : ValueObject
     {
+        public SearchNotificationCriteria()
+        {
+            RepeatMinutesIntervalForFail = 5 * 60;
+        }
         public int Take { get; set; }
 		public int Skip { get; set; }
         /// <summary>

--- a/VirtoCommerce.Platform.Core/Notifications/SearchNotificationCriteria.cs
+++ b/VirtoCommerce.Platform.Core/Notifications/SearchNotificationCriteria.cs
@@ -5,11 +5,7 @@ namespace VirtoCommerce.Platform.Core.Notifications
 {
 	public class SearchNotificationCriteria : ValueObject
     {
-        public SearchNotificationCriteria()
-        {
-            RepeatHoursIntervalForFail = 5;
-        }
-		public int Take { get; set; }
+        public int Take { get; set; }
 		public int Skip { get; set; }
         /// <summary>
         /// Sorting expression property1:asc;property2:desc
@@ -23,6 +19,6 @@ namespace VirtoCommerce.Platform.Core.Notifications
         /// <summary>
         /// time interval used to evaluate  active notifications have failure delivery
         /// </summary>
-        public int RepeatHoursIntervalForFail { get; set; }
+        public int RepeatMinutesIntervalForFail { get; set; }
 	}
 }

--- a/VirtoCommerce.Platform.Core/Notifications/SearchNotificationCriteria.cs
+++ b/VirtoCommerce.Platform.Core/Notifications/SearchNotificationCriteria.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Linq;
 using VirtoCommerce.Platform.Core.Common;
 
@@ -20,5 +21,8 @@ namespace VirtoCommerce.Platform.Core.Notifications
         /// time interval used to evaluate  active notifications have failure delivery
         /// </summary>
         public int RepeatMinutesIntervalForFail { get; set; }
+
+        [Obsolete("This property is obsolete. Use RepeatMinutesIntervalForFail instead.")]
+        public int RepeatHoursIntervalForFail { get; set; }
 	}
 }

--- a/VirtoCommerce.Platform.Data/Notifications/NotificationManager.cs
+++ b/VirtoCommerce.Platform.Data/Notifications/NotificationManager.cs
@@ -206,7 +206,7 @@ namespace VirtoCommerce.Platform.Data.Notifications
 
                 if (criteria.IsActive)
                 {
-                    query = query.Where(n => n.IsActive && n.SentDate == null && (n.LastFailAttemptDate == null || DbFunctions.AddHours(n.LastFailAttemptDate, criteria.RepeatHoursIntervalForFail) < DateTime.UtcNow)
+                    query = query.Where(n => n.IsActive && n.SentDate == null && (n.LastFailAttemptDate == null || DbFunctions.AddMinutes(n.LastFailAttemptDate, criteria.RepeatMinutesIntervalForFail) < DateTime.UtcNow)
                                              && (n.StartSendingDate == null || n.StartSendingDate < DateTime.UtcNow));
                 }
                 retVal.TotalCount = query.Count();
@@ -251,7 +251,7 @@ namespace VirtoCommerce.Platform.Data.Notifications
         {
             var retVal = GetNewNotification(entity.Type);
 
-            // Type may have been unregistered by now. 
+            // Type may have been unregistered by now.
             retVal?.InjectFrom(entity);
 
             if (retVal is EmailNotification emailNotification)

--- a/VirtoCommerce.Platform.Web/BackgroundJobs/SendNotificationsJobs.cs
+++ b/VirtoCommerce.Platform.Web/BackgroundJobs/SendNotificationsJobs.cs
@@ -18,7 +18,7 @@ namespace VirtoCommerce.Platform.Web.BackgroundJobs
         {
 			_notificationManager = notificationManager;
 	        _sendingBatchSize = settingsManager.GetValue("VirtoCommerce.Platform.Notifications.SendingJob.TakeCount", 20);
-            _settingsRepeatInterval = settingsManager.GetValue("VirtoCommerce.Platform.Notifications.SendingJob.RepeatInterval", 60);
+            _settingsRepeatInterval = settingsManager.GetValue("VirtoCommerce.Platform.Notifications.SendingJob.RepeatInterval", 5*60);
         }
 
         [DisableConcurrentExecution(60 * 60 * 24)]

--- a/VirtoCommerce.Platform.Web/Startup.cs
+++ b/VirtoCommerce.Platform.Web/Startup.cs
@@ -440,7 +440,7 @@ namespace VirtoCommerce.Platform.Web
 
             #region Caching
 
-            //Cure for System.Runtime.Caching.MemoryCache freezing 
+            //Cure for System.Runtime.Caching.MemoryCache freezing
             //https://www.zpqrtbnk.net/posts/appdomains-threads-cultureinfos-and-paracetamol
             app.SanitizeThreadCulture();
             ICacheManager<object> cacheManager = null;
@@ -523,6 +523,20 @@ namespace VirtoCommerce.Platform.Web
                                 ValueType = ModuleSetting.TypeInteger,
                                 Title = "Job Take Count",
                                 Description = "Take count for sending job"
+                            }
+                        }
+                    },
+                    new ModuleSettingsGroup
+                    {
+                        Name = "Platform|Notifications|SendingJob",
+                        Settings = new []
+                        {
+                            new ModuleSetting
+                            {
+                                Name = "VirtoCommerce.Platform.Notifications.SendingJob.RepeatInterval",
+                                ValueType = ModuleSetting.TypeInteger,
+                                Title = "Retry interval",
+                                Description = "Retry interval (minutes)"
                             }
                         }
                     },
@@ -719,7 +733,7 @@ namespace VirtoCommerce.Platform.Web
                 GlobalHost.DependencyResolver.UseRedis(new RedisScaleoutConfiguration(redisConnectionString, "VirtoCommerce.Platform.SignalR"));
             }
 
-            // SignalR 
+            // SignalR
             var tempCounterManager = new TempPerformanceCounterManager();
             GlobalHost.DependencyResolver.Register(typeof(IPerformanceCounterManager), () => tempCounterManager);
             var hubConfiguration = new HubConfiguration { EnableJavaScriptProxies = false };


### PR DESCRIPTION
### Problem
At the moment retry interval for failed notifications is 5 hours by default and there is no possibility to change it.

### Solution
Add ability to set in admin panel retry interval for resending failed notifications.

### Proposed of changes
Add new parameter for retry interval that can be changed in module settings.
