### PR TITLE
PT-3802: Add swagger description for OAuth token request endpoint

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Controllers/Api/AuthorizationController.cs
+++ b/src/VirtoCommerce.Platform.Web/Controllers/Api/AuthorizationController.cs
@@ -5,6 +5,7 @@ using System.Security.Claims;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore;
 using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Options;
@@ -53,6 +54,9 @@ namespace Mvc.Server
         // you must provide your own token endpoint action:
 
         [HttpPost("~/connect/token"), Produces("application/json")]
+        [ProducesResponseType(StatusCodes.Status200OK, Type = typeof(OpenIddictResponse))]
+        [ProducesResponseType(StatusCodes.Status400BadRequest, Type = typeof(OpenIddictResponse))]
+        // Be aware: look into OpenIDEndpointDescriptionFilter to know parameters description for the swagger document about this endpoint
         public async Task<ActionResult> Exchange()
         {
             OpenIddictRequest openIdConnectRequest = HttpContext.GetOpenIddictServerRequest();

--- a/src/VirtoCommerce.Platform.Web/Swagger/OpenIDEndpointDescriptionFilter.cs
+++ b/src/VirtoCommerce.Platform.Web/Swagger/OpenIDEndpointDescriptionFilter.cs
@@ -1,0 +1,45 @@
+using System.Collections.Generic;
+using Microsoft.AspNetCore.Mvc.Controllers;
+using Microsoft.OpenApi.Models;
+using Mvc.Server;
+using Swashbuckle.AspNetCore.SwaggerGen;
+
+namespace VirtoCommerce.Platform.Web.Swagger
+{
+    /// <summary>
+    /// This filter adds parameters description for "~/connect/token" endpoint
+    /// </summary>
+    public class OpenIDEndpointDescriptionFilter : IOperationFilter
+    {
+        public void Apply(OpenApiOperation operation, OperationFilterContext context)
+        {
+            var descriptor = context.ApiDescription.ActionDescriptor as ControllerActionDescriptor;
+
+            if (descriptor != null && nameof(AuthorizationController).StartsWith(descriptor.ControllerName) && descriptor.ActionName.Equals(nameof(AuthorizationController.Exchange)))
+            {
+                // In OpenAPI 3.0, form data passed thru an object schema where the object properties represent the form fields.
+                // The code below implemented as prescribed at the page https://swagger.io/docs/specification/describing-request-body/
+                operation.RequestBody = new OpenApiRequestBody();
+                operation.RequestBody.Required = true;
+                operation.RequestBody.Content = new Dictionary<string, OpenApiMediaType>();
+                var mediaType = new OpenApiMediaType
+                {
+                    Schema = new OpenApiSchema()
+                };
+                mediaType.Schema.Type = "object";
+                mediaType.Schema.Properties = new Dictionary<string, OpenApiSchema>
+                {
+                    { "grant_type", new OpenApiSchema() { Type = "string" } },
+                    { "scope", new OpenApiSchema() { Type = "string" } },
+                    { "username", new OpenApiSchema() { Type = "string" } },
+                    { "password", new OpenApiSchema() { Type = "string" } }
+                };
+                mediaType.Schema.Required = new HashSet<string>
+                {
+                    "grant_type"
+                };
+                operation.RequestBody.Content.Add("application/x-www-form-urlencoded", mediaType);
+            }
+        }
+    }
+}

--- a/src/VirtoCommerce.Platform.Web/Swagger/SwaggerServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Web/Swagger/SwaggerServiceCollectionExtensions.cs
@@ -84,6 +84,7 @@ namespace VirtoCommerce.Platform.Web.Swagger
                 c.OperationFilter<FileUploadOperationFilter>();
                 c.OperationFilter<SecurityRequirementsOperationFilter>();
                 c.OperationFilter<TagsFilter>();
+                c.OperationFilter<OpenIDEndpointDescriptionFilter>();
                 c.SchemaFilter<EnumSchemaFilter>();
                 c.SchemaFilter<SwaggerIgnoreFilter>();
                 c.MapType<object>(() => new OpenApiSchema { Type = "object" });


### PR DESCRIPTION
## Description
There wasn't a description for OAuth token request endpoint:
![image](https://user-images.githubusercontent.com/9972421/132653425-612e731e-e9d2-4520-a911-ff43f9b43d3f.png)
Now it's up and running for the test:
![image](https://user-images.githubusercontent.com/9972421/132653813-890c0351-2fd0-477a-9bd5-3c6580da86ea.png)

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-3801
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Platform.3.78.0-pr-2370.zip
