### PR TITLE
PT-8520: New fields not showing up in hamburger menu

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,4 +1,4 @@
-﻿root = true
+root = true
 
 [*]
 charset = utf-8
@@ -8,7 +8,24 @@ end_of_line = crlf
 trim_trailing_whitespace = true
 insert_final_newline = true
 
-# Dotnet code style settings:
+# Project files
+[*.csproj,*.props]
+indent_size = 2
+insert_final_newline = false
+
+# JSON files
+[*.json]
+indent_size = 2
+
+# Configuration files
+[*.config]
+indent_size = 2
+
+# HTML files
+[*.html,*.htm]
+insert_final_newline = false
+
+# Dotnet code style settings
 [*.{cs,vb}]
 
 # Sort using and Import directives with System.* appearing first
@@ -24,15 +41,23 @@ dotnet_style_qualification_for_event = false:suggestion
 dotnet_style_predefined_type_for_locals_parameters_members = true:suggestion
 dotnet_style_predefined_type_for_member_access = true:suggestion
 
+# Use explicit accessibility modifiers
+dotnet_style_require_accessibility_modifiers = true:suggestion
+
 # Suggest more modern language features when available
 dotnet_style_object_initializer = true:suggestion
 dotnet_style_collection_initializer = true:suggestion
 dotnet_style_coalesce_expression = true:suggestion
 dotnet_style_null_propagation = true:suggestion
 dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_prefer_inferred_tuple_names = true:suggestion
+dotnet_prefer_inferred_anonymous_type_member_names = true:suggestion
 
-# CSharp code style settings:
+# CSharp code style settings
 [*.cs]
+
+# Prefer curly braces even for one line of code
+csharp_prefer_braces = true:suggestion
 
 # Prefer "var" everywhere
 csharp_style_var_for_built_in_types = true:suggestion
@@ -55,6 +80,9 @@ csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
 csharp_style_inlined_variable_declaration = true:suggestion
 csharp_style_throw_expression = true:suggestion
 csharp_style_conditional_delegate_call = true:suggestion
+csharp_prefer_simple_default_expression = true:suggestion
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_pattern_local_over_anonymous_function = true:suggestion
 
 # Newline settings
 csharp_new_line_before_open_brace = all
@@ -63,3 +91,17 @@ csharp_new_line_before_catch = true
 csharp_new_line_before_finally = true
 csharp_new_line_before_members_in_object_initializers = true
 csharp_new_line_before_members_in_anonymous_types = true
+csharp_new_line_between_query_expression_clauses = true
+
+csharp_indent_case_contents = true
+csharp_indent_switch_labels = true
+csharp_indent_labels = flush_left
+
+csharp_space_after_cast = false
+csharp_space_after_keywords_in_control_flow_statements = true
+csharp_space_between_method_declaration_parameter_list_parentheses = false
+csharp_space_between_method_call_parameter_list_parentheses = false
+csharp_space_between_parentheses = false
+
+csharp_preserve_single_line_statements = false
+csharp_preserve_single_line_blocks = true

--- a/.gitignore
+++ b/.gitignore
@@ -278,6 +278,7 @@ app_data/
 
 .vscode
 
+/.nuke
 /src/VirtoCommerce.Platform.Web/modules
 # mkdocs output
 /site

--- a/.nuke
+++ b/.nuke
@@ -1,1 +1,0 @@
-VirtoCommerce.Platform.sln

--- a/VirtoCommerce.Platform.sln.DotSettings
+++ b/VirtoCommerce.Platform.sln.DotSettings
@@ -1,0 +1,3 @@
+<wpf:ResourceDictionary xml:space="preserve" xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml" xmlns:s="clr-namespace:System;assembly=mscorlib" xmlns:ss="urn:shemas-jetbrains-com:settings-storage-xaml" xmlns:wpf="http://schemas.microsoft.com/winfx/2006/xaml/presentation">
+	<s:Boolean x:Key="/Default/UserDictionary/Words/=virto/@EntryIndexedValue">True</s:Boolean>
+</wpf:ResourceDictionary>

--- a/src/VirtoCommerce.Platform.Core/Json/OutputJsonSerializerSettings.cs
+++ b/src/VirtoCommerce.Platform.Core/Json/OutputJsonSerializerSettings.cs
@@ -1,0 +1,39 @@
+using Newtonsoft.Json;
+
+namespace VirtoCommerce.Platform.Core.Json;
+
+public class OutputJsonSerializerSettings : JsonSerializerSettings
+{
+    public virtual void CopyFrom(JsonSerializerSettings settings)
+    {
+        ReferenceLoopHandling = settings.ReferenceLoopHandling;
+        MissingMemberHandling = settings.MissingMemberHandling;
+        ObjectCreationHandling = settings.ObjectCreationHandling;
+        NullValueHandling = settings.NullValueHandling;
+        DefaultValueHandling = settings.DefaultValueHandling;
+        Converters = settings.Converters;
+        PreserveReferencesHandling = settings.PreserveReferencesHandling;
+        TypeNameHandling = settings.TypeNameHandling;
+        MetadataPropertyHandling = settings.MetadataPropertyHandling;
+        TypeNameAssemblyFormatHandling = settings.TypeNameAssemblyFormatHandling;
+        ConstructorHandling = settings.ConstructorHandling;
+        ContractResolver = settings.ContractResolver;
+        EqualityComparer = settings.EqualityComparer;
+        ReferenceResolverProvider = settings.ReferenceResolverProvider;
+        TraceWriter = settings.TraceWriter;
+        SerializationBinder = settings.SerializationBinder;
+        Error = settings.Error;
+        Context = settings.Context;
+        DateFormatString = settings.DateFormatString;
+        MaxDepth = settings.MaxDepth;
+        Formatting = settings.Formatting;
+        DateFormatHandling = settings.DateFormatHandling;
+        DateTimeZoneHandling = settings.DateTimeZoneHandling;
+        DateParseHandling = settings.DateParseHandling;
+        FloatFormatHandling = settings.FloatFormatHandling;
+        FloatParseHandling = settings.FloatParseHandling;
+        StringEscapeHandling = settings.StringEscapeHandling;
+        Culture = settings.Culture;
+        CheckAdditionalContent = settings.CheckAdditionalContent;
+    }
+}

--- a/src/VirtoCommerce.Platform.Web/Json/ConfigureMvcOptions.cs
+++ b/src/VirtoCommerce.Platform.Web/Json/ConfigureMvcOptions.cs
@@ -1,0 +1,30 @@
+using System.Buffers;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.AspNetCore.Mvc.Formatters;
+using Microsoft.Extensions.Options;
+using VirtoCommerce.Platform.Core.Json;
+
+namespace VirtoCommerce.Platform.Web.Json;
+
+public class ConfigureMvcOptions : IConfigureOptions<MvcOptions>
+{
+    private readonly IOptions<OutputJsonSerializerSettings> _outputSerializerSettings;
+    private readonly IOptions<MvcNewtonsoftJsonOptions> _jsonOptions;
+    private readonly ArrayPool<char> _charPool;
+
+    public ConfigureMvcOptions(
+        IOptions<OutputJsonSerializerSettings> outputSerializerSettings,
+        IOptions<MvcNewtonsoftJsonOptions> jsonOptions,
+        ArrayPool<char> charPool)
+    {
+        _outputSerializerSettings = outputSerializerSettings;
+        _jsonOptions = jsonOptions;
+        _charPool = charPool;
+    }
+
+    public void Configure(MvcOptions options)
+    {
+        options.OutputFormatters.RemoveType<NewtonsoftJsonOutputFormatter>();
+        options.OutputFormatters.Add(new NewtonsoftJsonOutputFormatter(_outputSerializerSettings.Value, _charPool, options, _jsonOptions.Value));
+    }
+}

--- a/src/VirtoCommerce.Platform.Web/Json/ConfigureOutputJsonSerializerSettings.cs
+++ b/src/VirtoCommerce.Platform.Web/Json/ConfigureOutputJsonSerializerSettings.cs
@@ -1,0 +1,25 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Options;
+using VirtoCommerce.Platform.Core.Json;
+
+namespace VirtoCommerce.Platform.Web.Json;
+
+public class ConfigureOutputJsonSerializerSettings : IConfigureOptions<OutputJsonSerializerSettings>
+{
+    private readonly IOptions<MvcNewtonsoftJsonOptions> _jsonOptions;
+    private readonly Action<OutputJsonSerializerSettings, MvcNewtonsoftJsonOptions> _setupAction;
+
+    public ConfigureOutputJsonSerializerSettings(
+        IOptions<MvcNewtonsoftJsonOptions> jsonOptions,
+        Action<OutputJsonSerializerSettings, MvcNewtonsoftJsonOptions> setupAction)
+    {
+        _jsonOptions = jsonOptions;
+        _setupAction = setupAction;
+    }
+
+    public void Configure(OutputJsonSerializerSettings options)
+    {
+        _setupAction(options, _jsonOptions.Value);
+    }
+}

--- a/src/VirtoCommerce.Platform.Web/Json/MvcBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Web/Json/MvcBuilderExtensions.cs
@@ -1,0 +1,22 @@
+using System;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+using Microsoft.Extensions.Options;
+using VirtoCommerce.Platform.Core.Json;
+
+namespace VirtoCommerce.Platform.Web.Json;
+
+public static class MvcBuilderExtensions
+{
+    public static IMvcBuilder AddOutputJsonSerializerSettings(
+        this IMvcBuilder builder,
+        Action<OutputJsonSerializerSettings, MvcNewtonsoftJsonOptions> setupAction)
+    {
+        builder.Services.AddSingleton(setupAction);
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<OutputJsonSerializerSettings>, ConfigureOutputJsonSerializerSettings>());
+        builder.Services.TryAddEnumerable(ServiceDescriptor.Transient<IConfigureOptions<MvcOptions>, ConfigureMvcOptions>());
+
+        return builder;
+    }
+}

--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -52,6 +52,7 @@ using VirtoCommerce.Platform.Web.Azure;
 using VirtoCommerce.Platform.Web.Extensions;
 using VirtoCommerce.Platform.Web.Infrastructure;
 using VirtoCommerce.Platform.Web.Infrastructure.HealthCheck;
+using VirtoCommerce.Platform.Web.Json;
 using VirtoCommerce.Platform.Web.Licensing;
 using VirtoCommerce.Platform.Web.Middleware;
 using VirtoCommerce.Platform.Web.Migrations;
@@ -132,8 +133,12 @@ namespace VirtoCommerce.Platform.Web
                 options.SerializerSettings.DateTimeZoneHandling = DateTimeZoneHandling.Utc;
                 options.SerializerSettings.NullValueHandling = NullValueHandling.Ignore;
                 options.SerializerSettings.Formatting = Formatting.None;
-            }
-            );
+            })
+            .AddOutputJsonSerializerSettings((settings, jsonOptions) =>
+            {
+                settings.CopyFrom(jsonOptions.SerializerSettings);
+                settings.NullValueHandling = NullValueHandling.Include;
+            });
 
             services.AddSingleton(js =>
             {
@@ -497,7 +502,7 @@ namespace VirtoCommerce.Platform.Web
                 app.UseStaticFiles(new StaticFileOptions()
                 {
                     FileProvider = new PhysicalFileProvider(module.FullPhysicalPath),
-                    RequestPath = new PathString($"/modules/$({ module.ModuleName })")
+                    RequestPath = new PathString($"/modules/$({module.ModuleName})")
                 });
             }
 


### PR DESCRIPTION
## Description
A hamburger menu in a grid contains only those fields, that are present in the very first record in the grid.
This PR makes all fields to be serialized even if its values are `null`.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-8520
### Artifact URL:
