### PR TITLE
fix: Bump Microsoft.Identity.Client to 4.22.0

### DIFF
--- a/src/VirtoCommerce.Platform.Data/VirtoCommerce.Platform.Data.csproj
+++ b/src/VirtoCommerce.Platform.Data/VirtoCommerce.Platform.Data.csproj
@@ -28,6 +28,7 @@
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options.ConfigurationExtensions" Version="6.0.0" />
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.0" />
+        <PackageReference Include="Microsoft.Identity.Client" Version="4.22.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="Nager.Country" Version="3.1.1" />
         <PackageReference Include="Serialize.Linq" Version="1.8.1" />


### PR DESCRIPTION
## Description
We need NuGet packages for SharePoint online interactions:

- Microsoft.Identity.Web.Certificate depends on Azure.Identity ≥ 1.3.0
- Azure.Identity 1.3.0 depends on Microsoft.Identity.Client ≥ 4.22.0

## References
### QA-test:
### Jira-link:
### Artifact URL:
