### PR TITLE
VP-0: Ensure platform permissions are present at module postInitialization time

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -495,10 +495,10 @@ namespace VirtoCommerce.Platform.Web
             // Complete hangfire init
             app.UseHangfire(Configuration);
 
-            app.UseModules();
-
             //Register platform permissions
             app.UsePlatformPermissions();
+
+            app.UseModules();
 
             //Setup SignalR hub
             app.UseEndpoints(routes =>


### PR DESCRIPTION
[11/10 9:26 AM] Egidijus Mazeika
Hey, I've got an issue that platform permissions are missing at module postInitialize time. It's a bug in https://github.com/VirtoCommerce/vc-platform/blob/9c794c511ddb6afb9f167787a7572a2aabdecd82/src/VirtoCommerce.Platform.Web/Startup.cs#L513-L516 and the fix is to switch those 2 lines.
​
​[3:40 PM] Eugeny Tatarincev
    I think it is absolutely safe to swap them