### PR TITLE
PT-9939: An error in console Cannot read properties of undefined (reading isReadOnly)

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/settings/blades/setting-dictionary.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/settings/blades/setting-dictionary.js
@@ -92,7 +92,7 @@ angular.module('platformWebApp').controller('platformWebApp.settingDictionaryCon
             addNew();
         },
         canExecuteMethod: function () {
-            return !blade.currentEntity.isReadOnly;
+            return blade.currentEntity && !blade.currentEntity.isReadOnly;
         }
     },
     {
@@ -101,7 +101,7 @@ angular.module('platformWebApp').controller('platformWebApp.settingDictionaryCon
             deleteChecked();
         },
         canExecuteMethod: function () {
-            return !blade.currentEntity.isReadOnly && isItemsChecked();
+            return blade.currentEntity && !blade.currentEntity.isReadOnly && isItemsChecked();
         }
     }];
 


### PR DESCRIPTION
fix: An error in console "Cannot read properties of undefined (reading 'isReadOnly')" when open settings blade to Manage dictionary values in Catalog, Store, Customers, etc blades.

## Description

## References
### QA-test:
### Jira-link:
### Artifact URL:
