### PR TITLE
Added a setting for running Hangfire in SqlServer mode (instead of MemoryStorage)

### DIFF
--- a/src/VirtoCommerce.Platform.Web/appsettings.json
+++ b/src/VirtoCommerce.Platform.Web/appsettings.json
@@ -21,7 +21,10 @@
         //This options controls how the OpenID Connect
         //server (ASOS) handles the incoming requests to arriving on non-HTTPS endpoints should be rejected or not. By default, this property is set to false to help
         //mitigate man-in-the-middle attacks.
-        "AllowInsecureHttp": false
+        "AllowInsecureHttp": false,
+        "Hangfire": {
+           "JobStorageType":"SqlServer"
+        }
     },
     "Auth": {
         //auth server's url, e.g. http://localhost:5051/ or https://auth.example.com/ or leave empty for mode when authorization


### PR DESCRIPTION
Changed the way to launch Hangfire. By default SqlServer mode should be used instead of MemoryStorage