### PR TITLE
fixed posgresql commands to load the certificate

### DIFF
--- a/src/VirtoCommerce.Platform.Data.PostgreSql/PostgreSqlCertificateLoader.cs
+++ b/src/VirtoCommerce.Platform.Data.PostgreSql/PostgreSqlCertificateLoader.cs
@@ -58,14 +58,14 @@ namespace VirtoCommerce.Platform.Data.PostgreSql
                 var builder = new NpgsqlConnectionStringBuilder(connectionString);
 
                 const string cmdCheckMigration =
-                    @"select 1 from information_schema.TABLES where TABLE_SCHEMA = @dbName AND TABLE_NAME='ServerCertificate'";
+                    @"SELECT 1 FROM pg_tables
+                      WHERE
+                         schemaname = 'public' AND
+                         tablename  = 'ServerCertificate'
+                    ;";
 
                 const string cmdServerCert =
-                    @"SELECT Id
-                    ,PublicCertBase64
-                    ,PrivateKeyCertBase64
-                    ,PrivateKeyCertPassword
-                FROM ServerCertificate LIMIT 1";
+                    "SELECT \"Id\",\"PublicCertBase64\",\"PrivateKeyCertBase64\",\"PrivateKeyCertPassword\" FROM \"ServerCertificate\" LIMIT 1";
 
                 const int ixId = 0;
                 const int ixPublicCertBase64 = 1;


### PR DESCRIPTION
## Description
Sql commands to load the certificate are not correct for postgresql.
Fixed the command to check the presence of ServerCertificate table and the command to load the certificate.
Verified with PostgreSQL 15.2
Without this fix the number of rows in ServerCertificate table is incremented each time the application is restarted
## References
### QA-test:
### Jira-link:
### Artifact URL:
