### PR TITLE
PT-8404 Fill setting properties from the descriptor when publishing ObjectSettingChangedEvent

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Settings/ObjectSettingEntry.cs
+++ b/src/VirtoCommerce.Platform.Core/Settings/ObjectSettingEntry.cs
@@ -14,6 +14,8 @@ namespace VirtoCommerce.Platform.Core.Settings
             ModuleId = descriptor.ModuleId;
             GroupName = descriptor.GroupName;
             Name = descriptor.Name;
+            DisplayName = descriptor.DisplayName;
+            IsRequired = descriptor.IsRequired;
             ValueType = descriptor.ValueType;
             AllowedValues = descriptor.AllowedValues;
             DefaultValue = descriptor.DefaultValue;

--- a/src/VirtoCommerce.Platform.Data/Settings/SettingsManager.cs
+++ b/src/VirtoCommerce.Platform.Data/Settings/SettingsManager.cs
@@ -131,7 +131,7 @@ namespace VirtoCommerce.Platform.Data.Settings
             });
             return result;
         }
-        
+
         public virtual async Task RemoveObjectSettingsAsync(IEnumerable<ObjectSettingEntry> objectSettings)
         {
             if (objectSettings == null)
@@ -159,7 +159,7 @@ namespace VirtoCommerce.Platform.Data.Settings
             {
                 throw new ArgumentNullException(nameof(objectSettings));
             }
-            
+
             var changedEntries = new List<GenericChangedEntry<ObjectSettingEntry>>();
 
             using (var repository = _repositoryFactory())
@@ -197,8 +197,12 @@ namespace VirtoCommerce.Platform.Data.Settings
 
                     if (originalEntity != null)
                     {
-                        changedEntries.Add(new GenericChangedEntry<ObjectSettingEntry>(setting, originalEntity.ToModel(AbstractTypeFactory<ObjectSettingEntry>.TryCreateInstance()), EntryState.Modified));
+                        var oldEntry = originalEntity.ToModel(new ObjectSettingEntry(settingDescriptor));
+
                         modifiedEntity.Patch(originalEntity);
+
+                        var newEntry = originalEntity.ToModel(new ObjectSettingEntry(settingDescriptor));
+                        changedEntries.Add(new GenericChangedEntry<ObjectSettingEntry>(newEntry, oldEntry, EntryState.Modified));
                     }
                     else
                     {


### PR DESCRIPTION
## Description
Make `OldEntry` and `NewEntry` in `ObjectSettingChangedEvent` consistent and prevent false changes in audit log.
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-8404
### Artifact URL:
