### PR TITLE
VP-5722: Do not return hidden settings for entities by default

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Settings/ObjectSettingEntry.cs
+++ b/src/VirtoCommerce.Platform.Core/Settings/ObjectSettingEntry.cs
@@ -18,6 +18,7 @@ namespace VirtoCommerce.Platform.Core.Settings
             AllowedValues = descriptor.AllowedValues;
             DefaultValue = descriptor.DefaultValue;
             IsDictionary = descriptor.IsDictionary;
+            IsHidden = descriptor.IsHidden;
         }
         public bool ItHasValues => Value != null || !AllowedValues.IsNullOrEmpty();
         /// <summary>

--- a/src/VirtoCommerce.Platform.Core/Settings/SettingsExtension.cs
+++ b/src/VirtoCommerce.Platform.Core/Settings/SettingsExtension.cs
@@ -27,13 +27,18 @@ namespace VirtoCommerce.Platform.Core.Settings
         /// <param name="entity"></param>
         /// <param name="excludeHidden"></param>
         /// <returns></returns>
-        public static async Task DeepLoadSettingsAsync(this ISettingsManager manager, IHasSettings entity, bool excludeHidden)
+        public static Task DeepLoadSettingsAsync(this ISettingsManager manager, IHasSettings entity, bool excludeHidden)
         {
             if (entity == null)
             {
                 throw new ArgumentNullException(nameof(entity));
             }
 
+            return DeepLoadSettingsAsyncImpl(manager, entity, excludeHidden);
+        }
+
+        private static async Task DeepLoadSettingsAsyncImpl(ISettingsManager manager, IHasSettings entity, bool excludeHidden)
+        {
             //Deep load settings values for all object contains settings
             var hasSettingsObjects = entity.GetFlatObjectsListWithInterface<IHasSettings>();
             foreach (var hasSettingsObject in hasSettingsObjects)

--- a/src/VirtoCommerce.Platform.Core/Settings/SettingsExtension.cs
+++ b/src/VirtoCommerce.Platform.Core/Settings/SettingsExtension.cs
@@ -17,6 +17,18 @@ namespace VirtoCommerce.Platform.Core.Settings
         /// <param name="entity"></param>
         public static async Task DeepLoadSettingsAsync(this ISettingsManager manager, IHasSettings entity)
         {
+            await DeepLoadSettingsAsync(manager, entity, true);
+        }
+
+        /// <summary>
+        /// Deep load and populate settings values for entity and all nested objects
+        /// </summary>
+        /// <param name="manager"></param>
+        /// <param name="entity"></param>
+        /// <param name="excludeHidden"></param>
+        /// <returns></returns>
+        public static async Task DeepLoadSettingsAsync(this ISettingsManager manager, IHasSettings entity, bool excludeHidden)
+        {
             if (entity == null)
             {
                 throw new ArgumentNullException(nameof(entity));
@@ -31,6 +43,12 @@ namespace VirtoCommerce.Platform.Core.Settings
                 {
                     throw new SettingsTypeNotRegisteredException(hasSettingsObject.TypeName);
                 }
+
+                if (excludeHidden)
+                {
+                    typeSettings = typeSettings.Where(x => !x.IsHidden);
+                }
+
                 hasSettingsObject.Settings = (await manager.GetObjectSettingsAsync(typeSettings.Select(x => x.Name), hasSettingsObject.TypeName, hasSettingsObject.Id)).ToList();
             }
         }


### PR DESCRIPTION
They still could be got via the extended version of `ISettingsManager.DeepLoadSettingsAsync`