### PR TITLE
ValueObjects with different values should not be equal and should have different cache keys

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Common/ValueObject.cs
+++ b/src/VirtoCommerce.Platform.Core/Common/ValueObject.cs
@@ -49,7 +49,11 @@ namespace VirtoCommerce.Platform.Core.Common
 
         public virtual string GetCacheKey()
         {
-            return string.Join("|", GetEqualityComponents().Select(x => x ?? "null").Select(x => x is ICacheKey cacheKey ? cacheKey.GetCacheKey() : x.ToString()));
+            var keyValues = GetEqualityComponents()
+                .Select(x => x is string ? $"'{x}'" : x)
+                .Select(x => x is ICacheKey cacheKey ? cacheKey.GetCacheKey() : x?.ToString());
+
+            return string.Join("|", keyValues);
         }
 
         protected virtual IEnumerable<object> GetEqualityComponents()
@@ -59,17 +63,19 @@ namespace VirtoCommerce.Platform.Core.Common
                 var value = property.GetValue(this);
                 if (value == null)
                 {
-                    yield return "null";
+                    yield return null;
                 }
                 else
                 {
                     var valueType = value.GetType();
                     if (valueType.IsAssignableFromGenericList())
                     {
+                        yield return '[';
                         foreach (var child in ((IEnumerable)value))
                         {
-                            yield return child ?? "null";
+                            yield return child;
                         }
+                        yield return ']';
                     }
                     else
                     {

--- a/tests/VirtoCommerce.Platform.Tests/UnitTests/ValueObjectUnitTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/UnitTests/ValueObjectUnitTests.cs
@@ -55,7 +55,7 @@ namespace VirtoCommerce.Platform.Tests.UnitTests
 
                         var equals = object1.Equals(object2);
 
-                        Assert.False(equals);
+                        Assert.False(equals, $"Objects #{i} and #{j} must not be equal.");
                     }
                 }
             }

--- a/tests/VirtoCommerce.Platform.Tests/UnitTests/ValueObjectUnitTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/UnitTests/ValueObjectUnitTests.cs
@@ -1,0 +1,101 @@
+using System.Collections.Generic;
+using System.Linq;
+using VirtoCommerce.Platform.Core.Common;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Tests.UnitTests
+{
+    [Trait("Category", "Unit")]
+    public class ValueObjectTests
+    {
+        public class ComplexObject : ValueObject
+        {
+            public string SimpleProperty { get; set; }
+            public string AnotherSimpleProperty { get; set; }
+            public List<string> ListProperty { get; set; }
+            public List<string> AnotherListProperty { get; set; }
+        }
+
+        [Fact]
+        public void ObjectsWithTheSameValuesShouldBeEqual()
+        {
+            var object1 = new ComplexObject
+            {
+                SimpleProperty = "A",
+                ListProperty = new List<string> { "A", "B", "C" },
+            };
+
+            var object2 = new ComplexObject
+            {
+                SimpleProperty = "A",
+                ListProperty = new List<string> { "A", "B", "C" },
+            };
+
+            var code1 = object1.GetHashCode();
+            var code2 = object2.GetHashCode();
+
+            Assert.Equal(code1, code2);
+            Assert.Equal(object1, object2);
+        }
+
+        [Fact]
+        public void ObjectsWithDifferentValuesShouldNotBeEqual()
+        {
+            var objectsWithDifferentValues = GetObjectsWithDifferentValues();
+
+            // Compare each object with all other objects
+            for (var i = 0; i < objectsWithDifferentValues.Count; i++)
+            {
+                for (var j = 0; j < objectsWithDifferentValues.Count; j++)
+                {
+                    if (i != j)
+                    {
+                        var object1 = objectsWithDifferentValues[i];
+                        var object2 = objectsWithDifferentValues[j];
+
+                        var equals = object1.Equals(object2);
+
+                        Assert.False(equals);
+                    }
+                }
+            }
+        }
+
+        [Fact]
+        public void ObjectsWithDifferentValuesShouldHaveDifferentCacheKeys()
+        {
+            var objectsWithDifferentValues = GetObjectsWithDifferentValues();
+
+            var cacheKeys = objectsWithDifferentValues.Select(x => x.GetCacheKey()).ToList();
+            var uniqueCacheKeys = cacheKeys.Distinct().ToList();
+
+            Assert.Equal(objectsWithDifferentValues.Count, uniqueCacheKeys.Count);
+        }
+
+
+        private static IList<ComplexObject> GetObjectsWithDifferentValues()
+        {
+            return new[]
+            {
+                // All properties are null
+                new ComplexObject(),
+
+                new ComplexObject { SimpleProperty = "" },
+                new ComplexObject { SimpleProperty = "null" },
+
+                new ComplexObject { AnotherSimpleProperty = "" },
+                new ComplexObject { AnotherSimpleProperty = "null" },
+
+                new ComplexObject { ListProperty = new List<string>() },
+                new ComplexObject { ListProperty = new List<string> { null } },
+                new ComplexObject { ListProperty = new List<string> { "" } },
+                new ComplexObject { ListProperty = new List<string> { "null" } },
+
+                new ComplexObject { AnotherListProperty = new List<string>() },
+                new ComplexObject { AnotherListProperty = new List<string> { null } },
+                new ComplexObject { AnotherListProperty = new List<string> { "" } },
+                new ComplexObject { AnotherListProperty = new List<string> { "null" } },
+            };
+        }
+    }
+}


### PR DESCRIPTION
This PR fixes the following issues that lead to incorrect equality components and duplicate cache keys:
1. `null` and `"null"` values are considered equal.
2. Empty collections are just ignored.