### PR TITLE
PT-986: Add ability to configure DataProtection options

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -326,6 +326,7 @@ namespace VirtoCommerce.Platform.Web
             services.Configure<IdentityOptions>(Configuration.GetSection("IdentityOptions"));
             services.Configure<PasswordOptionsExtended>(Configuration.GetSection("IdentityOptions:Password"));
             services.Configure<UserOptionsExtended>(Configuration.GetSection("IdentityOptions:User"));
+            services.Configure<DataProtectionTokenProviderOptions>(Configuration.GetSection("IdentityOptions:DataProtection"));
 
             //always  return 401 instead of 302 for unauthorized  requests
             services.ConfigureApplicationCookie(options =>


### PR DESCRIPTION
This allows to configure token lifespan for data protection options in appsettings.json:
![image](https://user-images.githubusercontent.com/9972421/116042829-51055880-a688-11eb-87fb-30b6716651f4.png)

https://virtocommerce.atlassian.net/browse/PT-986