### PR TITLE
VP-6462: Platform:security:loginOnBehalf permission is missing

### DIFF
--- a/src/VirtoCommerce.Platform.Core/PlatformConstants.cs
+++ b/src/VirtoCommerce.Platform.Core/PlatformConstants.cs
@@ -55,7 +55,8 @@ namespace VirtoCommerce.Platform.Core
                                     SecurityCreate = "platform:security:create",
                                     SecurityAccess = "platform:security:access",
                                     SecurityUpdate = "platform:security:update",
-                                    SecurityDelete = "platform:security:delete";
+                                    SecurityDelete = "platform:security:delete",
+                                    SecurityLoginOnBehalf = "platform:security:loginOnBehalf";
 
                 public const string BackgroundJobsManage = "background_jobs:manage";
 
@@ -63,7 +64,6 @@ namespace VirtoCommerce.Platform.Core
                                     PlatformImport = "platform:import",
                                     PlatformExport = "platform:export";
 
-                public const string SecurityLoginOnBehalf = "platform:security:loginOnBehalf";
 
                 public static string[] AllPermissions { get; } = new[] { ResetCache, AssetAccess, AssetDelete, AssetUpdate, AssetCreate, AssetRead, ModuleQuery, ModuleAccess, ModuleManage,
                                               SettingQuery, SettingAccess, SettingUpdate, DynamicPropertiesQuery, DynamicPropertiesCreate, DynamicPropertiesAccess, DynamicPropertiesUpdate, DynamicPropertiesDelete,

--- a/src/VirtoCommerce.Platform.Core/PlatformConstants.cs
+++ b/src/VirtoCommerce.Platform.Core/PlatformConstants.cs
@@ -63,11 +63,11 @@ namespace VirtoCommerce.Platform.Core
                                     PlatformImport = "platform:import",
                                     PlatformExport = "platform:export";
 
-                public const string LoginOnBehalf = "platform:security:loginOnBehalf";
+                public const string SecurityLoginOnBehalf = "platform:security:loginOnBehalf";
 
                 public static string[] AllPermissions { get; } = new[] { ResetCache, AssetAccess, AssetDelete, AssetUpdate, AssetCreate, AssetRead, ModuleQuery, ModuleAccess, ModuleManage,
                                               SettingQuery, SettingAccess, SettingUpdate, DynamicPropertiesQuery, DynamicPropertiesCreate, DynamicPropertiesAccess, DynamicPropertiesUpdate, DynamicPropertiesDelete,
-                                              SecurityQuery, SecurityCreate, SecurityAccess,  SecurityUpdate,  SecurityDelete, BackgroundJobsManage, PlatformExportImportAccess, PlatformImport, PlatformExport, LoginOnBehalf};
+                                              SecurityQuery, SecurityCreate, SecurityAccess,  SecurityUpdate,  SecurityDelete, BackgroundJobsManage, PlatformExportImportAccess, PlatformImport, PlatformExport, SecurityLoginOnBehalf};
             }
         }
 

--- a/src/VirtoCommerce.Platform.Core/PlatformConstants.cs
+++ b/src/VirtoCommerce.Platform.Core/PlatformConstants.cs
@@ -63,11 +63,11 @@ namespace VirtoCommerce.Platform.Core
                                     PlatformImport = "platform:import",
                                     PlatformExport = "platform:export";
 
-                public const string SecurityLoginOnBehalf = "platform:security:loginOnBehalf";
+                public const string LoginOnBehalf = "platform:security:loginOnBehalf";
 
                 public static string[] AllPermissions { get; } = new[] { ResetCache, AssetAccess, AssetDelete, AssetUpdate, AssetCreate, AssetRead, ModuleQuery, ModuleAccess, ModuleManage,
                                               SettingQuery, SettingAccess, SettingUpdate, DynamicPropertiesQuery, DynamicPropertiesCreate, DynamicPropertiesAccess, DynamicPropertiesUpdate, DynamicPropertiesDelete,
-                                              SecurityQuery, SecurityCreate, SecurityAccess,  SecurityUpdate,  SecurityDelete, BackgroundJobsManage, PlatformExportImportAccess, PlatformImport, PlatformExport, SecurityLoginOnBehalf};
+                                              SecurityQuery, SecurityCreate, SecurityAccess,  SecurityUpdate,  SecurityDelete, BackgroundJobsManage, PlatformExportImportAccess, PlatformImport, PlatformExport, LoginOnBehalf};
             }
         }
 

--- a/src/VirtoCommerce.Platform.Core/PlatformConstants.cs
+++ b/src/VirtoCommerce.Platform.Core/PlatformConstants.cs
@@ -63,9 +63,11 @@ namespace VirtoCommerce.Platform.Core
                                     PlatformImport = "platform:import",
                                     PlatformExport = "platform:export";
 
+                public const string SecurityLoginOnBehalf = "platform:security:loginOnBehalf";
+
                 public static string[] AllPermissions { get; } = new[] { ResetCache, AssetAccess, AssetDelete, AssetUpdate, AssetCreate, AssetRead, ModuleQuery, ModuleAccess, ModuleManage,
                                               SettingQuery, SettingAccess, SettingUpdate, DynamicPropertiesQuery, DynamicPropertiesCreate, DynamicPropertiesAccess, DynamicPropertiesUpdate, DynamicPropertiesDelete,
-                                              SecurityQuery, SecurityCreate, SecurityAccess,  SecurityUpdate,  SecurityDelete, BackgroundJobsManage, PlatformExportImportAccess, PlatformImport, PlatformExport};
+                                              SecurityQuery, SecurityCreate, SecurityAccess,  SecurityUpdate,  SecurityDelete, BackgroundJobsManage, PlatformExportImportAccess, PlatformImport, PlatformExport, SecurityLoginOnBehalf};
             }
         }
 


### PR DESCRIPTION
### Related task:     
   VP-6462 platform:security:loginOnBehalf permission is missing
   https://github.com/VirtoCommerce/vc-platform/issues/2118

### Problem:
   The Login on behalf button is bound to the platform:security:loginOnBehalf permission, but this permission is not present in the permissions list and it cannot be assigned to any role

### Changes:
   Add security constant to platform