### PR TITLE
PT-13993: Left-click Menu Is being placed above top

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/css/themes/main/sass/modules/_base-modules.sass
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/css/themes/main/sass/modules/_base-modules.sass
@@ -167,6 +167,8 @@ ol
 .menu.__context.open,
 .menu.__context.__open
   display: block
+  max-height: 50vh
+  overflow-y: auto
 
 .splited-element:last-child
   border-top-color: white


### PR DESCRIPTION
## Description
fix: Left-click Menu Is being placed above top of screen for menus with many items. Added max-height and scroll-bar. 
 
![image](https://github.com/VirtoCommerce/vc-platform/assets/7639413/792c4a4b-40f3-49d2-882e-8076310d290c)

## References
### QA-test:
### Jira-link:
### Artifact URL:
