### PR TITLE
VP-2655: Fix PR decoration

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,6 +41,7 @@ jobs:
         $CMD="$($CMD) /d:sonar.host.url='https://sonarcloud.io'"
         $CMD="$($CMD) /d:sonar.login='${{ secrets.SONAR_TOKEN }}'"
         $CMD = "$($CMD) /d:sonar.branch='$($BRANCH)'"
+        $CMD = "$($CMD) /d:sonar.github.oauth='${{ secrets.GITHUB_TOKEN }}"
         if ('${{ github.event_name }}' -eq 'pull_request' ) {
           $CMD="$($CMD) /d:sonar.pullrequest.base='$('${{ github.event.pull_request.base.ref }}')'"
           $CMD="$($CMD) /d:sonar.pullrequest.branch='${{ github.event.pull_request.title }}'"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
         $CMD="$($CMD) /d:sonar.host.url='https://sonarcloud.io'"
         $CMD="$($CMD) /d:sonar.login='${{ secrets.SONAR_TOKEN }}'"
         $CMD = "$($CMD) /d:sonar.branch='$($BRANCH)'"
-        $CMD = "$($CMD) /d:sonar.github.oauth='${{ secrets.GITHUB_TOKEN }}"
+        $CMD = "$($CMD) /d:sonar.github.oauth='${{ secrets.GITHUB_TOKEN }}'"
         if ('${{ github.event_name }}' -eq 'pull_request' ) {
           $CMD="$($CMD) /d:sonar.pullrequest.base='$('${{ github.event.pull_request.base.ref }}')'"
           $CMD="$($CMD) /d:sonar.pullrequest.branch='${{ github.event.pull_request.title }}'"

--- a/src/VirtoCommerce.Platform.Web/Filters/DisableFormValueModelBindingAttribute.cs
+++ b/src/VirtoCommerce.Platform.Web/Filters/DisableFormValueModelBindingAttribute.cs
@@ -17,10 +17,12 @@ namespace VirtoCommerce.Platform.Web.Helpers
             factories.RemoveType<FormValueProviderFactory>();
             factories.RemoveType<FormFileValueProviderFactory>();
             factories.RemoveType<JQueryFormValueProviderFactory>();
+            // TODO: Implement smth
         }
 
         public void OnResourceExecuted(ResourceExecutedContext context)
         {
+            // factories.RemoveType<JQueryFormValueProviderFactory>();
         }
     }
 }


### PR DESCRIPTION
### Problem
PR is not decorated by SonarCloud

### Solution
A clear and concise description of what you want to happen.

### Proposed of changes
Describe the technical details of realization provided by you.

### Additional context (optional)
Add any other context or screenshots about the feature request here.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
