### PR TITLE
Improve performance of GetFlatObjectsListWithInterface()

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -60,11 +60,11 @@ jobs:
 
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild ${{ matrix.language }}
+    - name: Autobuild csharp
       if: ${{ matrix.language == 'csharp' }}
       run: vc-build Compile
 
-    - name: Autobuild ${{ matrix.language }}
+    - name: Autobuild javascript
       if: ${{ matrix.language == 'javascript' }}
       uses: github/codeql-action/autobuild@v2
 

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -12,6 +12,7 @@
 name: "CodeQL"
 
 on:
+  workflow_dispatch:
   push:
     branches: [ dev, master, support/2.x, support/2.x-dev ]
   pull_request:
@@ -37,6 +38,10 @@ jobs:
         # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
 
     steps:
+    # Initializes vc-build  for solution build.
+    - name: Install VirtoCommerce.GlobalTool
+      uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
+
     - name: Checkout repository
       uses: actions/checkout@v3
 
@@ -48,20 +53,26 @@ jobs:
         # If you wish to specify custom queries, you can do so here or in a config file.
         # By default, queries listed here will override any specified in a config file.
         # Prefix the list here with "+" to use these queries and those in the config file.
-        
+
         # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
         # queries: security-extended,security-and-quality
 
-        
+
     # Autobuild attempts to build any compiled languages  (C/C++, C#, or Java).
     # If this step fails, then you should remove it and run the build manually (see below)
-    - name: Autobuild
+    - name: Autobuild ${{ matrix.language }}
+      if: ${{ matrix.language == 'csharp' }}
+      run: vc-build Compile
+
+    - name: Autobuild ${{ matrix.language }}
+      if: ${{ matrix.language == 'javascript' }}
       uses: github/codeql-action/autobuild@v2
+
 
     # ℹ️ Command-line programs to run using the OS shell.
     # 📚 See https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#jobsjob_idstepsrun
 
-    #   If the Autobuild fails above, remove it and uncomment the following three lines. 
+    #   If the Autobuild fails above, remove it and uncomment the following three lines.
     #   modify them (or add more) to build your code if your project, please refer to the EXAMPLE below for guidance.
 
     # - run: |

--- a/tests/VirtoCommerce.Platform.Core.Tests/Common/ReflectionUtilityTests.cs
+++ b/tests/VirtoCommerce.Platform.Core.Tests/Common/ReflectionUtilityTests.cs
@@ -1,0 +1,42 @@
+using VirtoCommerce.Platform.Core.Commands;
+using VirtoCommerce.Platform.Core.Common;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Core.Tests.Common
+{
+    [Trait("Category", "Unit")]
+    public class ReflectionUtilityTests
+    {
+        [Fact]
+        public void GetFlatObjectsListWithInterface_Self()
+        {
+            var container = new CommandBase();
+            var result = container.GetFlatObjectsListWithInterface<IEntity>();
+            Assert.Single(result);
+        }
+
+        [Fact]
+        public void GetFlatObjectsListWithInterface_Entity()
+        {
+            var container = new { Entity = new CommandBase() };
+            var result = container.GetFlatObjectsListWithInterface<IEntity>();
+            Assert.Single(result);
+        }
+
+        [Fact]
+        public void GetFlatObjectsListWithInterface_NonEntity()
+        {
+            var container = new { NonEntity = new { Entity = new CommandBase() } };
+            var result = container.GetFlatObjectsListWithInterface<IEntity>();
+            Assert.Empty(result);
+        }
+
+        [Fact]
+        public void GetFlatObjectsListWithInterface_Array()
+        {
+            var container = new { Entities = new[] { new CommandBase() } };
+            var result = container.GetFlatObjectsListWithInterface<IEntity>();
+            Assert.Single(result);
+        }
+    }
+}


### PR DESCRIPTION
## Description
New implementation significantly reduces CPU and memory usage.
There are two main changes:
- Use HashSet to detect reference loops
- Don't create intermediate lists and arrays when making recursive calls

Benchmark results for a smallest entity `CommandBase`: 3 times faster, 5 times less allocated memory:
```
| Method |       Mean |    Error |   StdDev |  Gen 0 | Allocated |
|------- |-----------:|---------:|---------:|-------:|----------:|
|    Old | 3,305.9 ns | 40.85 ns | 38.21 ns | 0.4959 |   2,089 B |
|    New |   923.9 ns |  5.68 ns |  5.03 ns | 0.1011 |     424 B |
```

Benchmark results for a large entity `ExtendedCustomerOrderAggregate` with about 13000 nested entities: **19 times faster**, 2.5 times less allocated memory:
```
| Method |        Mean |    Error |   StdDev |     Gen 0 |    Gen 1 | Allocated |
|------- |------------:|---------:|---------:|----------:|---------:|----------:|
|    Old | 1,084.94 ms | 8.185 ms | 6.390 ms | 4000.0000 |        - |     20 MB |
|    New |    56.94 ms | 1.108 ms | 1.138 ms | 1700.0000 | 300.0000 |      8 MB |
```

## References
### QA-test:
### Jira-link:
### Artifact URL:
