### PR TITLE
VP-4159: Fix CI fail

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -90,7 +90,7 @@ jobs:
     - name: Install VirtoCommerce.GlobalTool
       run: |
         dotnet tool install --global VirtoCommerce.GlobalTool
-        mv Directory.Build.Props Directory.Build.props
+
     - name: Build Package
       run: vc-build Compress -skip Test
 


### PR DESCRIPTION
### Problem
CI fails after Directory.Build.props renaming

### Solution
Remove  `mv Directory.Build.Props Directory.Build.props`  from CI

