### PR TITLE
PT-9132: Store identity error value as a separate error parameter

### DIFF
--- a/src/VirtoCommerce.Platform.Security/CustomIdentityError.cs
+++ b/src/VirtoCommerce.Platform.Security/CustomIdentityError.cs
@@ -7,6 +7,17 @@ namespace VirtoCommerce.Platform.Security
         /// <summary>
         /// Auxiliary error parameter: E.g., RequiredLength, etc.
         /// </summary>
-        public int ErrorParameter { get; set; }
+        public string Parameter { get; set; }
+
+        public CustomIdentityError()
+        {
+        }
+
+        public CustomIdentityError(IdentityError basicError, object parameter)
+        {
+            Code = basicError.Code;
+            Description = basicError.Description;
+            Parameter = parameter.ToString();
+        }
     }
 }

--- a/src/VirtoCommerce.Platform.Security/CustomIdentityErrorDescriber.cs
+++ b/src/VirtoCommerce.Platform.Security/CustomIdentityErrorDescriber.cs
@@ -1,4 +1,5 @@
 using Microsoft.AspNetCore.Identity;
+using VirtoCommerce.Platform.Core.Security;
 
 namespace VirtoCommerce.Platform.Security
 {
@@ -7,6 +8,119 @@ namespace VirtoCommerce.Platform.Security
     /// </summary>
     public class CustomIdentityErrorDescriber : IdentityErrorDescriber
     {
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError"/> indicating the specified user <paramref name="userName"/> is invalid.
+        /// </summary>
+        /// <param name="userName">The user name that is invalid.</param>
+        /// <returns>An <see cref="IdentityError"/> indicating the specified user <paramref name="userName"/> is invalid.</returns>
+        public override IdentityError InvalidUserName(string userName)
+        {
+            return new CustomIdentityError
+            (
+                base.InvalidUserName(userName),
+                userName
+            );
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError"/> indicating the specified <paramref name="email"/> is invalid.
+        /// </summary>
+        /// <param name="email">The email that is invalid.</param>
+        /// <returns>An <see cref="IdentityError"/> indicating the specified <paramref name="email"/> is invalid.</returns>
+        public override IdentityError InvalidEmail(string email)
+        {
+            return new CustomIdentityError
+            (
+                base.InvalidEmail(email),
+                email
+            );
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError"/> indicating the specified <paramref name="userName"/> already exists.
+        /// </summary>
+        /// <param name="userName">The user name that already exists.</param>
+        /// <returns>An <see cref="IdentityError"/> indicating the specified <paramref name="userName"/> already exists.</returns>
+        public override IdentityError DuplicateUserName(string userName)
+        {
+            return new CustomIdentityError
+            (
+                base.DuplicateUserName(userName),
+                userName
+            );
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError"/> indicating the specified <paramref name="email"/> is already associated with an account.
+        /// </summary>
+        /// <param name="email">The email that is already associated with an account.</param>
+        /// <returns>An <see cref="IdentityError"/> indicating the specified <paramref name="email"/> is already associated with an account.</returns>
+        public override IdentityError DuplicateEmail(string email)
+        {
+            return new CustomIdentityError
+            (
+                base.DuplicateEmail(email),
+                email
+            );
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError"/> indicating the specified <paramref name="role"/> name is invalid.
+        /// </summary>
+        /// <param name="role">The invalid role.</param>
+        /// <returns>An <see cref="IdentityError"/> indicating the specific role <paramref name="role"/> name is invalid.</returns>
+        public override IdentityError InvalidRoleName(string role)
+        {
+            return new CustomIdentityError
+            (
+                base.InvalidRoleName(role),
+                role
+            );
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError"/> indicating the specified <paramref name="role"/> name already exists.
+        /// </summary>
+        /// <param name="role">The duplicate role.</param>
+        /// <returns>An <see cref="IdentityError"/> indicating the specific role <paramref name="role"/> name already exists.</returns>
+        public override IdentityError DuplicateRoleName(string role)
+        {
+            return new CustomIdentityError
+            (
+                base.DuplicateRoleName(role),
+                role
+            );
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError"/> indicating a user is already in the specified <paramref name="role"/>.
+        /// </summary>
+        /// <param name="role">The duplicate role.</param>
+        /// <returns>An <see cref="IdentityError"/> indicating a user is already in the specified <paramref name="role"/>.</returns>
+        public override IdentityError UserAlreadyInRole(string role)
+        {
+            return new CustomIdentityError
+            (
+                base.UserAlreadyInRole(role),
+                role
+            );
+        }
+
+        /// <summary>
+        /// Returns an <see cref="IdentityError"/> indicating a user is not in the specified <paramref name="role"/>.
+        /// </summary>
+        /// <param name="role">The duplicate role.</param>
+        /// <returns>An <see cref="IdentityError"/> indicating a user is not in the specified <paramref name="role"/>.</returns>
+        public override IdentityError UserNotInRole(string role)
+        {
+            return new CustomIdentityError
+            (
+                base.UserNotInRole(role),
+                role
+            );
+        }
+
         /// <summary>
         /// Returns an <see cref="IdentityError"/> indicating a password of the specified <paramref name="length"/> does not meet the minimum length requirements.
         /// </summary>
@@ -15,10 +129,10 @@ namespace VirtoCommerce.Platform.Security
         public override IdentityError PasswordTooShort(int length)
         {
             return new CustomIdentityError
-            {
-                Code = nameof(PasswordTooShort),
-                ErrorParameter = length
-            };
+            (
+                base.PasswordTooShort(length),
+                length
+            );
         }
 
         /// <summary>
@@ -29,10 +143,12 @@ namespace VirtoCommerce.Platform.Security
         public override IdentityError PasswordRequiresUniqueChars(int uniqueChars)
         {
             return new CustomIdentityError
-            {
-                Code = nameof(PasswordRequiresUniqueChars),
-                ErrorParameter = uniqueChars
-            };
+            (
+                base.PasswordRequiresUniqueChars(uniqueChars),
+                uniqueChars
+            );
         }
+
+
     }
 }

--- a/tests/VirtoCommerce.Platform.Web.Tests/Security/CustomPasswordValidatorTests.cs
+++ b/tests/VirtoCommerce.Platform.Web.Tests/Security/CustomPasswordValidatorTests.cs
@@ -102,7 +102,7 @@ namespace VirtoCommerce.Platform.Web.Tests.Security
             {
                 var tooShort = TryFindErrorByCode(result, nameof(IdentityErrorDescriber.PasswordTooShort));
                 Assert.IsType<CustomIdentityError>(tooShort);
-                Assert.Equal(minLength, ((CustomIdentityError)tooShort).ErrorParameter);
+                Assert.Equal(minLength, int.Parse(((CustomIdentityError)tooShort).Parameter));
             }
 
             Assert.Equal(expectedMustHaveUpper, ExistsErrorByCode(result, nameof(IdentityErrorDescriber.PasswordRequiresUpper)));


### PR DESCRIPTION
## Description
Store identity error value as a separate error parameter allowing to propagate error details separately from the error description
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/PT-9132
### Artifact URL:
