### PR TITLE
VM-1179: Fix exception if no database already created in PostgreSql

### DIFF
--- a/src/VirtoCommerce.Platform.Hangfire/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Hangfire/Extensions/ServiceCollectionExtensions.cs
@@ -16,7 +16,7 @@ namespace VirtoCommerce.Platform.Hangfire.Extensions
             var connectionString = configuration.GetConnectionString("VirtoCommerce.Hangfire") ?? configuration.GetConnectionString("VirtoCommerce");
 
             // Prevent Hangfire to apply migrations (prepare schema) here because database may not exist yet.
-            // Migrations will forced to apply at ApplicationBuilderExtensions.UseHangfire
+            // Migrations will be forced to apply at ApplicationBuilderExtensions.UseHangfire
             switch (databaseProvider)
             {
                 case "PostgreSql":

--- a/src/VirtoCommerce.Platform.Hangfire/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Hangfire/Extensions/ServiceCollectionExtensions.cs
@@ -15,8 +15,8 @@ namespace VirtoCommerce.Platform.Hangfire.Extensions
             var databaseProvider = configuration.GetValue("DatabaseProvider", "SqlServer");
             var connectionString = configuration.GetConnectionString("VirtoCommerce.Hangfire") ?? configuration.GetConnectionString("VirtoCommerce");
 
-            // Call UseStorage with fake StorageOptions to avoid Hangfire tries to apply its migrations because these never do in case of database absence.
-            // Real options provided in ApplicationBuilderExtensions.UseHangfire where migrations forced to apply.
+            // Prevent Hangfire to apply migrations (prepare schema) here because database may not exist yet.
+            // Migrations will forced to apply at ApplicationBuilderExtensions.UseHangfire
             switch (databaseProvider)
             {
                 case "PostgreSql":

--- a/src/VirtoCommerce.Platform.Hangfire/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Hangfire/Extensions/ServiceCollectionExtensions.cs
@@ -15,6 +15,8 @@ namespace VirtoCommerce.Platform.Hangfire.Extensions
             var databaseProvider = configuration.GetValue("DatabaseProvider", "SqlServer");
             var connectionString = configuration.GetConnectionString("VirtoCommerce.Hangfire") ?? configuration.GetConnectionString("VirtoCommerce");
 
+            // Call UseStorage with fake StorageOptions to avoid Hangfire tries to apply its migrations because these never do in case of database absence.
+            // Real options provided in ApplicationBuilderExtensions.UseHangfire where migrations forced to apply.
             switch (databaseProvider)
             {
                 case "PostgreSql":
@@ -26,8 +28,6 @@ namespace VirtoCommerce.Platform.Hangfire.Extensions
                         new MySqlStorageOptions { PrepareSchemaIfNecessary = false }));
                     break;
                 default:
-                    // Call UseSqlServerStorage with fake SqlServerStorageOptions to avoid Hangfire tries to apply its migrations because these never do in case of database absence.
-                    // Real options provided in ApplicationBuilderExtensions.UseHangfire where migrations forced to apply.
                     globalConfiguration.UseSqlServerStorage(connectionString,
                         new SqlServerStorageOptions { PrepareSchemaIfNecessary = false });
                     break;

--- a/src/VirtoCommerce.Platform.Hangfire/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Hangfire/Extensions/ServiceCollectionExtensions.cs
@@ -18,7 +18,8 @@ namespace VirtoCommerce.Platform.Hangfire.Extensions
             switch (databaseProvider)
             {
                 case "PostgreSql":
-                    globalConfiguration.UsePostgreSqlStorage(connectionString);
+                    globalConfiguration.UsePostgreSqlStorage(connectionString,
+                        new PostgreSqlStorageOptions { PrepareSchemaIfNecessary = false });
                     break;
                 case "MySql":
                     globalConfiguration.UseStorage(new MySqlStorage(connectionString,


### PR DESCRIPTION
## Description

Hangfire fire exception if there is no already created database when use PostreSql because of missed workaround already available for MySql and SqlServer.

## References
### QA-test:
### Jira-link:
### Artifact URL:
