### PR TITLE
PT-5277: Disable SampleDataUrl option value validation to allow set empty string

### DIFF
--- a/src/VirtoCommerce.Platform.Core/PlatformOptions.cs
+++ b/src/VirtoCommerce.Platform.Core/PlatformOptions.cs
@@ -33,7 +33,7 @@ namespace VirtoCommerce.Platform.Core
 
         // URL for discovery sample data for initial installation
         // e.g. http://virtocommerce.blob.core.windows.net/sample-data
-        [Url]
+        // [Url] Remove validation attribute to allow set empty strings in the option
         public string SampleDataUrl { get; set; }
 
         // Default path to store export files

--- a/tests/VirtoCommerce.Platform.Tests/UnitTests/OptionsValidationUnitTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/UnitTests/OptionsValidationUnitTests.cs
@@ -20,7 +20,6 @@ namespace VirtoCommerce.Platform.Tests.UnitTests
                 {
                     o.LocalUploadFolderPath = null;
                     o.LicenseActivationUrl = "wrong url";
-                    o.SampleDataUrl = "wrong url";
                 })
                 .ValidateDataAnnotations();
 
@@ -29,10 +28,9 @@ namespace VirtoCommerce.Platform.Tests.UnitTests
 
             //Assert
             var error = Assert.Throws<OptionsValidationException>(() => sp.GetRequiredService<IOptions<PlatformOptions>>().Value);
-            ValidateFailure<PlatformOptions>(error, Options.DefaultName, 3,
+            ValidateFailure<PlatformOptions>(error, Options.DefaultName, 2,
                 $"DataAnnotation validation failed for members: '{nameof(PlatformOptions.LocalUploadFolderPath)}' with the error: 'The {nameof(PlatformOptions.LocalUploadFolderPath)} field is required.'.",
-                $"DataAnnotation validation failed for members: '{nameof(PlatformOptions.LicenseActivationUrl)}' with the error: 'The {nameof(PlatformOptions.LicenseActivationUrl)} field is not a valid fully-qualified http, https, or ftp URL.",
-                $"DataAnnotation validation failed for members: '{nameof(PlatformOptions.SampleDataUrl)}' with the error: 'The {nameof(PlatformOptions.SampleDataUrl)} field is not a valid fully-qualified http, https, or ftp URL.");
+                $"DataAnnotation validation failed for members: '{nameof(PlatformOptions.LicenseActivationUrl)}' with the error: 'The {nameof(PlatformOptions.LicenseActivationUrl)} field is not a valid fully-qualified http, https, or ftp URL.");
         }
 
         [Fact]


### PR DESCRIPTION
## Description
Disable SampleDataUrl option value validation to allow set empty string
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-5277
### Artifact URL: https://vc3prerelease.blob.core.windows.net/packages/VirtoCommerce.Platform.3.89.0-pr-2405.zip
