### PR TITLE
Allow to reset platform cache via endpoint call

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Controllers/Api/ChangeLogController.cs
+++ b/src/VirtoCommerce.Platform.Web/Controllers/Api/ChangeLogController.cs
@@ -3,6 +3,7 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authorization;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
+using VirtoCommerce.Platform.Caching;
 using VirtoCommerce.Platform.Core;
 using VirtoCommerce.Platform.Core.ChangeLog;
 using VirtoCommerce.Platform.Web.Model;
@@ -34,6 +35,17 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
         public ActionResult ForceChanges(ForceChangesRequest forceRequest)
         {
             _lastModifiedDateTime.Reset();
+            return NoContent();
+        }
+
+        [HttpPost]
+        [Route("~/api/platform-cache/reset")]
+        [Authorize(PlatformConstants.Security.Permissions.ResetCache)]
+        [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
+        public ActionResult ResetPlatformCache()
+        {
+            GlobalCacheRegion.ExpireRegion();
+
             return NoContent();
         }
 


### PR DESCRIPTION
This PR adds an endpoint which invalidates `GlobalCacheRegion` - this will purge the entire platform cache. It might be useful to reset cache after database changes by platform administrators (via direct SQL scripts) or to investigate cache issues by platform developers.

Note: I intentionally did not add this endpoint to platform UI - it should only be used when it's absolutely needed, so platform administrators MUST know why they need to reset the cache to use this endpoint. That's why IMO there should be no easy way to do it from UI.