### PR TITLE
PT-9049: Update StackExchange.Redis From 2.1. To 2.6.86

### DIFF
--- a/src/VirtoCommerce.Platform.Caching/VirtoCommerce.Platform.Caching.csproj
+++ b/src/VirtoCommerce.Platform.Caching/VirtoCommerce.Platform.Caching.csproj
@@ -25,7 +25,7 @@
         <PackageReference Include="Microsoft.Extensions.Options.DataAnnotations" Version="6.0.0" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
         <PackageReference Include="Polly" Version="7.2.1" />
-        <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
+        <PackageReference Include="StackExchange.Redis" Version="2.6.86" />
     </ItemGroup>
 
     <ItemGroup>

--- a/src/VirtoCommerce.Platform.DistributedLock/VirtoCommerce.Platform.DistributedLock.csproj
+++ b/src/VirtoCommerce.Platform.DistributedLock/VirtoCommerce.Platform.DistributedLock.csproj
@@ -19,7 +19,7 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="StackExchange.Redis" Version="2.1.58" />
+        <PackageReference Include="StackExchange.Redis" Version="2.6.86" />
         <PackageReference Include="RedLock.net" Version="2.2.0" />
     </ItemGroup>
 


### PR DESCRIPTION
## Description
feat: Update StackExchange.Redis From 2.1. To 2.6.86.  [ReleaseNotes](https://stackexchange.github.io/StackExchange.Redis/ReleaseNotes), [Configuration](https://stackexchange.github.io/StackExchange.Redis/Configuration)

## References
### QA-test:
### Jira-link:
### Artifact URL:
