### PR TITLE
PT-8727 Moved AddExpirationToken to GetDefaultCacheEntryOption

### DIFF
--- a/src/VirtoCommerce.Platform.Caching/PlatformMemoryCache.cs
+++ b/src/VirtoCommerce.Platform.Caching/PlatformMemoryCache.cs
@@ -29,8 +29,6 @@ namespace VirtoCommerce.Platform.Caching
             {
                 result.RegisterPostEvictionCallback(callback: EvictionCallback);
                 var options = GetDefaultCacheEntryOptions();
-                //Add GlobalCache token for each entry
-                options.AddExpirationToken(GlobalCacheRegion.CreateChangeToken());
                 result.SetOptions(options);
             }
             return result;
@@ -73,6 +71,10 @@ namespace VirtoCommerce.Platform.Caching
                     result.SlidingExpiration = SlidingExpiration;
                 }
             }
+
+            //Add GlobalCache token for each entry
+            result.AddExpirationToken(GlobalCacheRegion.CreateChangeToken());
+
 
             return result;
         }


### PR DESCRIPTION
## Description
the 3rd party code could call GetDefaultCacheEntryOption without AddExpirationToken and items can be in InMemory cache if redis is disconned.

## References
### QA-test:
### Jira-link:
### Artifact URL:
