### PR TITLE
PT-642: Exclude all ignored files and *module files ...

### DIFF
--- a/build/Build.cs
+++ b/build/Build.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Text.RegularExpressions;
 using System.IO;
 using System.Linq;
 using System.Net.Http;
@@ -575,9 +576,10 @@ partial class Build : NukeBuild
              ignoredFiles = ignoredFiles.Select(x => x.Trim()).Distinct().ToArray();
 
              DeleteFile(ZipFilePath);
-             //TODO: Exclude all dependencies of dependent modules
-             CompressionTasks.CompressZip(ModuleOutputDirectory, ZipFilePath, (x) => !ignoredFiles.Contains(x.Name, StringComparer.OrdinalIgnoreCase)
-                                                                                     && !(ModuleManifest.Dependencies ?? Array.Empty<ManifestDependency>()).Any(md => x.Name.StartsWith($"{md.Id}Module", StringComparison.OrdinalIgnoreCase)));
+             //TODO: Exclude all ignored files and *module files not related to compressed module
+             var moduleRegex = new Regex(@".+Module\..*", RegexOptions.IgnoreCase);
+             CompressionTasks.CompressZip(ModuleOutputDirectory, ZipFilePath, (x) => (!ignoredFiles.Contains(x.Name, StringComparer.OrdinalIgnoreCase) && !moduleRegex.IsMatch(x.Name))
+                                                                                     || x.Name.StartsWith($"{ModuleManifest.Id}Module.", StringComparison.OrdinalIgnoreCase));
          }
          else
          {

--- a/module.ignore
+++ b/module.ignore
@@ -8,6 +8,7 @@ EntityFrameworkCore.Triggers.dll
 FluentValidation.dll
 Hangfire.AspNetCore.dll
 Hangfire.Core.dll
+Hangfire.Core.resources.dll
 Hangfire.MemoryStorage.dll
 Hangfire.SqlServer.dll
 MessagePack.dll
@@ -126,6 +127,7 @@ System.IO.Abstractions.dll
 System.IO.FileSystem.AccessControl.dll
 System.IO.Pipelines.dll
 System.Runtime.Caching.dll
+System.Runtime.CompilerServices.Unsafe.dll
 System.Security.AccessControl.dll
 System.Security.Cryptography.ProtectedData.dll
 System.Security.Principal.Windows.dll


### PR DESCRIPTION
There is a problem:
*vc-build Compress* command currently excludes assemblies related to only one level of modules dependencies, enlisted in *module.manifest*,
Solution:
Exclude all ignored files and *module files not related to compressing module, regardless of module dependencies.

https://virtocommerce.atlassian.net/browse/PT-28
