### PR TITLE
fix: Auth ClaimTypeMap Clearing breaks external AzureAd Auth

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -280,8 +280,6 @@ namespace VirtoCommerce.Platform.Web
             // register it as a singleton to use in extenral login providers
             services.AddSingleton(defaultTokenHandler);
 
-            JwtSecurityTokenHandler.DefaultInboundClaimTypeMap.Clear();
-            JwtSecurityTokenHandler.DefaultOutboundClaimTypeMap.Clear();
             authBuilder.AddJwtBearer(options =>
             {
                 options.Authority = Configuration["Auth:Authority"];


### PR DESCRIPTION
## Description
fix: Auth ClaimTypeMap Clearing breaks external AzureAd #1780

## References
### QA-test:
### Jira-link:
### Artifact URL:
