### PR TITLE
Fix InvalidCastException

### DIFF
--- a/VirtoCommerce.Platform.sln
+++ b/VirtoCommerce.Platform.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 16
-VisualStudioVersion = 16.0.29025.244
+# Visual Studio Version 17
+VisualStudioVersion = 17.2.32630.192
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "src", "src", "{90F6E3EE-475A-4844-A4C4-078613591F81}"
 EndProject

--- a/src/VirtoCommerce.Platform.Caching/GenericCachingRegion.cs
+++ b/src/VirtoCommerce.Platform.Caching/GenericCachingRegion.cs
@@ -19,7 +19,8 @@ namespace VirtoCommerce.Platform.Caching
             {
                 throw new ArgumentNullException(nameof(entities));
             }
-            return CreateChangeToken((IEnumerable<T>) entities.Select(x => x.Id));
+
+            return CreateChangeToken(entities.Select(x => x.Id));
         }
 
         public static IChangeToken CreateChangeToken(IEnumerable<string> entityIds)
@@ -34,6 +35,7 @@ namespace VirtoCommerce.Platform.Caching
             {
                 changeTokens.Add(CreateChangeTokenForKey(entityId));
             }
+
             return new CompositeChangeToken(changeTokens);
         }
     }


### PR DESCRIPTION
## Description
When calling `GenericCachingRegion.CreateChangeToken(products)` the following error occurs:
```
System.InvalidCastException: Unable to cast object of type
'SelectEnumerableIterator`2[VirtoCommerce.CatalogModule.Core.Model.CatalogProduct,System.String]' to type
'System.Collections.Generic.IEnumerable`1[VirtoCommerce.CatalogModule.Core.Model.CatalogProduct]'.
```

## References
### QA-test:
### Jira-link:
### Artifact URL:
