### PR TITLE
Updated method to read the Web and Core xml file

### DIFF
--- a/VirtoCommerce.Platform.Web/Swagger/SwaggerConfig.cs
+++ b/VirtoCommerce.Platform.Web/Swagger/SwaggerConfig.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -159,10 +160,23 @@ namespace VirtoCommerce.Platform.Web.Swagger
             }
         }
 
+        //private static string[] GetXmlFilesPaths(string virtualDirectoryPath)
+        //{
+        //    var physicalPath = HostingEnvironment.MapPath(virtualDirectoryPath);
+        //    return physicalPath != null ? Directory.GetFiles(physicalPath, "*.Web.XML") : new string[] { };
+        //}
+
         private static string[] GetXmlFilesPaths(string virtualDirectoryPath)
         {
             var physicalPath = HostingEnvironment.MapPath(virtualDirectoryPath);
-            return physicalPath != null ? Directory.GetFiles(physicalPath, "*.Web.XML") : new string[] { };
+            string[] ext = new string[2] { "*.Web.XML", "*.Core.XML" };
+
+            var r = from searchPattern in ext
+                    from f in Directory.GetFiles(physicalPath, searchPattern)
+                    select f;
+
+            return r.ToArray();            
         }
     }
 }
+


### PR DESCRIPTION
Updated the GetXmlFilesPaths in SwaggerConfig.cs file to read the both (Web & Core) xml file for swagger comments.

Problem
Currently system is reading only .Web.xml file. And the API request/response properties class is available in .Core.xml. So the properties help description comments is not showing in Swagger

Solution
A xml read file method has been updated by reading both (Web.xml, Core.xml) files.

Proposed of changes
To show the API properties explanation in Swagger which will help developer/user to know about the properties.

Additional context (optional)
It will be good if you can also do the one small testing of code at your end.

### Make sure these boxes are checked:
- [ ] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [ ] Check methods and variable namings - it should be self descriptive, no typos
- [ ] Check you did not introduce breaking changes in API and public models/services.
- [ ] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [ ] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [ ] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [ ] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [ ] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [ ] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
