### PR TITLE
VP-6894: Regenerate SecurityStamp on email change; Define ApplicationDiscriminator

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Controllers/Api/SecurityController.cs
+++ b/src/VirtoCommerce.Platform.Web/Controllers/Api/SecurityController.cs
@@ -20,8 +20,8 @@ using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Security.Events;
 using VirtoCommerce.Platform.Core.Security.Search;
 using VirtoCommerce.Platform.Web.Model.Security;
-using SignInResult = Microsoft.AspNetCore.Identity.SignInResult;
 using PlatformPermissions = VirtoCommerce.Platform.Core.PlatformConstants.Security.Permissions;
+using SignInResult = Microsoft.AspNetCore.Identity.SignInResult;
 
 namespace VirtoCommerce.Platform.Web.Controllers.Api
 {
@@ -543,7 +543,8 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
 
             if (!applicationUser.Email.EqualsInvariant(user.Email))
             {
-                user.EmailConfirmed = false;
+                // SetEmailAsync also: sets EmailConfirmed to false and updates the SecurityStamp
+                await _userManager.SetEmailAsync(user, user.Email);
             }
 
             var result = await _userManager.UpdateAsync(user);

--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -326,6 +326,10 @@ namespace VirtoCommerce.Platform.Web
                 });
 
             services.Configure<IdentityOptions>(Configuration.GetSection("IdentityOptions"));
+            services.AddDataProtection(options =>
+            {
+                options.ApplicationDiscriminator = "VirtoCommerceGroup";
+            });
 
             //always  return 401 instead of 302 for unauthorized  requests
             services.ConfigureApplicationCookie(options =>
@@ -500,7 +504,7 @@ namespace VirtoCommerce.Platform.Web
             app.UsePruneExpiredTokensJob();
 
             app.UseModules();
-            
+
             app.UseEndpoints(endpoints =>
             {
                 endpoints.MapControllerRoute(name: "default", pattern: "{controller=Home}/{action=Index}/{id?}");


### PR DESCRIPTION
Regenerate SecurityStamp on email change:
* This will expire any previous token (incl. email confirmation token)

Define ApplicationDiscriminator:
* When the same ApplicationDiscriminator used in Storefront and Platform, the Identity UserManager can validate tokens issued in both applications.

Jira: https://virtocommerce.atlassian.net/browse/VP-6894