### PR TITLE
VP-2794: Start using short sha

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
           $versionSuffix = "-$($versionSuffixNode.InnerText.Trim())" 
         }  
           
-        $version = "$($versionPrefix)$versionSuffix-$('{{ github.sha }}'.Substring(0, 8))"
+        $version = "$($versionPrefix)$versionSuffix-$('${{ github.sha }}'.Substring(0, 8))"
 
         echo ::set-output name=tag::$version
       id: image
@@ -156,7 +156,7 @@ jobs:
           $versionSuffix = "-$($versionSuffixNode.InnerText.Trim())" 
         }  
           
-        $version = "$($versionPrefix)$versionSuffix-$('{{ github.sha }}'.Substring(0, 8))"
+        $version = "$($versionPrefix)$versionSuffix-$('${{ github.sha }}'.Substring(0, 8))"
 
         echo ::set-output name=tag::$version
       id: image
@@ -226,7 +226,7 @@ jobs:
           $versionSuffix = "-$($versionSuffixNode.InnerText.Trim())" 
         }  
           
-        $version = "$($versionPrefix)$versionSuffix-$('{{ github.sha }}'.Substring(0, 8))"
+        $version = "$($versionPrefix)$versionSuffix-$('${{ github.sha }}'.Substring(0, 8))"
 
         echo ::set-output name=tag::$version
       id: image

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -80,7 +80,7 @@ jobs:
           
         $version = "$($versionPrefix)$versionSuffix-$('${{ github.sha }}'.Substring(0, 8))"
 
-        echo ::set-output name=tag::$version
+        echo "::set-output name=tag::$version"
       id: image
 
     - name: Install VirtoCommerce.GlobalTool
@@ -158,7 +158,7 @@ jobs:
           
         $version = "$($versionPrefix)$versionSuffix-$('${{ github.sha }}'.Substring(0, 8))"
 
-        echo ::set-output name=tag::$version
+        echo "::set-output name=tag::$version"
       id: image
 
     - name: Pull Platform Docker Image from GitHub
@@ -228,7 +228,7 @@ jobs:
           
         $version = "$($versionPrefix)$versionSuffix-$('${{ github.sha }}'.Substring(0, 8))"
 
-        echo ::set-output name=tag::$version
+        echo "::set-output name=tag::$version"
       id: image
 
     - name: Pull Platform Docker Image from GitHub

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,9 +62,6 @@ jobs:
     name: Build Package
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
-    env:
-      SHA8: ${ GITHUB_SHA:8 }
-
     steps:
     - uses: actions/checkout@v2
 
@@ -76,11 +73,30 @@ jobs:
     - name: Build Package
       run: vc-build Compress -skip Test
 
+    - name: Get Image Tag
+      shell: pwsh
+      run: |
+        [Xml]$buildPropsXml = Get-Content -Path 'Directory.Build.Props'
+      
+        $versionPrefixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionPrefix') | Select-Object -First 1
+        $versionSuffixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionSuffix') | Select-Object -First 1
+        $versionPrefix = "$($versionPrefixNode.InnerText.Trim())"
+        if (-not ([string]::IsNullOrEmpty($versionSuffixNode.InnerText))) 
+        { 
+          $versionSuffix = "-$($versionSuffixNode.InnerText.Trim())" 
+        }  
+          
+        $version = "$($versionPrefix)$versionSuffix-$('{{ github.sha }}'.Substring(0, 8))"
+
+        echo ::set-output name=tag::$version
+      working-directory: ./src/github.com/argoproj/argo-cd
+      id: image
+
     - name: Build Docker Image
       run: |
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
         pwsh -command "Invoke-WebRequest -Uri https://raw.githubusercontent.com/VirtoCommerce/jenkins-pipeline-scripts/master/resources/docker.core/linux/platform/Dockerfile -OutFile artifacts/publish/Dockerfile"
-        docker build artifacts/publish --build-arg SOURCE=. --tag "docker.pkg.github.com/$REPOSITORY/platform:$SHA8"
+        docker build artifacts/publish --build-arg SOURCE=. --tag "docker.pkg.github.com/$REPOSITORY/platform:${{ steps.image.outputs.tag }}"
 
     - name: Docker Login
       uses: azure/docker-login@v1
@@ -100,16 +116,13 @@ jobs:
     - name: Push Docker Image to GitHub
       run: |
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
-        docker push "docker.pkg.github.com/$REPOSITORY/platform:$SHA8"
+        docker push "docker.pkg.github.com/$REPOSITORY/platform:${{ steps.image.outputs.tag }}"
 
   swagger-validation:
     name: Swagger Schema Validation
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     needs: build-package
-    env:
-      SHA8: ${ GITHUB_SHA:8 }
-
     steps:
     - uses: actions/checkout@v2
 
@@ -131,10 +144,29 @@ jobs:
         username: $GITHUB_ACTOR
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Get Image Tag
+      shell: pwsh
+      run: |
+        [Xml]$buildPropsXml = Get-Content -Path 'Directory.Build.Props'
+      
+        $versionPrefixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionPrefix') | Select-Object -First 1
+        $versionSuffixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionSuffix') | Select-Object -First 1
+        $versionPrefix = "$($versionPrefixNode.InnerText.Trim())"
+        if (-not ([string]::IsNullOrEmpty($versionSuffixNode.InnerText))) 
+        { 
+          $versionSuffix = "-$($versionSuffixNode.InnerText.Trim())" 
+        }  
+          
+        $version = "$($versionPrefix)$versionSuffix-$('{{ github.sha }}'.Substring(0, 8))"
+
+        echo ::set-output name=tag::$version
+      working-directory: ./src/github.com/argoproj/argo-cd
+      id: image
+
     - name: Pull Platform Docker Image from GitHub
       run: |
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
-        docker pull "docker.pkg.github.com/$REPOSITORY/platform:$SHA8"
+        docker pull "docker.pkg.github.com/$REPOSITORY/platform:${{ steps.image.outputs.tag }}"
 
     - name: Run container
       run: |
@@ -144,7 +176,7 @@ jobs:
         pwsh -command "Invoke-WebRequest -Uri https://raw.githubusercontent.com/VirtoCommerce/jenkins-pipeline-scripts/master/resources/docker.core/linux/docker-compose.yml -OutFile docker-compose.yml"
         pwsh -command "((Get-Content -path docker-compose.yml -Raw) -replace 'virtocommerce/platform','docker.pkg.github.com/$REPOSITORY/platform') | Set-Content -Path docker-compose.yml"
         pwsh -command "((Get-Content -path docker-compose.yml -Raw) -replace 'MultipleActiveResultSets=True','MultipleActiveResultSets=False') | Set-Content -Path docker-compose.yml"
-        echo PLATFORM_DOCKER_TAG=$SHA8 >> .env
+        echo PLATFORM_DOCKER_TAG=${{ steps.image.outputs.tag }} >> .env
         echo STOREFRONT_DOCKER_TAG=3.0-preview-linux >> .env
         echo DOCKER_PLATFORM_PORT=8081 >> .env
         echo DOCKER_STOREFRONT_PORT=8082 >> .env
@@ -175,9 +207,6 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     needs: [build-package, unit-tests, swagger-validation]
-    env:
-      SHA8: ${ GITHUB_SHA:8 }
-
     steps:
     - name: Docker Login
       uses: azure/docker-login@v1
@@ -186,10 +215,29 @@ jobs:
         username: $GITHUB_ACTOR
         password: ${{ secrets.GITHUB_TOKEN }}
 
+    - name: Get Image Tag
+      shell: pwsh
+      run: |
+        [Xml]$buildPropsXml = Get-Content -Path 'Directory.Build.Props'
+      
+        $versionPrefixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionPrefix') | Select-Object -First 1
+        $versionSuffixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionSuffix') | Select-Object -First 1
+        $versionPrefix = "$($versionPrefixNode.InnerText.Trim())"
+        if (-not ([string]::IsNullOrEmpty($versionSuffixNode.InnerText))) 
+        { 
+          $versionSuffix = "-$($versionSuffixNode.InnerText.Trim())" 
+        }  
+          
+        $version = "$($versionPrefix)$versionSuffix-$('{{ github.sha }}'.Substring(0, 8))"
+
+        echo ::set-output name=tag::$version
+      working-directory: ./src/github.com/argoproj/argo-cd
+      id: image
+
     - name: Pull Platform Docker Image from GitHub
       run: |
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
-        docker pull "docker.pkg.github.com/$REPOSITORY/platform:$SHA8"
+        docker pull "docker.pkg.github.com/$REPOSITORY/platform:${{ steps.image.outputs.tag }}"
 
     - name: Push Docker Image to docker.pkg.github.com
       shell: pwsh
@@ -208,7 +256,7 @@ jobs:
 
         $PLATFORM_DOCKER_TAG = $PLATFORM_DOCKER_TAG.Replace('/', '_')
         
-        docker tag "$($REPOSITORY):$($env.SHA8)" "$($REPOSITORY):$($PLATFORM_DOCKER_TAG)"
+        docker tag "$($REPOSITORY):${{ steps.image.outputs.tag }}" "$($REPOSITORY):$($PLATFORM_DOCKER_TAG)"
         docker push "$($REPOSITORY):$($PLATFORM_DOCKER_TAG)"
 
     - name: Push Docker Image to hub.docker.io
@@ -220,6 +268,6 @@ jobs:
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
         PLATFORM_DOCKER_TAG='dev-linux-experimental'
         if [ '${{ github.ref }}' = 'refs/heads/master' ]; then PLATFORM_DOCKER_TAG=linux-experimental; fi
-        docker tag docker.pkg.github.com/$REPOSITORY/platform:$SHA8 ${{ secrets.DOCKER_USERNAME }}/platform:$PLATFORM_DOCKER_TAG
+        docker tag docker.pkg.github.com/$REPOSITORY/platform:${{ steps.image.outputs.tag }} ${{ secrets.DOCKER_USERNAME }}/platform:$PLATFORM_DOCKER_TAG
         docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_TOKEN }}
         docker push ${{ secrets.DOCKER_USERNAME }}/platform:$PLATFORM_DOCKER_TAG

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -247,7 +247,7 @@ jobs:
           $PLATFORM_DOCKER_TAG = 'linux-latest'
         }
         elseif ('${{ github.event_name }}' -eq 'pull_request') {
-          $PLATFORM_DOCKER_TAG = '${{ github.event.pull_request.head.ref }}'
+          $PLATFORM_DOCKER_TAG = 'pr${{ github.event.pull_request.number }}'
         }
         else {
           $PLATFORM_DOCKER_TAG = "$('${{ github.ref }}'.Replace('refs/heads/', ''))-linux-latest"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,18 +65,10 @@ jobs:
     steps:
     - uses: actions/checkout@v2
 
-    - name: Install VirtoCommerce.GlobalTool
-      run: |
-        dotnet tool install --global VirtoCommerce.GlobalTool --version 3.0.0-beta0010
-        mv Directory.Build.Props Directory.Build.props
-
-    - name: Build Package
-      run: vc-build Compress -skip Test
-
     - name: Get Image Tag
       shell: pwsh
       run: |
-        [Xml]$buildPropsXml = Get-Content -Path 'Directory.Build.props'
+        [Xml]$buildPropsXml = Get-Content -Path 'Directory.Build.Props'
       
         $versionPrefixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionPrefix') | Select-Object -First 1
         $versionSuffixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionSuffix') | Select-Object -First 1
@@ -90,6 +82,14 @@ jobs:
 
         echo ::set-output name=tag::$version
       id: image
+
+    - name: Install VirtoCommerce.GlobalTool
+      run: |
+        dotnet tool install --global VirtoCommerce.GlobalTool --version 3.0.0-beta0010
+        mv Directory.Build.Props Directory.Build.props
+
+    - name: Build Package
+      run: vc-build Compress -skip Test
 
     - name: Build Docker Image
       run: |
@@ -146,7 +146,7 @@ jobs:
     - name: Get Image Tag
       shell: pwsh
       run: |
-        [Xml]$buildPropsXml = Get-Content -Path 'Directory.Build.props'
+        [Xml]$buildPropsXml = Get-Content -Path 'Directory.Build.Props'
       
         $versionPrefixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionPrefix') | Select-Object -First 1
         $versionSuffixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionSuffix') | Select-Object -First 1
@@ -216,7 +216,7 @@ jobs:
     - name: Get Image Tag
       shell: pwsh
       run: |
-        [Xml]$buildPropsXml = Get-Content -Path 'Directory.Build.props'
+        [Xml]$buildPropsXml = Get-Content -Path 'Directory.Build.Props'
       
         $versionPrefixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionPrefix') | Select-Object -First 1
         $versionSuffixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionSuffix') | Select-Object -First 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     env:
-      SHA8: ${GITHUB_SHA::8}
+      SHA8: ${{ GITHUB_SHA::8 }}
 
     steps:
     - uses: actions/checkout@v2
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-package
     env:
-      SHA8: ${GITHUB_SHA::8}
+      SHA8: ${{ GITHUB_SHA::8 }}
 
     steps:
     - uses: actions/checkout@v2
@@ -176,8 +176,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-package, unit-tests, swagger-validation]
     env:
-      SHA8: ${GITHUB_SHA::8}
-      
+      SHA8: ${{ GITHUB_SHA::8 }}
+
     steps:
     - name: Docker Login
       uses: azure/docker-login@v1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -62,6 +62,8 @@ jobs:
     name: Build Package
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
+    env:
+      SHA8: ${GITHUB_SHA::8}
 
     steps:
     - uses: actions/checkout@v2
@@ -78,7 +80,7 @@ jobs:
       run: |
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
         pwsh -command "Invoke-WebRequest -Uri https://raw.githubusercontent.com/VirtoCommerce/jenkins-pipeline-scripts/master/resources/docker.core/linux/platform/Dockerfile -OutFile artifacts/publish/Dockerfile"
-        docker build artifacts/publish --build-arg SOURCE=. --tag "docker.pkg.github.com/$REPOSITORY/platform:${{ github.sha::8 }}"
+        docker build artifacts/publish --build-arg SOURCE=. --tag "docker.pkg.github.com/$REPOSITORY/platform:$SHA8"
 
     - name: Docker Login
       uses: azure/docker-login@v1
@@ -98,13 +100,15 @@ jobs:
     - name: Push Docker Image to GitHub
       run: |
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
-        docker push "docker.pkg.github.com/$REPOSITORY/platform:${{ github.sha::8 }}"
+        docker push "docker.pkg.github.com/$REPOSITORY/platform:$SHA8"
 
   swagger-validation:
     name: Swagger Schema Validation
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     needs: build-package
+    env:
+      SHA8: ${GITHUB_SHA::8}
 
     steps:
     - uses: actions/checkout@v2
@@ -130,7 +134,7 @@ jobs:
     - name: Pull Platform Docker Image from GitHub
       run: |
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
-        docker pull "docker.pkg.github.com/$REPOSITORY/platform:${{ github.sha::8 }}"
+        docker pull "docker.pkg.github.com/$REPOSITORY/platform:$SHA8"
 
     - name: Run container
       run: |
@@ -140,7 +144,7 @@ jobs:
         pwsh -command "Invoke-WebRequest -Uri https://raw.githubusercontent.com/VirtoCommerce/jenkins-pipeline-scripts/master/resources/docker.core/linux/docker-compose.yml -OutFile docker-compose.yml"
         pwsh -command "((Get-Content -path docker-compose.yml -Raw) -replace 'virtocommerce/platform','docker.pkg.github.com/$REPOSITORY/platform') | Set-Content -Path docker-compose.yml"
         pwsh -command "((Get-Content -path docker-compose.yml -Raw) -replace 'MultipleActiveResultSets=True','MultipleActiveResultSets=False') | Set-Content -Path docker-compose.yml"
-        echo PLATFORM_DOCKER_TAG=${{ github.sha::8 }} >> .env
+        echo PLATFORM_DOCKER_TAG=$SHA8 >> .env
         echo STOREFRONT_DOCKER_TAG=3.0-preview-linux >> .env
         echo DOCKER_PLATFORM_PORT=8081 >> .env
         echo DOCKER_STOREFRONT_PORT=8082 >> .env
@@ -171,7 +175,9 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     needs: [build-package, unit-tests, swagger-validation]
-
+    env:
+      SHA8: ${GITHUB_SHA::8}
+      
     steps:
     - name: Docker Login
       uses: azure/docker-login@v1
@@ -183,7 +189,7 @@ jobs:
     - name: Pull Platform Docker Image from GitHub
       run: |
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
-        docker pull "docker.pkg.github.com/$REPOSITORY/platform:${{ github.sha::8 }}"
+        docker pull "docker.pkg.github.com/$REPOSITORY/platform:$SHA8"
 
     - name: Push Docker Image to docker.pkg.github.com
       shell: pwsh
@@ -202,7 +208,7 @@ jobs:
 
         $PLATFORM_DOCKER_TAG = $PLATFORM_DOCKER_TAG.Replace('/', '_')
         
-        docker tag "$($REPOSITORY):${{ github.sha::8 }}" "$($REPOSITORY):$($PLATFORM_DOCKER_TAG)"
+        docker tag "$($REPOSITORY):$($env.SHA8)" "$($REPOSITORY):$($PLATFORM_DOCKER_TAG)"
         docker push "$($REPOSITORY):$($PLATFORM_DOCKER_TAG)"
 
     - name: Push Docker Image to hub.docker.io
@@ -214,6 +220,6 @@ jobs:
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
         PLATFORM_DOCKER_TAG='dev-linux-experimental'
         if [ '${{ github.ref }}' = 'refs/heads/master' ]; then PLATFORM_DOCKER_TAG=linux-experimental; fi
-        docker tag docker.pkg.github.com/$REPOSITORY/platform:${{ github.sha::8 }} ${{ secrets.DOCKER_USERNAME }}/platform:$PLATFORM_DOCKER_TAG
+        docker tag docker.pkg.github.com/$REPOSITORY/platform:$SHA8 ${{ secrets.DOCKER_USERNAME }}/platform:$PLATFORM_DOCKER_TAG
         docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_TOKEN }}
         docker push ${{ secrets.DOCKER_USERNAME }}/platform:$PLATFORM_DOCKER_TAG

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -76,7 +76,7 @@ jobs:
     - name: Get Image Tag
       shell: pwsh
       run: |
-        [Xml]$buildPropsXml = Get-Content -Path 'Directory.Build.Props'
+        [Xml]$buildPropsXml = Get-Content -Path 'Directory.Build.props'
       
         $versionPrefixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionPrefix') | Select-Object -First 1
         $versionSuffixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionSuffix') | Select-Object -First 1
@@ -146,7 +146,7 @@ jobs:
     - name: Get Image Tag
       shell: pwsh
       run: |
-        [Xml]$buildPropsXml = Get-Content -Path 'Directory.Build.Props'
+        [Xml]$buildPropsXml = Get-Content -Path 'Directory.Build.props'
       
         $versionPrefixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionPrefix') | Select-Object -First 1
         $versionSuffixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionSuffix') | Select-Object -First 1
@@ -216,7 +216,7 @@ jobs:
     - name: Get Image Tag
       shell: pwsh
       run: |
-        [Xml]$buildPropsXml = Get-Content -Path 'Directory.Build.Props'
+        [Xml]$buildPropsXml = Get-Content -Path 'Directory.Build.props'
       
         $versionPrefixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionPrefix') | Select-Object -First 1
         $versionSuffixNode = $buildPropsXml.SelectNodes('Project/PropertyGroup/VersionSuffix') | Select-Object -First 1

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,6 +113,7 @@ jobs:
         path: artifacts/publish/  
 
     - name: Push Docker Image to GitHub
+      shell: pwsh
       run: |
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
         docker push "docker.pkg.github.com/$REPOSITORY/platform:${{ steps.image.outputs.tag }}"
@@ -206,6 +207,8 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-package, unit-tests, swagger-validation]
     steps:
+    - uses: actions/checkout@v2
+
     - name: Docker Login
       uses: azure/docker-login@v1
       with:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -271,37 +271,36 @@ jobs:
         docker push ${{ secrets.DOCKER_USERNAME }}/platform:$PLATFORM_DOCKER_TAG
         echo "::set-env name=BUILD_STATE::successful"
 
-      - name: Set Build status Failed
-        if: failure()
-        run: echo "::set-env name=BUILD_STATE::failed"
+    - name: Set Build status Failed
+      if: failure()
+      run: echo "::set-env name=BUILD_STATE::failed"
 
-      - name: Parse Jira Keys from Commit
-        id: jira_keys
-        if: always()
-        uses: HighwayThree/jira-extract-issue-keys@master
-        with:
-          is-pull-request: ${{ github.event_name == 'pull_request' }}
-          parse-all-commits: ${{ github.event_name == 'push' }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-  
-      - name: Push Build Info to Jira
-        if: steps.jira_keys.outputs.jira-keys != ''
-        id: push_build_info_to_jira
-        uses: HighwayThree/jira-upload-build-info@master
-        with:
-          cloud-instance-base-url: '${{ secrets.CLOUD_INSTANCE_BASE_URL }}'
-          client-id: '${{ secrets.CLIENT_ID }}'
-          client-secret: '${{ secrets.CLIENT_SECRET }}'
-          pipeline-id: '${{ github.repository }} ${{ github.workflow }}'
-          build-number: ${{ github.run_number }}
-          build-display-name: 'Workflow: ${{ github.workflow }} (#${{ github.run_number }})'
-          build-state: "${{ env.BUILD_STATE }}"
-          build-url: '${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}'
-          update-sequence-number: '${{ github.run_id }}'
-          last-updated: '${{github.event.head_commit.timestamp}}'
-          issue-keys: "${{ steps.jira_keys.outputs.jira-keys }}"
-          commit-id: '${{ github.sha }}'
-          repo-url: '${{ github.event.repository.html_url }}'
-          build-ref-url: '${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}'
-  
+    - name: Parse Jira Keys from Commit
+      id: jira_keys
+      if: always()
+      uses: HighwayThree/jira-extract-issue-keys@master
+      with:
+        is-pull-request: ${{ github.event_name == 'pull_request' }}
+        parse-all-commits: ${{ github.event_name == 'push' }}
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+    - name: Push Build Info to Jira
+      if: steps.jira_keys.outputs.jira-keys != ''
+      id: push_build_info_to_jira
+      uses: HighwayThree/jira-upload-build-info@master
+      with:
+        cloud-instance-base-url: '${{ secrets.CLOUD_INSTANCE_BASE_URL }}'
+        client-id: '${{ secrets.CLIENT_ID }}'
+        client-secret: '${{ secrets.CLIENT_SECRET }}'
+        pipeline-id: '${{ github.repository }} ${{ github.workflow }}'
+        build-number: ${{ github.run_number }}
+        build-display-name: 'Workflow: ${{ github.workflow }} (#${{ github.run_number }})'
+        build-state: "${{ env.BUILD_STATE }}"
+        build-url: '${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}'
+        update-sequence-number: '${{ github.run_id }}'
+        last-updated: '${{github.event.head_commit.timestamp}}'
+        issue-keys: "${{ steps.jira_keys.outputs.jira-keys }}"
+        commit-id: '${{ github.sha }}'
+        repo-url: '${{ github.event.repository.html_url }}'
+        build-ref-url: '${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -63,7 +63,7 @@ jobs:
     # The type of runner that the job will run on
     runs-on: ubuntu-latest
     env:
-      SHA8: ${{ GITHUB_SHA::8 }}
+      SHA8: ${ GITHUB_SHA:8 }
 
     steps:
     - uses: actions/checkout@v2
@@ -108,7 +108,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: build-package
     env:
-      SHA8: ${{ GITHUB_SHA::8 }}
+      SHA8: ${ GITHUB_SHA:8 }
 
     steps:
     - uses: actions/checkout@v2
@@ -176,7 +176,7 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-package, unit-tests, swagger-validation]
     env:
-      SHA8: ${{ GITHUB_SHA::8 }}
+      SHA8: ${ GITHUB_SHA:8 }
 
     steps:
     - name: Docker Login

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -113,7 +113,6 @@ jobs:
         path: artifacts/publish/  
 
     - name: Push Docker Image to GitHub
-      shell: pwsh
       run: |
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
         docker push "docker.pkg.github.com/$REPOSITORY/platform:${{ steps.image.outputs.tag }}"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -78,7 +78,7 @@ jobs:
       run: |
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
         pwsh -command "Invoke-WebRequest -Uri https://raw.githubusercontent.com/VirtoCommerce/jenkins-pipeline-scripts/master/resources/docker.core/linux/platform/Dockerfile -OutFile artifacts/publish/Dockerfile"
-        docker build artifacts/publish --build-arg SOURCE=. --tag "docker.pkg.github.com/$REPOSITORY/platform:${{ github.sha }}"
+        docker build artifacts/publish --build-arg SOURCE=. --tag "docker.pkg.github.com/$REPOSITORY/platform:${{ github.sha::8 }}"
 
     - name: Docker Login
       uses: azure/docker-login@v1
@@ -98,7 +98,7 @@ jobs:
     - name: Push Docker Image to GitHub
       run: |
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
-        docker push "docker.pkg.github.com/$REPOSITORY/platform:${{ github.sha }}"
+        docker push "docker.pkg.github.com/$REPOSITORY/platform:${{ github.sha::8 }}"
 
   swagger-validation:
     name: Swagger Schema Validation
@@ -130,7 +130,7 @@ jobs:
     - name: Pull Platform Docker Image from GitHub
       run: |
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
-        docker pull "docker.pkg.github.com/$REPOSITORY/platform:${{ github.sha }}"
+        docker pull "docker.pkg.github.com/$REPOSITORY/platform:${{ github.sha::8 }}"
 
     - name: Run container
       run: |
@@ -140,7 +140,7 @@ jobs:
         pwsh -command "Invoke-WebRequest -Uri https://raw.githubusercontent.com/VirtoCommerce/jenkins-pipeline-scripts/master/resources/docker.core/linux/docker-compose.yml -OutFile docker-compose.yml"
         pwsh -command "((Get-Content -path docker-compose.yml -Raw) -replace 'virtocommerce/platform','docker.pkg.github.com/$REPOSITORY/platform') | Set-Content -Path docker-compose.yml"
         pwsh -command "((Get-Content -path docker-compose.yml -Raw) -replace 'MultipleActiveResultSets=True','MultipleActiveResultSets=False') | Set-Content -Path docker-compose.yml"
-        echo PLATFORM_DOCKER_TAG=${{ github.sha }} >> .env
+        echo PLATFORM_DOCKER_TAG=${{ github.sha::8 }} >> .env
         echo STOREFRONT_DOCKER_TAG=3.0-preview-linux >> .env
         echo DOCKER_PLATFORM_PORT=8081 >> .env
         echo DOCKER_STOREFRONT_PORT=8082 >> .env
@@ -183,7 +183,7 @@ jobs:
     - name: Pull Platform Docker Image from GitHub
       run: |
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
-        docker pull "docker.pkg.github.com/$REPOSITORY/platform:${{ github.sha }}"
+        docker pull "docker.pkg.github.com/$REPOSITORY/platform:${{ github.sha::8 }}"
 
     - name: Push Docker Image to docker.pkg.github.com
       shell: pwsh
@@ -202,7 +202,7 @@ jobs:
 
         $PLATFORM_DOCKER_TAG = $PLATFORM_DOCKER_TAG.Replace('/', '_')
         
-        docker tag "$($REPOSITORY):${{ github.sha }}" "$($REPOSITORY):$($PLATFORM_DOCKER_TAG)"
+        docker tag "$($REPOSITORY):${{ github.sha::8 }}" "$($REPOSITORY):$($PLATFORM_DOCKER_TAG)"
         docker push "$($REPOSITORY):$($PLATFORM_DOCKER_TAG)"
 
     - name: Push Docker Image to hub.docker.io
@@ -214,6 +214,6 @@ jobs:
         REPOSITORY=$(echo $GITHUB_REPOSITORY | tr '[A-Z]' '[a-z]') 
         PLATFORM_DOCKER_TAG='dev-linux-experimental'
         if [ '${{ github.ref }}' = 'refs/heads/master' ]; then PLATFORM_DOCKER_TAG=linux-experimental; fi
-        docker tag docker.pkg.github.com/$REPOSITORY/platform:${{ github.sha }} ${{ secrets.DOCKER_USERNAME }}/platform:$PLATFORM_DOCKER_TAG
+        docker tag docker.pkg.github.com/$REPOSITORY/platform:${{ github.sha::8 }} ${{ secrets.DOCKER_USERNAME }}/platform:$PLATFORM_DOCKER_TAG
         docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_TOKEN }}
         docker push ${{ secrets.DOCKER_USERNAME }}/platform:$PLATFORM_DOCKER_TAG

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,7 +89,6 @@ jobs:
         $version = "$($versionPrefix)$versionSuffix-$('{{ github.sha }}'.Substring(0, 8))"
 
         echo ::set-output name=tag::$version
-      working-directory: ./src/github.com/argoproj/argo-cd
       id: image
 
     - name: Build Docker Image
@@ -160,7 +159,6 @@ jobs:
         $version = "$($versionPrefix)$versionSuffix-$('{{ github.sha }}'.Substring(0, 8))"
 
         echo ::set-output name=tag::$version
-      working-directory: ./src/github.com/argoproj/argo-cd
       id: image
 
     - name: Pull Platform Docker Image from GitHub
@@ -231,7 +229,6 @@ jobs:
         $version = "$($versionPrefix)$versionSuffix-$('{{ github.sha }}'.Substring(0, 8))"
 
         echo ::set-output name=tag::$version
-      working-directory: ./src/github.com/argoproj/argo-cd
       id: image
 
     - name: Pull Platform Docker Image from GitHub

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -255,6 +255,7 @@ jobs:
         
         docker tag "$($REPOSITORY):${{ steps.image.outputs.tag }}" "$($REPOSITORY):$($PLATFORM_DOCKER_TAG)"
         docker push "$($REPOSITORY):$($PLATFORM_DOCKER_TAG)"
+        echo "::set-env name=BUILD_STATE::successful"
 
     - name: Push Docker Image to hub.docker.io
       if: ${{ env.DOCKER_USERNAME != 0 && env.DOCKER_TOKEN != 0 && github.event_name != 'pull_request' }}
@@ -268,3 +269,39 @@ jobs:
         docker tag docker.pkg.github.com/$REPOSITORY/platform:${{ steps.image.outputs.tag }} ${{ secrets.DOCKER_USERNAME }}/platform:$PLATFORM_DOCKER_TAG
         docker login -u ${{ secrets.DOCKER_USERNAME }} -p ${{ secrets.DOCKER_TOKEN }}
         docker push ${{ secrets.DOCKER_USERNAME }}/platform:$PLATFORM_DOCKER_TAG
+        echo "::set-env name=BUILD_STATE::successful"
+
+      - name: Set Build status Failed
+        if: failure()
+        run: echo "::set-env name=BUILD_STATE::failed"
+
+      - name: Parse Jira Keys from Commit
+        id: jira_keys
+        if: always()
+        uses: HighwayThree/jira-extract-issue-keys@master
+        with:
+          is-pull-request: ${{ github.event_name == 'pull_request' }}
+          parse-all-commits: ${{ github.event_name == 'push' }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  
+      - name: Push Build Info to Jira
+        if: steps.jira_keys.outputs.jira-keys != ''
+        id: push_build_info_to_jira
+        uses: HighwayThree/jira-upload-build-info@master
+        with:
+          cloud-instance-base-url: '${{ secrets.CLOUD_INSTANCE_BASE_URL }}'
+          client-id: '${{ secrets.CLIENT_ID }}'
+          client-secret: '${{ secrets.CLIENT_SECRET }}'
+          pipeline-id: '${{ github.repository }} ${{ github.workflow }}'
+          build-number: ${{ github.run_number }}
+          build-display-name: 'Workflow: ${{ github.workflow }} (#${{ github.run_number }})'
+          build-state: "${{ env.BUILD_STATE }}"
+          build-url: '${{github.event.repository.html_url}}/actions/runs/${{github.run_id}}'
+          update-sequence-number: '${{ github.run_id }}'
+          last-updated: '${{github.event.head_commit.timestamp}}'
+          issue-keys: "${{ steps.jira_keys.outputs.jira-keys }}"
+          commit-id: '${{ github.sha }}'
+          repo-url: '${{ github.event.repository.html_url }}'
+          build-ref-url: '${{ github.event.repository.html_url }}/actions/runs/${{ github.run_id }}'
+  


### PR DESCRIPTION
### Problem
Docker images with SHA as a tag are not useful.

### Solution
Use [version number]-[sha (first 8 chars)] if version suffix is not defined or
[version number]-[version suffix]-[sha (first 8 chars)].

### Proposed of changes
Read Version and Suffix from Directory.Build.Props

### Additional context (optional)
N/A

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
