### PR TITLE
VP-2190: Do not add application parts for failed modules

### DIFF
--- a/src/VirtoCommerce.Platform.Modules/ModuleInitializer.cs
+++ b/src/VirtoCommerce.Platform.Modules/ModuleInitializer.cs
@@ -108,8 +108,6 @@ namespace VirtoCommerce.Platform.Modules
                 manifestModule.Errors.Add(exception.ToString());
             }
             _loggerFacade.LogError(moduleException.ToString());
-
-            //throw moduleException;
         }
 
         /// <summary>

--- a/src/VirtoCommerce.Platform.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Web/Extensions/ServiceCollectionExtensions.cs
@@ -4,6 +4,7 @@ using Microsoft.AspNetCore.Hosting;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Hosting;
 using Microsoft.Extensions.Logging;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Modules.External;
 
@@ -37,7 +38,9 @@ namespace VirtoCommerce.Platform.Modules
             foreach (var module in moduleCatalog.Modules.OfType<ManifestModuleInfo>().Where(x => x.State == ModuleState.NotStarted).ToArray())
             {
                 manager.LoadModule(module.ModuleName);
-                if (module.Assembly != null)
+
+                // VP-2190: Ne need to add parts for modules with laoding errors - it could cause an exception
+                if (module.Assembly != null && module.Errors.IsNullOrEmpty())
                 {
                     // Register API controller from modules
                     mvcBuilder.AddApplicationPart(module.Assembly);

--- a/src/VirtoCommerce.Platform.Web/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Web/Extensions/ServiceCollectionExtensions.cs
@@ -39,7 +39,7 @@ namespace VirtoCommerce.Platform.Modules
             {
                 manager.LoadModule(module.ModuleName);
 
-                // VP-2190: Ne need to add parts for modules with laoding errors - it could cause an exception
+                // VP-2190: No need to add parts for modules with laoding errors - it could cause an exception
                 if (module.Assembly != null && module.Errors.IsNullOrEmpty())
                 {
                     // Register API controller from modules


### PR DESCRIPTION
Application parts for modules with loading errors should not be added, as such modules could break our application - as their types could not be loaded in runtime. Added such filtration in startup