### PR TITLE
PT-3877: Add FlushLessStream, a workaround to avoid hangs on writing to AzureStorage

### DIFF
--- a/src/VirtoCommerce.Platform.Assets.AzureBlobStorage/AzureBlobProvider.cs
+++ b/src/VirtoCommerce.Platform.Assets.AzureBlobStorage/AzureBlobProvider.cs
@@ -106,15 +106,17 @@ namespace VirtoCommerce.Platform.Assets.AzureBlobStorage
             {
                 HttpHeaders = new BlobHttpHeaders
                 {
-                    ContentType = MimeTypeResolver.ResolveContentType(Path.GetFileName(filePath)),
+                    ContentType = MimeTypeResolver.ResolveContentType(Path.GetFileName(filePath)),                    
                     // Leverage Browser Caching - 7days
                     // Setting Cache-Control on Azure Blobs can help reduce bandwidth and improve the performance by preventing consumers from having to continuously download resources.
                     // More Info https://developers.google.com/speed/docs/insights/LeverageBrowserCaching
                     CacheControl = BlobCacheControlPropertyValue
-                }
+                }                
             };
 
-            return await blob.OpenWriteAsync(true, options);
+            // FlushLessStream wraps BlockBlobWriteStream to not use Flush multiple times.
+            // !!! Call Flush several times on a plain BlockBlobWriteStream causes stream hangs/errors.
+            return new FlushLessStream(await blob.OpenWriteAsync(true, options));
         }
 
         public virtual async Task RemoveAsync(string[] urls)

--- a/src/VirtoCommerce.Platform.Assets.AzureBlobStorage/AzureBlobProvider.cs
+++ b/src/VirtoCommerce.Platform.Assets.AzureBlobStorage/AzureBlobProvider.cs
@@ -116,6 +116,7 @@ namespace VirtoCommerce.Platform.Assets.AzureBlobStorage
 
             // FlushLessStream wraps BlockBlobWriteStream to not use Flush multiple times.
             // !!! Call Flush several times on a plain BlockBlobWriteStream causes stream hangs/errors.
+            // https://github.com/Azure/azure-sdk-for-net/issues/20652
             return new FlushLessStream(await blob.OpenWriteAsync(true, options));
         }
 

--- a/src/VirtoCommerce.Platform.Assets.AzureBlobStorage/FlushLessStream.cs
+++ b/src/VirtoCommerce.Platform.Assets.AzureBlobStorage/FlushLessStream.cs
@@ -1,0 +1,77 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VirtoCommerce.Platform.Assets.AzureBlobStorage
+{
+
+    /// <summary>
+    /// Wraps stream that can't flush multiple times (like BlockBlobWriteStream).
+    /// Flushes only once at Dispose.
+    /// </summary>
+    public class FlushLessStream : Stream
+    {
+        private readonly Stream _underStream;
+        public FlushLessStream(Stream stream)
+        {
+            _underStream = stream;
+        }
+
+        public override bool CanRead => _underStream.CanRead;
+
+        public override bool CanSeek => _underStream.CanSeek;
+
+        public override bool CanWrite => _underStream.CanWrite;
+
+        public override long Length => _underStream.Length;
+
+        public override long Position { get => _underStream.Position; set => _underStream.Position = value; }
+
+        public override void Flush()
+        {
+            // The method especially left empty
+        }
+
+        public override int Read(byte[] buffer, int offset, int count)
+        {
+            return _underStream.Read(buffer, offset, count);
+        }
+
+        public override long Seek(long offset, SeekOrigin origin)
+        {
+            return _underStream.Seek(offset, origin);
+        }
+
+        public override void SetLength(long value)
+        {
+            _underStream.SetLength(value);
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing)
+            {
+                _underStream.Flush();
+                _underStream.Dispose();
+            }
+
+            base.Dispose(disposing);
+        }
+
+        public override ValueTask WriteAsync(ReadOnlyMemory<byte> buffer, CancellationToken cancellationToken = default)
+        {
+            return base.WriteAsync(buffer, cancellationToken);
+        }
+
+        public override void Write(byte[] buffer, int offset, int count)
+        {
+            _underStream.Write(buffer, offset, count);
+        }
+
+        public override void Write(ReadOnlySpan<byte> buffer)
+        {
+            base.Write(buffer);
+        }
+    }
+}


### PR DESCRIPTION
## Description
Typically, we use MemoryStream to prevent multiple flushes to BlockBlobWriteStream, otherwise, the stream write hangs.
Another side of this approach is redundant memory consumption, even "out of memory" errors.
The solution is to wrap BlockBlobWriteStream and call the Flush for it only once at the Dispose. This allows removing all redundant MemoryStream copies in using places (a.e. exports).
## References
https://github.com/Azure/azure-sdk-for-net/issues/20652
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-1910
https://virtocommerce.atlassian.net/browse/PT-3876
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Platform.3.75.0-pr-2360.zip
