### PR TITLE
VP-5190: Add copying simple API keys during v2-v3 migration

### DIFF
--- a/src/VirtoCommerce.Platform.Security/Migrations/20000000000000_UpdateSecurityV2.cs
+++ b/src/VirtoCommerce.Platform.Security/Migrations/20000000000000_UpdateSecurityV2.cs
@@ -171,6 +171,38 @@ namespace VirtoCommerce.Platform.Security.Migrations
                             EXEC (N'INSERT INTO [AspNetRoleClaims] ([RoleId],[ClaimType],[ClaimValue]) SELECT [RoleId], ''permission'', [PermissionId] FROM [PlatformRolePermission]')
 	                    END
 
+                        BEGIN
+                            CREATE TABLE [UserApiKey] (
+                                [Id] nvarchar(128) NOT NULL,
+                                [CreatedDate] datetime2 NOT NULL,
+                                [ModifiedDate] datetime2 NULL,
+                                [CreatedBy] nvarchar(64) NULL,
+                                [ModifiedBy] nvarchar(64) NULL,
+                                [ApiKey] nvarchar(450) NULL,
+                                [UserName] nvarchar(max) NULL,
+                                [UserId] nvarchar(max) NULL,
+                                [IsActive] bit NOT NULL,
+                                CONSTRAINT [PK_UserApiKey] PRIMARY KEY ([Id])
+                            );
+                        END
+
+                        BEGIN
+                            CREATE UNIQUE INDEX [IX_UserApiKey_ApiKey] ON [UserApiKey] ([ApiKey]) WHERE [ApiKey] IS NOT NULL;
+                        END
+
+                        BEGIN
+                            -- Copy only simple Api keys from v2 to v3.
+                            INSERT INTO [UserApiKey]
+                            ([Id], [CreatedDate], [ModifiedDate], [CreatedBy], [ModifiedBy], [ApiKey], [UserName], [UserId], [IsActive])
+                            SELECT 
+                            [Id], [CreatedDate], [ModifiedDate], [CreatedBy], [ModifiedBy], [SecretKey], [Name], [AccountId], [IsActive] from [PlatformApiAccount]
+                            WHERE ApiAccountType=2                        
+                        END
+
+                        BEGIN
+                            INSERT INTO [__EFMigrationsHistory] ([MigrationId], [ProductVersion]) VALUES (N'20200320170218_UserApiKey', N'3.1.5');
+                        END;
+
                     END");
         }
 


### PR DESCRIPTION
### Problem
Simple API keys upgrade copying was forgotten to implement.

### Make sure these boxes are checked:
- [x] Check all the changes in github PR - files count (non of them are redundant, have meaningful changes, all are added), if target branch is correct
- [x] Check methods and variable namings - it should be self descriptive, no typos
- [x] Check you did not introduce breaking changes in API and public models/services.
- [x] Respect extensibility - https://community.virtocommerce.com/t/extensibility-basics-the-domain-model-and-persistence-layer-extension/141
- [x] Follow [DRY](https://en.wikipedia.org/wiki/Don%27t_repeat_yourself) and [SOLID](https://en.wikipedia.org/wiki/SOLID) principles
- [x] For unit tests - follow Microsoft best practices: https://docs.microsoft.com/en-us/dotnet/core/testing/unit-testing-best-practices
- [x] Consolidate solution dependencies in case you are using newer version, update VC module dependencies in module.manifest. Do not upgrade 3rd party packages that are shipped with the platform with the version newer than in the platform.
- [x] Check code style conventions - https://github.com/VirtoCommerce/styleguide/blob/master/csharp.md
- [x] Check PR have a concise and descriptive title, follow [git commit message rules](https://github.com/VirtoCommerce/styleguide/blob/master/gitcommits.md)
