### PR TITLE
PT-10998: move  AI telemetry in the end of ConfigureServices method

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -463,13 +463,6 @@ namespace VirtoCommerce.Platform.Web
             // Register the Swagger generator
             services.AddSwagger(Configuration, platformOptions.UseAllOfToExtendReferenceSchemas);
 
-            // The following line enables Application Insights telemetry collection.
-            // CAUTION: It is important to keep the adding AI telemetry in the end of ConfigureServices method in order to avoid of multiple
-            // AI modules initialization https://virtocommerce.atlassian.net/browse/VP-6653 and  https://github.com/microsoft/ApplicationInsights-dotnet/issues/2114 until we don't
-            // get rid of calling IServiceCollection.BuildServiceProvider from the platform and modules code, each BuildServiceProvider call leads to the running the
-            // extra AI module and causes the hight CPU utilization and telemetry data flood on production env.
-            services.AddAppInsightsTelemetry(Configuration);
-
             services.AddHealthChecks()
                 .AddCheck<ModulesHealthChecker>("Modules health",
                     failureStatus: HealthStatus.Degraded,
@@ -483,6 +476,13 @@ namespace VirtoCommerce.Platform.Web
             services.AddOptions<LoginPageUIOptions>().Bind(loginPageUIOptions);
             services.AddDatabaseDeveloperPageExceptionFilter();
             services.AddHttpClient();
+
+            // The following line enables Application Insights telemetry collection.
+            // CAUTION: It is important to keep the adding AI telemetry in the end of ConfigureServices method in order to avoid of multiple
+            // AI modules initialization https://virtocommerce.atlassian.net/browse/VP-6653 and  https://github.com/microsoft/ApplicationInsights-dotnet/issues/2114 until we don't
+            // get rid of calling IServiceCollection.BuildServiceProvider from the platform and modules code, each BuildServiceProvider call leads to the running the
+            // extra AI module and causes the hight CPU utilization and telemetry data flood on production env.
+            services.AddAppInsightsTelemetry(Configuration);
         }
 
         public static ServerCertificate GetServerCertificate(ICertificateLoader certificateLoader)


### PR DESCRIPTION
## Description
fix: move  AI telemetry in the end of ConfigureServices method in order to avoid of multiple AI modules initialization.

## References
### QA-test:
### Jira-link:
### Artifact URL:
