### PR TITLE
PT-12153: Add "AllowApiAccessForCustomers" setting. 

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Security/AuthorizationOptions.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/AuthorizationOptions.cs
@@ -17,6 +17,14 @@ namespace VirtoCommerce.Platform.Core.Security
         // then no limitations should be applied to the permissions.
         public string LimitedCookiePermissions { get; set; }
 
+        /// <summary>
+        /// Allows API returns password Hash and TimeStamp. By default, false.
+        /// </summary>
         public bool ReturnPasswordHash { get; set; }
+
+        /// <summary>
+        /// Allows customers to access the API endpoints and perform authorized actions. By default, false.
+        /// </summary>
+        public bool AllowApiAccessForCustomers { get; set; }
     }
 }

--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -411,6 +411,7 @@ namespace VirtoCommerce.Platform.Web
                     .RequireAuthenticatedUser()
                     // Customer user can get token, but can't use any API where auth is needed
                     .RequireAssertion(context =>
+                        authorizationOptions.AllowApiAccessForCustomers ||
                         !context.User.HasClaim(OpenIddictConstants.Claims.Role, PlatformConstants.Security.SystemRoles.Customer))
                     .Build();
                 //The good article is described the meaning DefaultPolicy and FallbackPolicy

--- a/src/VirtoCommerce.Platform.Web/appsettings.json
+++ b/src/VirtoCommerce.Platform.Web/appsettings.json
@@ -174,7 +174,8 @@
     "ReturnPasswordHash": true,
     "RefreshTokenLifeTime": "30.00:00:00",
     "AccessTokenLifeTime": "00:30:00",
-    "LimitedCookiePermissions": "platform:asset:read;platform:export;content:read;platform:asset:create;licensing:issue;export:download"
+    "LimitedCookiePermissions": "platform:asset:read;platform:export;content:read;platform:asset:create;licensing:issue;export:download",
+    "AllowApiAccessForCustomers": false
   },
   "AzureAd": {
     "Enabled": false,


### PR DESCRIPTION
## Description
feat: Add "AllowApiAccessForCustomers" setting. Enables or disables API access for customers.  By default, false. When set to true, it allows customers to access the API endpoints and perform authorized actions. 

App settings section: Authorization:AllowApiAccessForCustomers.

```json
 "Authorization": {
...
    "AllowApiAccessForCustomers": true,
...
  },
```

## References
### QA-test:
### Jira-link:
### Artifact URL:
