### PR TITLE
Fix markup to show long error message

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/css/themes/main/sass/modules/_errors.sass
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/css/themes/main/sass/modules/_errors.sass
@@ -36,3 +36,10 @@
     display: none
     overflow: hidden
     color: red
+
+.error-dialog
+  overflow-y: auto
+  max-height: 500px
+
+  .error-message
+    word-wrap: break-word;  

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/modularity/dialogs/errorDetails-dialog.tpl.html
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/modularity/dialogs/errorDetails-dialog.tpl.html
@@ -1,7 +1,10 @@
 <div class="modal-header-error">
     <h3 class="modal-title">{{ 'platform.dialogs.error-details.title' | translate }}</h3>
 </div>
-<div class="modal-body" ng-bind-html="message | translate: messageValues"></div>
+<div class="modal-body error-dialog">
+    <span class="error-message" ng-bind-html="message | translate: messageValues"></span>
+</div>
+
 <div class="modal-footer">
     <button class="btn btn-primary" ng-click="yes()">{{ 'platform.commands.ok' | translate }}</button>
 </div>

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/modularity/dialogs/errorDetails-dialog.tpl.html
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/modularity/dialogs/errorDetails-dialog.tpl.html
@@ -4,7 +4,6 @@
 <div class="modal-body error-dialog">
     <span class="error-message" ng-bind-html="message | translate: messageValues"></span>
 </div>
-
 <div class="modal-footer">
     <button class="btn btn-primary" ng-click="yes()">{{ 'platform.commands.ok' | translate }}</button>
 </div>


### PR DESCRIPTION
## Related task: 
VP-5983 Error popup > text is too long and appears outside of popup
## Problem 
When we try to make Bulk Update for Cell Phones category then an error popup appears with long text (it works ok for other categories).
![image](https://user-images.githubusercontent.com/11813599/99071984-36509300-25c4-11eb-9beb-b158bf9205be.png)

## Solution:
Fix markup to show long error message
![2020-11-13 143031 error big](https://user-images.githubusercontent.com/11813599/99071842-f689ab80-25c3-11eb-86f1-567ada919b94.png)

## Changes:
Add error scrolling 
Add error word wrap