### PR TITLE
PT-4681: Throw ApplicationUser changed event to refresh members cache

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Security/CustomUserManager.cs
+++ b/src/VirtoCommerce.Platform.Web/Security/CustomUserManager.cs
@@ -395,10 +395,10 @@ namespace VirtoCommerce.Platform.Web.Security
 
         public override async Task<IdentityResult> SetLockoutEndDateAsync(ApplicationUser user, DateTimeOffset? lockoutEnd)
         {
-            var result =  await base.SetLockoutEndDateAsync(user, lockoutEnd);
+            var result = await base.SetLockoutEndDateAsync(user, lockoutEnd);
 
             if (result.Succeeded)
-            {                
+            {
                 var changedEntries = new List<GenericChangedEntry<ApplicationUser>>
                 {
                     new GenericChangedEntry<ApplicationUser>(user, EntryState.Modified)


### PR DESCRIPTION
## Description
Throw ApplicationUser changed event to refresh members cache at lockout end date change.
This will cause to correctly show the locked state in XAPI.
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-4681
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Platform.3.84.0-pr-2392.zip
