### PR TITLE
PT-12295: Assign permissions section on New Role blade displays unsorted list of modules 

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/security/blades/role-detail.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/security/blades/role-detail.js
@@ -1,7 +1,7 @@
 angular.module('platformWebApp').controller('platformWebApp.roleDetailController', ['$q', '$scope', 'platformWebApp.bladeNavigationService', 'platformWebApp.roles', 'platformWebApp.dialogService', function ($q, $scope, bladeNavigationService, roles, dialogService) {
     var blade = $scope.blade;
     blade.updatePermission = 'platform:security:update';
-    var promise = roles.queryPermissions().$promise;
+    var promise = roles.queryPermissions({ take: 10000 }).$promise;
 
     blade.refresh = function (parentRefresh) {
         if (blade.isNew) {
@@ -25,6 +25,14 @@ angular.module('platformWebApp').controller('platformWebApp.roleDetailController
             promise.then(function (promiseData) {
                 blade.isLoading = false;
                 blade.currentEntities = _.groupBy(promiseData, 'groupName');
+
+                blade.currentEntities = Object.keys(blade.currentEntities).sort().reduce(
+                    (obj, key) => {
+                        obj[key] = blade.currentEntities[key];
+                        return obj;
+                    },
+                    {}
+                );
             });
         } else {
             blade.isLoading = false;

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/security/wizards/new-role-wizard.tpl.html
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/security/wizards/new-role-wizard.tpl.html
@@ -24,7 +24,7 @@
             <div class="list __items" ng-init="openItems=[]">
                 <div class="list-group" ng-class="{'__opened': openItems[$index]}" ng-click="openItems[$index]=!openItems[$index]" ng-repeat-start="(key,values) in blade.currentEntities">{{key}}</div>
                 <div class="list __sub" ng-repeat-end>
-                    <label class="list-item" ng-repeat="data in values">
+                    <label class="list-item" ng-repeat="data in values | orderBy:'name'">
                         <input type="checkbox" ng-model="data.isChecked">
                         <span class="switch"></span>
                         <span class="list-name">{{ data.name }}</span>


### PR DESCRIPTION
## Description
fix: "Assign permissions" section on "New Role" blade displays unsorted list of modules.

## References
### QA-test:
### Jira-link:
### Artifact URL:
