### PR TITLE
app_data and 404

### DIFF
--- a/src/VirtoCommerce.Platform.Core/PlatformOptions.cs
+++ b/src/VirtoCommerce.Platform.Core/PlatformOptions.cs
@@ -37,7 +37,7 @@ namespace VirtoCommerce.Platform.Core
         public string SampleDataUrl { get; set; }
 
         // Default path to store export files
-        public string DefaultExportFolder { get; set; } = "app_data/export";
+        public string DefaultExportFolder { get; set; } = "export";
 
         public string DefaultExportFileName { get; set; } = "exported_{0:yyyyMMddHHmmss}.zip";
 


### PR DESCRIPTION
Resolved issue with app_data in the path and 404 error on Azure Envirionent when download export document.
Client see 400 or 404 error because "_" is prohobiten symbol. 

## Description
Client see 400 or 404 error because "_" is prohobiten symbol. 

## References
### QA-test:
### Jira-link:
### Artifact URL:
