### PR TITLE
PT-692: Clear blade history every time when the same blade is reopened

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/navigation/breadcrumbs/breadcrumbs.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/navigation/breadcrumbs/breadcrumbs.js
@@ -141,7 +141,7 @@ angular.module('platformWebApp')
         return {
             push: function (breadcrumbs, id) {
                 var history = map[id];
-                if (!history) {
+                if (!history || !_.some(breadcrumbs)) {
                     map[id] = history = {
                         ignoreNextAction: false,
                         records: []


### PR DESCRIPTION
## Description

This bug is "phantom" and hard to reproduce.
But there is no point in having active "Back" button when you reopen the same blade once again => let's reset the history every time when the blade is reopened.


## References
### QA-test:
### Jira-link: https://virtocommerce.atlassian.net/browse/PT-692
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Platform.3.82.0-pr-2385.zip
