### PR TITLE
fix for lock user account when db provider is PostreSql

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Controllers/Api/SecurityController.cs
+++ b/src/VirtoCommerce.Platform.Web/Controllers/Api/SecurityController.cs
@@ -804,7 +804,7 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
             var user = await UserManager.FindByIdAsync(id);
             if (user != null)
             {
-                var result = await UserManager.SetLockoutEndDateAsync(user, DateTime.MaxValue);
+                var result = await UserManager.SetLockoutEndDateAsync(user, DateTime.MaxValue.ToUniversalTime());
                 return Ok(result.ToSecurityResult());
             }
 
@@ -825,7 +825,7 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
             if (user != null)
             {
                 await UserManager.ResetAccessFailedCountAsync(user);
-                var result = await UserManager.SetLockoutEndDateAsync(user, DateTimeOffset.MinValue);
+                var result = await UserManager.SetLockoutEndDateAsync(user, DateTimeOffset.MinValue.ToUniversalTime());
                 return Ok(result.ToSecurityResult());
             }
 


### PR DESCRIPTION
## Description
Both DateTime.MaxValue and DateTime.MinValue has Unspecified kind. There's an error when trying to save such a value to PostgreSql database.
This fix converts the dates into the universal time and "Lock account" works ok.
It was verified with PostgreSQL 15.2 and MySql 5.7 versions (Security/Users/account Lock account command)
## References
### QA-test:
### Jira-link:
### Artifact URL:
