### PR TITLE
PT-10831: login/email overlaps text in modal

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/en.VirtoCommerce.Platform.json
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/en.VirtoCommerce.Platform.json
@@ -330,7 +330,8 @@
             },
             "account-changePassword": {
                 "labels": {
-                    "title": "Please enter a new password for the '{{userName}}' user",
+                    "title": "Please enter a new password",
+                    "login": "Login",
                     "force-change-info": "Your password has expired. You must <b>change the password to continue</b> using the manager.",
                     "current-password": "Current password",
                     "new-password": "New password",

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/security/dialogs/changePasswordDialog.tpl.html
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/security/dialogs/changePasswordDialog.tpl.html
@@ -6,11 +6,18 @@
          </div>
          <header class="window-head" ng-class="{'warning': !canCancel}">
              <img class="__logo" ng-src="{{uiCustomization.contrast_logo || '/images/contrast-logo.svg'}}" />
-             <span class="window-t">{{ 'platform.blades.account-changePassword.labels.title' | translate: {userName: userName} }}</span>
+             <span class="window-t">{{ 'platform.blades.account-changePassword.labels.title' | translate}}</span>
          </header>
          <div class="window-cnt">
              <form class="form" novalidate ng-submit="ok()" name="changePasswordForm">
                  <p ng-if="!canCancel" translate="platform.blades.account-changePassword.labels.force-change-info"></p>
+                 <div class="form-group">
+                     <label class="form-label">{{ 'platform.blades.account-changePassword.labels.login' | translate }}</label>
+                     <div class="form-input">
+                         <input name="userName" readonly ng-model="userName"/>
+                     </div>
+                 </div>
+
                  <div class="form-group">
                      <label class="form-label required">{{ 'platform.blades.account-changePassword.labels.current-password' | translate }}</label>
                      <div class="form-input">


### PR DESCRIPTION
## Description
fix: Improve UX for change password dialog to resolve Login/Email overlaps text in modal header

![image](https://user-images.githubusercontent.com/7639413/227952443-9e827cb6-12a1-49be-af02-a1522344181e.png)


## References
### QA-test:
### Jira-link:
### Artifact URL:
