### PR TITLE
Optimize caching in CrudService

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Caching/MemoryCacheExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/MemoryCacheExtensions.cs
@@ -1,5 +1,7 @@
 using System;
 using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
 using VirtoCommerce.Platform.Core.Common;
@@ -8,7 +10,78 @@ namespace VirtoCommerce.Platform.Core.Caching
 {
     public static class MemoryCacheExtensions
     {
-        private static ConcurrentDictionary<string, object> _lockLookup = new ConcurrentDictionary<string, object>();
+        private static readonly StringComparer _ignoreCase = StringComparer.OrdinalIgnoreCase;
+        private static readonly ConcurrentDictionary<string, object> _lockLookup = new ConcurrentDictionary<string, object>();
+
+        public static async Task<IDictionary<string, TItem>> GetOrLoadByIdsAsync<TItem>(
+            this IMemoryCache memoryCache,
+            string keyPrefix,
+            IList<string> ids,
+            Func<IList<string>, Task<IDictionary<string, TItem>>> loadItems,
+            Action<MemoryCacheEntryOptions, string> configureCache)
+        {
+
+            ids = ids
+                ?.Where(id => !string.IsNullOrEmpty(id))
+                .Distinct(_ignoreCase)
+                .ToArray()
+                ?? Array.Empty<string>();
+
+            if (!TryGetByIds<TItem>(memoryCache, keyPrefix, ids, out var result))
+            {
+                using (await AsyncLock.GetLockByKey(keyPrefix).GetReleaserAsync())
+                {
+                    if (!TryGetByIds(memoryCache, keyPrefix, ids, out result))
+                    {
+                        var missingIds = ids
+                            .Except(result.Keys)
+                            .ToList();
+
+                        var loadResult = await loadItems(missingIds);
+
+                        foreach (var id in missingIds)
+                        {
+                            var cacheKey = CacheKey.With(keyPrefix, id);
+
+                            result[id] = memoryCache.GetOrCreateExclusive(cacheKey, options =>
+                            {
+                                configureCache(options, id);
+                                return loadResult.GetValueSafe(id);
+                            });
+                        }
+                    }
+                }
+            }
+
+            return result;
+        }
+
+        public static bool TryGetByIds<TItem>(this IMemoryCache memoryCache, string keyPrefix, IList<string> ids, out IDictionary<string, TItem> result)
+        {
+            result = new Dictionary<string, TItem>(_ignoreCase);
+
+            foreach (var id in ids)
+            {
+                var key = CacheKey.With(keyPrefix, id);
+
+                if (memoryCache.TryGetValue(key, out var itemFromCache))
+                {
+                    result[id] = (TItem)itemFromCache;
+                }
+            }
+
+            return result.Keys.Count == ids.Count;
+        }
+
+        public static void RemoveByIds(this IMemoryCache memoryCache, string keyPrefix, IEnumerable<string> ids)
+        {
+            foreach (var id in ids)
+            {
+                var cacheKey = CacheKey.With(keyPrefix, id);
+                memoryCache.Remove(cacheKey);
+            }
+        }
+
         /// <summary>
         ///  It is async thread-safe wrapper on IMemoryCache and guarantees that the cacheable delegates (cache miss) only executes once
         /// </summary>
@@ -53,7 +126,7 @@ namespace VirtoCommerce.Platform.Core.Caching
                             }
                         }
                     }
-                    finally                        
+                    finally
                     {
                         _lockLookup.TryRemove(key, out var _);
                     }

--- a/src/VirtoCommerce.Platform.Core/Extensions/DictionaryExtension.cs
+++ b/src/VirtoCommerce.Platform.Core/Extensions/DictionaryExtension.cs
@@ -12,5 +12,41 @@ namespace VirtoCommerce.Platform.Core.Common
             }
             return value;
         }
+
+        /// <summary>
+        /// Doesn't throw an exception when the key is null or does not exist
+        /// </summary>
+        public static TValue GetValueSafe<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key)
+        {
+            return dictionary.GetValueSafe(key, default);
+        }
+
+        /// <summary>
+        /// Doesn't throw an exception when the key is null or does not exist
+        /// </summary>
+        public static TValue GetValueSafe<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, TValue defaultValue)
+        {
+            if (key != null && dictionary.TryGetValue(key, out var value))
+            {
+                return value;
+            }
+
+            return defaultValue;
+        }
+
+        /// <summary>
+        /// Doesn't throw an exception when the key is null
+        /// </summary>
+        public static bool TryGetValueSafe<TKey, TValue>(this IDictionary<TKey, TValue> dictionary, TKey key, out TValue value)
+        {
+            if (key != null)
+            {
+                return dictionary.TryGetValue(key, out value);
+            }
+
+            value = default;
+
+            return false;
+        }
     }
 }

--- a/src/VirtoCommerce.Platform.Core/Extensions/EnumerableExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Extensions/EnumerableExtensions.cs
@@ -89,5 +89,10 @@ namespace VirtoCommerce.Platform.Core.Common
 
             return hash;
         }
+
+        public static IDictionary<TKey, TValue> ToIDictionary<TKey, TValue>(this IEnumerable<TValue> source, Func<TValue, TKey> keySelector)
+        {
+            return source.ToDictionary(keySelector);
+        }
     }
 }

--- a/src/VirtoCommerce.Platform.Core/Extensions/ObjectExtension.cs
+++ b/src/VirtoCommerce.Platform.Core/Extensions/ObjectExtension.cs
@@ -61,7 +61,7 @@ namespace VirtoCommerce.Platform.Core.Common
         public static string GetMD5Hash(this object instance)
         {
             return ComputeHash(instance, MD5.Create());
-         }
+        }
 
         /// <summary>
         ///     Gets a SHA1 hash of the current instance.
@@ -107,6 +107,11 @@ namespace VirtoCommerce.Platform.Core.Common
                 objType = Nullable.GetUnderlyingType(objType);
             }
             return (T)Convert.ChangeType(obj, objType);
+        }
+
+        public static T CloneTyped<T>(this T instance) where T : ICloneable
+        {
+            return (T)instance.Clone();
         }
     }
 }

--- a/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
+++ b/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
@@ -72,36 +71,33 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
         /// <returns></returns>
         public virtual async Task<IReadOnlyCollection<TModel>> GetAsync(List<string> ids, string responseGroup = null)
         {
-            var cacheKey = CacheKey.With(GetType(), nameof(GetAsync), string.Join("-", ids), responseGroup);
-            var result = await _platformMemoryCache.GetOrCreateExclusiveAsync(cacheKey, async (cacheEntry) =>
-            {
-                var models = new List<TModel>();
+            var cacheKeyPrefix = CacheKey.With(GetType(), nameof(GetAsync));
 
-                using (var repository = _repositoryFactory())
+            var modelsByIds = await _platformMemoryCache.GetOrLoadByIdsAsync(cacheKeyPrefix, ids,
+                async missingIds =>
                 {
-                    //Disable DBContext change tracking for better performance 
+                    using var repository = _repositoryFactory();
+
+                    // Disable DBContext change tracking for better performance 
                     repository.DisableChangesTracking();
 
-                    //It is so important to generate change tokens for all ids even for not existing objects to prevent an issue
-                    //with caching of empty results for non - existing objects that have the infinitive lifetime in the cache
-                    //and future unavailability to create objects with these ids.
-                    cacheEntry.AddExpirationToken(CreateCacheToken(ids));
+                    var entities = await LoadEntities(repository, missingIds, responseGroup);
 
-                    var entities = await LoadEntities(repository, ids, responseGroup);
+                    return entities
+                        .Select(x => ProcessModel(responseGroup, x, x.ToModel(AbstractTypeFactory<TModel>.TryCreateInstance())))
+                        .Where(x => x != null)
+                        .ToIDictionary(x => x.Id);
+                },
+                (cacheOptions, id) =>
+                {
+                    cacheOptions.AddExpirationToken(CreateCacheToken(id));
+                });
 
-                    foreach (var entity in entities)
-                    {
-                        var model = entity.ToModel(AbstractTypeFactory<TModel>.TryCreateInstance());
-                        model = ProcessModel(responseGroup, entity, model);
-                        if (model != null) models.Add(model);
-                    }
-
-                }
-
-                return models;
-            });
-
-            return new ReadOnlyCollection<TModel>(result.Select(x => (TModel)x.Clone()).ToList());
+            return modelsByIds.Values
+                .Where(x => x != null)
+                .Select(x => x.CloneTyped())
+                .OrderBy(x => ids.IndexOf(x.Id))
+                .ToList();
         }
 
         [Obsolete("Use method GetAsync instead")]
@@ -305,9 +301,15 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
         /// </summary>
         /// <param name="ids"></param>
         /// <returns></returns>
+        [Obsolete("Use CreateCacheToken(string id)")]
         protected virtual IChangeToken CreateCacheToken(IEnumerable<string> ids)
         {
             return GenericCachingRegion<TModel>.CreateChangeToken(ids);
+        }
+
+        protected virtual IChangeToken CreateCacheToken(string id)
+        {
+            return GenericCachingRegion<TModel>.CreateChangeTokenForKey(id);
         }
 
         /// <summary>


### PR DESCRIPTION
## Description
### Problem
When calling `GetAsync("1", "2")` and then `GetAsync("2", "1")` or `GetAsync("1")`, CrudService loads the same objects from the database multiple times and adds the same objects to the cache multiple times because it builds the cache key by joining all ids into a single string.
### Solution
Build a separate cache key for each object and add only one object per id to the cache.
### Benefits
- Reduced number of requests to the database
- Reduced memory usage

## References
### QA-test:
### Jira-link:
### Artifact URL:
