### PR TITLE
Fixed misspeling

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/systemInfo/blades/system-info.tpl.html
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/systemInfo/blades/system-info.tpl.html
@@ -17,7 +17,7 @@
                             </li>
                             <li class="list-item">
                                 <div class="list-t">{{ 'platform.blades.license.labels.type' | translate }}</div>
-                                <div class="list-descr">{{'platform.templates.licensing.license-present' | translate: blade.currentEntity.license.type}}</div>
+                                <div class="list-descr">{{blade.currentEntity.license.type}}</div>
                             </li>
                             <li class="list-item">
                                 <div class="list-t">{{'platform.templates.licensing.expiration-date' | translate}}</div>


### PR DESCRIPTION
Fixed wrong value for License Type on platform information blade, if the license is activated. From  "license, expires on Oct 4, 2021",  To correct, Ex: Cloud.


Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Platform.3.83.0-pr-2387.zip