### PR TITLE
VP-6484: Fix SSO Azure AD  signature validation failed error when Azure AD App has custom signing keys

### DIFF
--- a/docs/techniques/authentication-with-azure-ad.md
+++ b/docs/techniques/authentication-with-azure-ad.md
@@ -129,3 +129,28 @@ To answer this question, let's dive deeper to the Azure Active Directory authent
     - The account already exists and is linked with Azure Active Directory account of signed-in user. In this case, no further actions will be performed - Virto Commerce Platform will just authenticate that user using the existing account.
     - The account already exists, but is missing the Azure Active Directory external sign-in information. In this case Virto Commerce Platform will modify that account to add external login information for the Azure Active Directory account. All other account information (including roles, permissions and personal information) will remain untouched.
     - Finally, if such account does not exist yet, VC Platform will create it and link it with Azure Active Directory account.
+
+## Configuration when Azure AD App has custom signing keys
+
+If your app has custom signing keys you can receive this error on `POST https://localhost:5001/signin-oidc` request.
+
+```json
+Microsoft.IdentityModel.Tokens.SecurityTokenSignatureKeyNotFoundException: IDX10501: Signature validation failed. Unable to match key
+```
+https://github.com/Azure/azure-sdk-for-net/issues/17695
+
+If your app has custom signing keys as a result of using the claims-mapping feature, you must append an appid query parameter containing the app ID in order to get a jwks_uri pointing to your app's signing key information. For example: https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid-configuration?appid=6731de76-14a6-49ae-97bc-6eba6914391e contains a jwks_uri of https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys?appid=6731de76-14a6-49ae-97bc-6eba6914391e.
+
+To solve this situation the updated configuration should look like this:
+```json
+    "AzureAd": {
+        "Enabled": true,
+        "AuthenticationType": "AzureAD",
+        "AuthenticationCaption": "Azure Active Directory",
+        "ApplicationId": "b6d8dc6a-6ddd-4497-ad55-d65f91ca7f50",
+        "TenantId": "fe353e8f-5f08-43b4-89d1-f4acec93df33",
+        "AzureAdInstance": "https://login.microsoftonline.com/",
+        "MetadataAddress": "https://login.microsoftonline.com/fe353e8f-5f08-43b4-89d1-f4acec93df33/v2.0/.well-known/openid-configuration?appid=b6d8dc6a-6ddd-4497-ad55-d65f91ca7f50",
+        "DefaultUserType": "Manager"
+    },
+```

--- a/src/VirtoCommerce.Platform.Web/Azure/AzureAdOptions.cs
+++ b/src/VirtoCommerce.Platform.Web/Azure/AzureAdOptions.cs
@@ -40,5 +40,10 @@ namespace VirtoCommerce.Platform.Web.Azure
         /// </summary>
         public string DefaultUserType { get; set; }
 
+        //
+        // Summary:
+        //     Gets or sets the discovery endpoint for obtaining metadata
+        public string MetadataAddress { get; set; }
+
     }
 }

--- a/src/VirtoCommerce.Platform.Web/Controllers/ExternalSignInController.cs
+++ b/src/VirtoCommerce.Platform.Web/Controllers/ExternalSignInController.cs
@@ -62,7 +62,7 @@ namespace VirtoCommerce.Platform.Web.Controllers
             ApplicationUser platformUser = null;
 
             //try yo take an user name from claims
-            var userName = externalLoginInfo.Principal.FindFirstValue(ClaimTypes.Upn);
+            var userName = externalLoginInfo.Principal.FindFirstValue(ClaimTypes.Upn) ?? externalLoginInfo.Principal.FindFirstValue("preferred_username");
             if (string.IsNullOrWhiteSpace(userName))
             {
                 throw new InvalidOperationException("Received external login info does not have an UPN claim or DefaultUserName.");

--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -235,15 +235,19 @@ namespace VirtoCommerce.Platform.Web
                 if (options.Enabled)
                 {
                     //TODO: Need to check how this influence to OpennIddict Reference tokens activated by this line below  AddValidation(options => options.UseReferenceTokens());
+                    //TechDept: Need to upgrade to Microsoft.Identity.Web
+                    //https://docs.microsoft.com/en-us/azure/active-directory/develop/microsoft-identity-web
                     authBuilder.AddOpenIdConnect(options.AuthenticationType, options.AuthenticationCaption,
                         openIdConnectOptions =>
                         {
                             openIdConnectOptions.ClientId = options.ApplicationId;
+
                             openIdConnectOptions.Authority = $"{options.AzureAdInstance}{options.TenantId}";
                             openIdConnectOptions.UseTokenLifetime = true;
                             openIdConnectOptions.RequireHttpsMetadata = false;
                             openIdConnectOptions.SignInScheme = IdentityConstants.ExternalScheme;
                             openIdConnectOptions.SecurityTokenValidator = defaultTokenHandler;
+                            openIdConnectOptions.MetadataAddress = options.MetadataAddress;
                         });
                 }
             }

--- a/src/VirtoCommerce.Platform.Web/appsettings.json
+++ b/src/VirtoCommerce.Platform.Web/appsettings.json
@@ -152,6 +152,12 @@
         "ApplicationId": "(Replace this with Application (client) ID, e.g. 01234567-89ab-cdef-0123-456789abcdef)",
         "TenantId": "(Replace this with Directory (tenant) ID, e.g. abcdef01-2345-6789-abcd-ef0123456789)",
         "AzureAdInstance": "https://login.microsoftonline.com/",
+        //If your app has custom signing keys as a result of using the claims-mapping feature, you must append an appid query parameter containing the app ID in order to get a
+        //jwks_uri pointing to your app's signing key information.
+        //For example: https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid-configuration?appid=6731de76-14a6-49ae-97bc-6eba6914391e contains a jwks_uri
+        //of https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys?appid=6731de76-14a6-49ae-97bc-6eba6914391e.
+        //Please uncomment the flowing property if our app has custom signing keys.
+        //"MetadataAddress": "https://login.microsoftonline.com/{{TenantId}}/v2.0/.well-known/openid-configuration?appid={{ApplicationId}}",
         "DefaultUserType": "Manager"
     },
     "Caching": {


### PR DESCRIPTION
If your app has custom signing keys you can receive this error on `POST https://localhost:5001/signin-oidc` request.

```json
Microsoft.IdentityModel.Tokens.SecurityTokenSignatureKeyNotFoundException: IDX10501: Signature validation failed. Unable to match key
```
https://github.com/Azure/azure-sdk-for-net/issues/17695

If your app has custom signing keys as a result of using the claims-mapping feature, you must append an appid query parameter containing the app ID in order to get a jwks_uri pointing to your app's signing key information. For example: https://login.microsoftonline.com/{tenant}/v2.0/.well-known/openid-configuration?appid=6731de76-14a6-49ae-97bc-6eba6914391e contains a jwks_uri of https://login.microsoftonline.com/{tenant}/discovery/v2.0/keys?appid=6731de76-14a6-49ae-97bc-6eba6914391e.

To solve this situation the updated configuration should look like this:
```json
    "AzureAd": {
        "Enabled": true,
        "AuthenticationType": "AzureAD",
        "AuthenticationCaption": "Azure Active Directory",
        "ApplicationId": "b6d8dc6a-6ddd-4497-ad55-d65f91ca7f50",
        "TenantId": "fe353e8f-5f08-43b4-89d1-f4acec93df33",
        "AzureAdInstance": "https://login.microsoftonline.com/",
        "MetadataAddress": "https://login.microsoftonline.com/fe353e8f-5f08-43b4-89d1-f4acec93df33/v2.0/.well-known/openid-configuration?appid=b6d8dc6a-6ddd-4497-ad55-d65f91ca7f50",
        "DefaultUserType": "Manager"
    },
```