### PR TITLE
Fix type casting while deserealization

### DIFF
--- a/src/VirtoCommerce.Platform.Data/ExportImport/JsonSerializerExtensions.cs
+++ b/src/VirtoCommerce.Platform.Data/ExportImport/JsonSerializerExtensions.cs
@@ -41,10 +41,10 @@ namespace VirtoCommerce.Platform.Data.ExportImport
 
         public static async Task DeserializeJsonArrayWithPagingAsync<T>(this JsonTextReader reader, JsonSerializer serializer, int pageSize, Func<IEnumerable<T>, Task> action, Action<int> progressCallback, ICancellationToken cancellationToken)
         {
-            await reader.ReadAsync();
+            reader.Read();
             if (reader.TokenType == JsonToken.StartArray)
             {
-                await reader.ReadAsync();
+                reader.Read();
 
                 var items = new List<T>();
                 var processedCount = 0;
@@ -55,7 +55,7 @@ namespace VirtoCommerce.Platform.Data.ExportImport
                     var item = serializer.Deserialize<T>(reader);
                     items.Add(item);
                     processedCount++;
-                    await reader.ReadAsync();
+                    reader.Read();
                     if (processedCount % pageSize == 0 || reader.TokenType == JsonToken.EndArray)
                     {
                         await action(items);

--- a/src/VirtoCommerce.Platform.Data/ExportImport/JsonSerializerExtensions.cs
+++ b/src/VirtoCommerce.Platform.Data/ExportImport/JsonSerializerExtensions.cs
@@ -41,10 +41,10 @@ namespace VirtoCommerce.Platform.Data.ExportImport
 
         public static async Task DeserializeJsonArrayWithPagingAsync<T>(this JsonTextReader reader, JsonSerializer serializer, int pageSize, Func<IEnumerable<T>, Task> action, Action<int> progressCallback, ICancellationToken cancellationToken)
         {
-            reader.Read();
+            await reader.ReadAsync();
             if (reader.TokenType == JsonToken.StartArray)
             {
-                reader.Read();
+                await reader.ReadAsync();
 
                 var items = new List<T>();
                 var processedCount = 0;
@@ -52,11 +52,10 @@ namespace VirtoCommerce.Platform.Data.ExportImport
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 
-                    var itemType = AbstractTypeFactory<T>.TryCreateInstance().GetType();
-                    var item = serializer.Deserialize(reader, itemType);
-                    items.Add((T)item);
+                    var item = serializer.Deserialize<T>(reader);
+                    items.Add(item);
                     processedCount++;
-                    reader.Read();
+                    await reader.ReadAsync();
                     if (processedCount % pageSize == 0 || reader.TokenType == JsonToken.EndArray)
                     {
                         await action(items);


### PR DESCRIPTION
## Description
The issue was discovered incidentally. While importing store tax providers DB threw an error with problems with a unique index. I started to research and found that some of our entities use discriminators for typecasting. And tax provider is one of that entities, so that while importing we should just call generic  Newtonsoft's deserializer method, and our Polymorphic JSON converter will cast the right type for us.

## References
### QA-test:
### Jira-link:
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Platform.3.80.0-pr-2374.zip
