### PR TITLE
PT-10550: adds the security headers to all responses

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Web/Extensions/ApplicationBuilderExtensions.cs
@@ -6,8 +6,6 @@ using Microsoft.AspNetCore.Builder;
 using Microsoft.AspNetCore.Http;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.FileProviders;
-using Microsoft.Extensions.Primitives;
-using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Modularity;
 using VirtoCommerce.Platform.Core.Modularity.Exceptions;
 using VirtoCommerce.Platform.Core.Settings;
@@ -19,11 +17,6 @@ namespace VirtoCommerce.Platform.Web.Extensions
 {
     public static class ApplicationBuilderExtensions
     {
-        private static readonly Dictionary<string, StringValues> CustomHeaders = new()
-        {
-            { "X-Frame-Options", new StringValues("SAMEORIGIN") }
-        };
-
         public static IApplicationBuilder UsePlatformSettings(this IApplicationBuilder appBuilder)
         {
             var settingsRegistrar = appBuilder.ApplicationServices.GetRequiredService<ISettingsRegistrar>();
@@ -58,17 +51,6 @@ namespace VirtoCommerce.Platform.Web.Extensions
                     moduleManager.PostInitializeModule(module, appBuilder);
                 }
             }
-            return appBuilder;
-        }
-
-        public static IApplicationBuilder UseSecurityHeaders(this IApplicationBuilder appBuilder)
-        {
-            appBuilder.Use(async (context, next) =>
-            {
-                context.Response.Headers.AddRange(CustomHeaders);
-                await next();
-            });
-
             return appBuilder;
         }
 

--- a/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
+++ b/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
     <PropertyGroup>
         <TargetFramework>net6.0</TargetFramework>
         <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -37,6 +37,7 @@
         <PackageReference Include="Microsoft.Identity.Client" Version="4.45.0" />
         <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.10.8" />
         <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
+        <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.20.0" />
         <PackageReference Include="OpenIddict.AspNetCore" Version="3.0.4" />
         <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="3.0.4" />
         <PackageReference Include="Serilog.AspNetCore" Version="6.1.0" />


### PR DESCRIPTION
## Description
feat: Adds the following security headers to all responses:
* X-Content-Type-Options: nosniff
Strict-Transport-Security: max-age=31536000; includeSubDomains - only applied to HTTPS responses
* X-Frame-Options: Deny - only applied to "document" responses
* X-XSS-Protection: 1; mode=block - only applied to "document" responses
* Referrer-Policy: strict-origin-when-cross-origin - only applied to "document" responses
* Content-Security-Policy: object-src 'none'; form-action 'self'; frame-ancestors 'none' - only applied to "document" responses

by using https://github.com/andrewlock/NetEscapades.AspNetCore.SecurityHeaders

## References
### QA-test:
### Jira-link:
### Artifact URL:
