### PR TITLE
DL-178: Upgrade the platform references to enable host Elsa [DO NOT MERGE!!!]

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
     </PropertyGroup>
 
     <PropertyGroup>
-        <VersionPrefix>3.202.0</VersionPrefix>
+        <VersionPrefix>3.203.0</VersionPrefix>
         <VersionSuffix></VersionSuffix>
         <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
         <NoWarn>$(NoWarn);S3875;S4457</NoWarn>

--- a/src/VirtoCommerce.Platform.Data/VirtoCommerce.Platform.Data.csproj
+++ b/src/VirtoCommerce.Platform.Data/VirtoCommerce.Platform.Data.csproj
@@ -21,11 +21,11 @@
         <PackageReference Include="EntityFrameworkCore.Triggers" Version="1.2.2" />
         <PackageReference Include="FluentValidation" Version="10.3.4" />
         <PackageReference Include="Microsoft.AspNetCore.Hosting.Abstractions" Version="2.2.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="6.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="6.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.1" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.1" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />

--- a/src/VirtoCommerce.Platform.Hangfire/VirtoCommerce.Platform.Hangfire.csproj
+++ b/src/VirtoCommerce.Platform.Hangfire/VirtoCommerce.Platform.Hangfire.csproj
@@ -23,7 +23,7 @@
         <PackageReference Include="Hangfire.AspNetCore" Version="1.7.14" />
         <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
         <PackageReference Include="HangFire.SqlServer" Version="1.7.14" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.1" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>
 

--- a/src/VirtoCommerce.Platform.Security/VirtoCommerce.Platform.Security.csproj
+++ b/src/VirtoCommerce.Platform.Security/VirtoCommerce.Platform.Security.csproj
@@ -20,11 +20,11 @@
     <ItemGroup>
         <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="6.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="6.0.0" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.0">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.1">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>

--- a/src/VirtoCommerce.Platform.Web/Program.cs
+++ b/src/VirtoCommerce.Platform.Web/Program.cs
@@ -27,7 +27,8 @@ namespace VirtoCommerce.Platform.Web
               })
               .ConfigureWebHostDefaults(webBuilder =>
                 {
-                    webBuilder.UseStartup<Startup>();
+                    webBuilder.UseStaticWebAssets();
+                    webBuilder.UseStartup<Startup>();                    
                     webBuilder.ConfigureKestrel((context, options) => { options.Limits.MaxRequestBodySize = null; });
                 })
             .ConfigureServices((hostingContext, services) =>

--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -398,6 +398,7 @@ namespace VirtoCommerce.Platform.Web
                          options.DiscoveryPath = Path.GetFullPath(options.DiscoveryPath ?? "modules");
                      })
                     .ValidateDataAnnotations();
+
             services.AddModules(mvcBuilder);
 
             services.AddOptions<ExternalModuleCatalogOptions>().Bind(Configuration.GetSection("ExternalModules")).ValidateDataAnnotations();
@@ -531,6 +532,8 @@ namespace VirtoCommerce.Platform.Web
                 endpoints.MapHub<PushNotificationHub>("/pushNotificationHub");
 
                 endpoints.MapHealthChecks();
+
+                endpoints.MapRazorPages();
             });
 
             //Seed default users

--- a/src/VirtoCommerce.Platform.Web/Swagger/OptionalParametersFilter.cs
+++ b/src/VirtoCommerce.Platform.Web/Swagger/OptionalParametersFilter.cs
@@ -16,8 +16,8 @@ namespace VirtoCommerce.Platform.Web.Swagger
             }
 
             var optionalParameters = context.ApiDescription.ParameterDescriptions
-                .Where(p => p.ParameterDescriptor != null &&
-                ((ControllerParameterDescriptor)p.ParameterDescriptor).ParameterInfo.CustomAttributes.Any(attr => attr.AttributeType == typeof(SwaggerOptionalAttribute))).ToList();
+                .Where(p => (p.ParameterDescriptor is ControllerParameterDescriptor descriptor) &&
+                descriptor.ParameterInfo.CustomAttributes.Any(attr => attr.AttributeType == typeof(SwaggerOptionalAttribute))).ToList();
 
             foreach (var apiParameter in optionalParameters)
             {

--- a/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
+++ b/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
@@ -51,6 +51,9 @@
         <PackageReference Include="System.Linq.Async" Version="5.1.0" />
         <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
         <PackageReference Include="VirtoCommerce.Assets.Abstractions" Version="3.200.0" />
+        <PackageReference Include="MediatR" Version="9.0.0" />
+	<PackageReference Include="MediatR.Extensions.Microsoft.DependencyInjection" Version="9.0.0" />
+	<PackageReference Include="AutoMapper.Extensions.Microsoft.DependencyInjection" Version="8.1.1" />
         <PackageReference Include="VirtoCommerce.BuildWebpack" Version="1.0.0" />
     </ItemGroup>
     <ItemGroup>

--- a/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
+++ b/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
@@ -16,19 +16,21 @@
 
     <ItemGroup>
         <PackageReference Include="FluentValidation" Version="10.3.4" />
+        <PackageReference Include="Humanizer" Version="2.13.14" />
         <PackageReference Include="Microsoft.ApplicationInsights.AspNetCore" Version="2.15.0" />
         <PackageReference Include="Microsoft.ApplicationInsights.PerfCounterCollector" Version="2.15.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="6.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="6.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="6.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.Diagnostics.EntityFrameworkCore" Version="6.0.0" />
-        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.0" />
+        <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.1" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="6.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Client.Core" Version="6.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="6.0.0" />
         <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="6.0.0" />
         <PackageReference Include="Microsoft.Azure.SignalR" Version="1.5.1" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.0">
+        <PackageReference Include="Microsoft.Data.SqlClient" Version="4.0.0" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="6.0.1">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
@@ -39,13 +41,14 @@
         <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
         <PackageReference Include="OpenIddict.AspNetCore" Version="3.0.4" />
         <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="3.0.4" />
-        <PackageReference Include="Swashbuckle.AspNetCore" Version="5.6.3" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="5.6.3" />
+        <PackageReference Include="Scrutor" Version="3.3.0" />
+        <PackageReference Include="Swashbuckle.AspNetCore" Version="6.2.1" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="6.2.1" />
         <PackageReference Include="Swashbuckle.AspNetCore.Cli" Version="4.0.1" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="5.1.2" />
-        <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="5.6.3" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="7.0.2" />
+        <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="6.2.1" />
         <PackageReference Include="System.Diagnostics.DiagnosticSource" Version="6.0.0" />
-        <PackageReference Include="System.Linq.Async" Version="5.0.0" />
+        <PackageReference Include="System.Linq.Async" Version="5.1.0" />
         <PackageReference Include="System.Security.Cryptography.Algorithms" Version="4.3.1" />
         <PackageReference Include="VirtoCommerce.Assets.Abstractions" Version="3.200.0" />
         <PackageReference Include="VirtoCommerce.BuildWebpack" Version="1.0.0" />

--- a/tests/VirtoCommerce.Platform.Benchmark.ArrayVsList/VirtoCommerce.Platform.Benchmark.ArrayVsList.csproj
+++ b/tests/VirtoCommerce.Platform.Benchmark.ArrayVsList/VirtoCommerce.Platform.Benchmark.ArrayVsList.csproj
@@ -8,7 +8,7 @@
   <ItemGroup>
     <PackageReference Include="BenchmarkDotNet" Version="0.13.1" />
     <PackageReference Include="GenFu" Version="1.6.0" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="6.0.1" />
   </ItemGroup>
 
 </Project>

--- a/tests/VirtoCommerce.Platform.Caching.Tests/VirtoCommerce.Platform.Caching.Tests.csproj
+++ b/tests/VirtoCommerce.Platform.Caching.Tests/VirtoCommerce.Platform.Caching.Tests.csproj
@@ -15,7 +15,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/VirtoCommerce.Platform.Core.Tests/VirtoCommerce.Platform.Core.Tests.csproj
+++ b/tests/VirtoCommerce.Platform.Core.Tests/VirtoCommerce.Platform.Core.Tests.csproj
@@ -15,7 +15,7 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="coverlet.collector" Version="3.1.0">
+    <PackageReference Include="coverlet.collector" Version="3.1.1">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/VirtoCommerce.Platform.Tests/VirtoCommerce.Platform.Tests.csproj
+++ b/tests/VirtoCommerce.Platform.Tests/VirtoCommerce.Platform.Tests.csproj
@@ -9,7 +9,7 @@
 
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.17.0" />
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.1">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/VirtoCommerce.Platform.Web.Tests/VirtoCommerce.Platform.Web.Tests.csproj
+++ b/tests/VirtoCommerce.Platform.Web.Tests/VirtoCommerce.Platform.Web.Tests.csproj
@@ -16,7 +16,7 @@
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
         </PackageReference>
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.1">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>

--- a/tests/VirtoCommerce.Testing/VirtoCommerce.Testing.csproj
+++ b/tests/VirtoCommerce.Testing/VirtoCommerce.Testing.csproj
@@ -11,7 +11,7 @@
     </PropertyGroup>
     <ItemGroup>
         <PackageReference Include="AutoFixture" Version="4.17.0" />
-        <PackageReference Include="coverlet.collector" Version="3.1.0">
+        <PackageReference Include="coverlet.collector" Version="3.1.1">
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
           <PrivateAssets>all</PrivateAssets>
         </PackageReference>


### PR DESCRIPTION
## Description
Upgrade the platform references to enable host Elsa Server and Elsa Designer. The changes are not directly related to, but we should enable some features in the platform to allow it:
1. Enable hosting static web-assets;
2. Enable hosting of Razor pages;
3. Upgrade some obsolete packages.
Please take a reference to a Jira link (below) to have more info...
## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/DL-178
### Artifact URL: ghcr.io/VirtoCommerce/platform:3.204.0-pr-2458-dl-178-workflow-spike-28b42a8d
