### PR TITLE
PT-12552: Bump jQuery from 2.1.4 to 3.7.0

### DIFF
--- a/src/VirtoCommerce.Platform.Web/npm-shrinkwrap.json
+++ b/src/VirtoCommerce.Platform.Web/npm-shrinkwrap.json
@@ -40,8 +40,7 @@
         "bourbon": "~7.3.0",
         "codemirror": "~5.45.0",
         "font-awesome": "~4.7.0",
-        "glob": "~7.1.7",
-        "jquery": "^2.1.4",
+        "jquery": "^3.7.0",
         "marked": "^4.2.12",
         "moment-timezone": "0.5.13",
         "ng-focus-on": "~0.2.2",
@@ -59,6 +58,7 @@
       "devDependencies": {
         "clean-webpack-plugin": "^4.0.0",
         "css-loader": "^6.5.1",
+        "glob": "~7.1.7",
         "mini-css-extract-plugin": "^2.5.1",
         "node-bourbon": "~4.2.8",
         "path": "~0.12.7",
@@ -3205,9 +3205,9 @@
       }
     },
     "node_modules/jquery": {
-      "version": "2.2.4",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-2.2.4.tgz",
-      "integrity": "sha512-lBHj60ezci2u1v2FqnZIraShGgEXq35qCzMv4lITyHGppTnA13rwR0MgwyNJh9TnDs3aXUvd1xjAotfraMHX/Q=="
+      "version": "3.7.0",
+      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.7.0.tgz",
+      "integrity": "sha512-umpJ0/k8X0MvD1ds0P9SfowREz2LenHsQaxSohMZ5OMNEU2r0tf8pdeEFTHMFxWVxKNyU9rTtK3CWzUCTKJUeQ=="
     },
     "node_modules/jquery-ui": {
       "version": "1.13.2",
@@ -6523,11 +6523,6 @@
       "dependencies": {
         "postcss": "^6.0.1"
       }
-    },
-    "node_modules/webpack-jquery-ui/node_modules/jquery": {
-      "version": "3.6.3",
-      "resolved": "https://registry.npmjs.org/jquery/-/jquery-3.6.3.tgz",
-      "integrity": "sha512-bZ5Sy3YzKo9Fyc8wH2iIQK4JImJ6R0GWI9kL1/k7Z91ZBNgkRXE6U0JfHIizZbort8ZunhSI3jw9I6253ahKfg=="
     },
     "node_modules/webpack-jquery-ui/node_modules/loader-runner": {
       "version": "2.4.0",

--- a/src/VirtoCommerce.Platform.Web/package.json
+++ b/src/VirtoCommerce.Platform.Web/package.json
@@ -10,14 +10,14 @@
   "devDependencies": {
     "clean-webpack-plugin": "^4.0.0",
     "css-loader": "^6.5.1",
+    "glob": "~7.1.7",
     "mini-css-extract-plugin": "^2.5.1",
     "node-bourbon": "~4.2.8",
     "path": "~0.12.7",
     "sass": "~1.58.3",
     "sass-loader": "~12.6.0",
     "webpack": "^5.68.0",
-    "webpack-cli": "^4.10.0",
-    "glob": "~7.1.7"
+    "webpack-cli": "^4.10.0"
   },
   "dependencies": {
     "@aspnet/signalr": "~1.1.4",
@@ -52,7 +52,7 @@
     "bourbon": "~7.3.0",
     "codemirror": "~5.45.0",
     "font-awesome": "~4.7.0",
-    "jquery": "^2.1.4",
+    "jquery": "^3.7.0",
     "marked": "^4.2.12",
     "moment-timezone": "0.5.13",
     "ng-focus-on": "~0.2.2",


### PR DESCRIPTION
## Description
fix: Bump jQuery from 2.1.4 to 3.7.0

## References
### QA-test:
### Jira-link:
### Artifact URL:
