### PR TITLE
CrudService.SaveChangesAsync(): Customize loading and matching existing entities

### DIFF
--- a/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
+++ b/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
@@ -195,12 +195,12 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
 
             using (var repository = _repositoryFactory())
             {
-                var dataExistEntities = await LoadEntities(repository, models.Where(x => !x.IsTransient()).Select(x => x.Id));
+                var dataExistEntities = await LoadExistingEntities(repository, models);
 
                 foreach (var model in models)
                 {
 
-                    var originalEntity = dataExistEntities.FirstOrDefault(x => x.Id == model.Id);
+                    var originalEntity = FindExistingEntity(dataExistEntities, model);
                     var modifiedEntity = AbstractTypeFactory<TEntity>.TryCreateInstance().FromModel(model, pkMap);
 
                     if (originalEntity != null)
@@ -235,6 +235,16 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
             await AfterSaveChangesAsync(models, changedEntries);
 
             await _eventPublisher.Publish(EventFactory<TChangedEvent>(changedEntries));
+        }
+
+        protected virtual Task<IEnumerable<TEntity>> LoadExistingEntities(IRepository repository, IEnumerable<TModel> models)
+        {
+            return LoadEntities(repository, models.Where(x => !x.IsTransient()).Select(x => x.Id));
+        }
+
+        protected virtual TEntity FindExistingEntity(IEnumerable<TEntity> existingEntities, TModel model)
+        {
+            return existingEntities.FirstOrDefault(x => x.Id == model.Id);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
This PR modifies the `CrudService.SaveChangesAsync()` method to allow customization of loading existing entities and finding the matching one for each model being saved. Currently, this is always done by ID, and the only way to customize this behavior is to override the entire `SaveChangesAsync()` method. However, this PR extracts these operations into separate methods, providing a simpler way for such customization.

## But why would we need that customization?
Imagine some hypothetical service that deals with some entities like product tags.

```csharp
// Transient model in ...Core/Models
public class Tag : AuditableEntity
{
    public string TaggedItemId { get; set; }
    public string Tag { get; set; }
}

// Persistable entity in ...Data/Models
public class TagEntity : AuditableEntity, IDataEntity<TagEntity, Tag>
{
    [Required]
    [StringLength(128)]
    public string TaggedItemId { get; set; }

    [Required]
    [StringLength(128)]
    public string Tag { get; set; }

    // ...
}

// ...DbContext.OnModelCreating()
modelBuilder.Entity<TagEntity>.ToTable(...).HasKey(x => x.Id);
modelBuilder.Entity<TagEntity>.Property(x => x.Id).HasMaxLength(128).ValueGeneratedOnAdd();
modelBuilder.Entity<TagEntity>
    .HasIndex(x => new { x.TaggedItemId, x.Tag })
    .IsUnique();
```

On one hand, these models could be identified by `Id`, but, on the other hand, this is not enough - they could also be identified by `(TaggedItemId, Tag)` pair, even if `Id` does not match any existing entities. With the [current implementation](https://github.com/VirtoCommerce/vc-platform/blob/dev/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs#L189), the only way to do that is to override the entire `SaveChangesAsync()` method and change the code that loads existing entities (line 198) and the code that finds matching existing entity for each model (line 203) - for example, like this:

```csharp
public class ProductTagService : CrudService<Tag, TagEntity, ...>
{
    // ...

    public override async Task SaveChangesAsync(IEnumerable<Tag> models)
    {
        // ...
        using (var repository = _repositoryFactory())
        {
            var ids = models.Where(x => !x.IsTransient()).Select(x => x.Id).ToList();
            var taggedItemIds = models.Select(x => x.TaggedItemId).Distinct().ToList();
            var tags = models.Select(x => x.Tag).Distinct().ToList();

            var dataExistEntities = await repository.Tags
                .Where(x => ids.Contains(x.Id) || taggedItemIds.Contains(x.TaggedItemId) && tags.Contains(x.Tag))
                .ToListAsync();

            foreach (var model in models)
            {
                var originalEntity = dataExistEntities.FirstOrDefault(x => x.Id.EqualsInvariant(model.Id) || x.TaggedItemId.EqualsInvariant(model.TaggedItemId) && x.Tag.EqualsInvariant(model.Tag));
               
                // ... The rest of the method is copied without any changes ...
            }

            // ...
        }

        // ...
    }
}
```

However, with this PR there will be much simpler and cleaner alternative:

```csharp
public class ProductTagService : CrudService<Tag, TagEntity, ...>
{
    // ...

    protected override Task<IEnumerable<TagEntity>> LoadExistingEntities(IRepository repository, IEnumerable<Tag> models)
    {
        var ids = models.Where(x => !x.IsTransient()).Select(x => x.Id).ToList();
        var taggedItemIds = models.Select(x => x.TaggedItemId).Distinct().ToList();
        var tags = models.Select(x => x.Tag).Distinct().ToList();

        return ((IPersonalizationRepository)repository).Tags
            .Where(x => ids.Contains(x.Id) || taggedItemIds.Contains(x.TaggedItemId) && tags.Contains(x.Tag))
            .ToListAsync();
    }

    protected override TagEntity FindExistingEntity(IEnumerable<TagEntity> existingEntities, Tag model)
    {
        return existingEntities.FirstOrDefault(x => x.Id.EqualsInvariant(model.Id) || x.TaggedItemId.EqualsInvariant(model.TaggedItemId) && x.Tag.EqualsInvariant(model.Tag));
    }
}
```

Existing services that match entities by Id should also work with this code - the default implementation of these two methods should work exactly as it did before.

## References
### QA-test:
### Jira-link:
### Artifact URL:
