### PR TITLE
VP-3329: Set Start sending date for new email notifications

### DIFF
--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -15,8 +15,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Virto Commerce 2.13")]
 [assembly: AssemblyCopyright("Copyright © VirtoCommerce 2011-2020")]
 
-[assembly: AssemblyFileVersion("2.13.64.0")]
-[assembly: AssemblyVersion("2.13.64.0")]
+[assembly: AssemblyFileVersion("2.13.63.0")]
+[assembly: AssemblyVersion("2.13.63.0")]
 
 
 #if DEBUG

--- a/CommonAssemblyInfo.cs
+++ b/CommonAssemblyInfo.cs
@@ -15,8 +15,8 @@ using System.Runtime.InteropServices;
 [assembly: AssemblyProduct("Virto Commerce 2.13")]
 [assembly: AssemblyCopyright("Copyright © VirtoCommerce 2011-2020")]
 
-[assembly: AssemblyFileVersion("2.13.63.0")]
-[assembly: AssemblyVersion("2.13.63.0")]
+[assembly: AssemblyFileVersion("2.13.64.0")]
+[assembly: AssemblyVersion("2.13.64.0")]
 
 
 #if DEBUG

--- a/VirtoCommerce.Platform.Data.Notifications/SendGridEmailNotificationSendingGateway.cs
+++ b/VirtoCommerce.Platform.Data.Notifications/SendGridEmailNotificationSendingGateway.cs
@@ -65,6 +65,7 @@ namespace VirtoCommerce.Platform.Data.Notifications
                 }
             }
             mail.SetReplyTo(from);
+            emailNotification.StartSendingDate = DateTime.UtcNow;
 
             try
             {

--- a/VirtoCommerce.Platform.Data/Notifications/DefaultSmtpEmailNotificationSendingGateway.cs
+++ b/VirtoCommerce.Platform.Data/Notifications/DefaultSmtpEmailNotificationSendingGateway.cs
@@ -70,6 +70,8 @@ namespace VirtoCommerce.Platform.Data.Notifications
                     var port = _settingsManager.GetValue(_smtpClientPortSettingName, 465); // Default SMTP port with SSL
                     var useSsl = _settingsManager.GetValue(_smtpClientUseSslSettingName, false);
 
+                    emailNotification.StartSendingDate = DateTime.UtcNow;
+
                     using (var smtpClient = new SmtpClient(host, Convert.ToInt32(port)))
                     {
                         smtpClient.Credentials = new System.Net.NetworkCredential(login, password);


### PR DESCRIPTION
### Problem
The start sending date is always today's date and time when notification was successfully sent via smtp. 

### Solution
This date should be date/time when send process started. 

### Proposed of changes
It was null all the time, so i added assignment to the corresponding property.

### Additional context (optional)
![image](https://user-images.githubusercontent.com/22875828/85875081-f71bd400-b7d3-11ea-8d39-42bdfb69af65.png)


### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow ms best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
