### PR TITLE
Fix get image version action

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -68,7 +68,7 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Get Image Version
-      uses: VirtoCommerce/vc-github-actions/get-image-version@v3.0.1
+      uses: VirtoCommerce/vc-github-actions/get-image-version@master
       id: image
 
     - name: Install VirtoCommerce.GlobalTool


### PR DESCRIPTION
Set VirtoCommerce/vc-github-actions/get-image-version to master branch
