### PR TITLE
PT-8963: Remove redundant Oids in self-signed certificate generator (MacOS compatible)

### DIFF
--- a/src/VirtoCommerce.Platform.Security/Services/ServerCertificateService.cs
+++ b/src/VirtoCommerce.Platform.Security/Services/ServerCertificateService.cs
@@ -36,10 +36,7 @@ namespace VirtoCommerce.Platform.Security.Services
             var subject = new X500DistinguishedName("O=Virtocommerce, S=Vilnius, C=LT, CN=virtocommerce.com");
             var request = new CertificateRequest(subject, algorithm, HashAlgorithmName.SHA256, RSASignaturePadding.Pkcs1);
             request.CertificateExtensions.Add(new X509KeyUsageExtension(X509KeyUsageFlags.DigitalSignature | X509KeyUsageFlags.KeyEncipherment, critical: true));
-            request.CertificateExtensions.Add(new X509EnhancedKeyUsageExtension(new OidCollection() {
-                Oid.FromOidValue("1.3.6.1.5.5.7.3.1", OidGroup.EnhancedKeyUsage), // Add Server Authentication usage
-                Oid.FromOidValue("1.3.6.1.5.5.7.3.2", OidGroup.EnhancedKeyUsage) // Add Client Authentication usage
-            }, true));
+
             var dnsExtensionBuilder = new SubjectAlternativeNameBuilder();
             dnsExtensionBuilder.AddDnsName("virtocommerce.com");
             request.CertificateExtensions.Add(dnsExtensionBuilder.Build());


### PR DESCRIPTION
## Description
Remove redundant Oids in self-signed certificate generator to improve compatibility with MacOS.
Seems we can skip additional oids because we use certs in bearer auth only.
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-8963
### Artifact URL:
