### PR TITLE
PT-13884: Dynamic dictionary item name must be required.

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Exceptions/InvalidCollectionItemException.cs
+++ b/src/VirtoCommerce.Platform.Core/Exceptions/InvalidCollectionItemException.cs
@@ -1,0 +1,13 @@
+using System;
+
+namespace VirtoCommerce.Platform.Core.Exceptions
+{
+    public class InvalidCollectionItemException : Exception
+    {
+        public InvalidCollectionItemException() { }
+
+        public InvalidCollectionItemException(string message) : base(message) { }
+
+        public InvalidCollectionItemException(string message, Exception innerException) : base(message, innerException) { }
+    }
+}

--- a/src/VirtoCommerce.Platform.Data.MySql/Migrations/Data/20231026084751_DynamicPropertyItemNameRequired.Designer.cs
+++ b/src/VirtoCommerce.Platform.Data.MySql/Migrations/Data/20231026084751_DynamicPropertyItemNameRequired.Designer.cs
@@ -2,62 +2,61 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VirtoCommerce.Platform.Data.Repositories;
 
 #nullable disable
 
-namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
+namespace VirtoCommerce.Platform.Data.MySql.Migrations.Data
 {
     [DbContext(typeof(PlatformDbContext))]
-    partial class PlatformDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231026084751_DynamicPropertyItemNameRequired")]
+    partial class DynamicPropertyItemNameRequired
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "6.0.13")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
-
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
+                .HasAnnotation("Relational:MaxIdentifierLength", 64);
 
             modelBuilder.Entity("VirtoCommerce.Platform.Data.Localizations.LocalizedItemEntity", b =>
                 {
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("Alias")
                         .HasMaxLength(512)
-                        .HasColumnType("nvarchar(512)");
+                        .HasColumnType("varchar(512)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("LanguageCode")
                         .HasMaxLength(512)
-                        .HasColumnType("nvarchar(512)");
+                        .HasColumnType("varchar(512)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("Value")
                         .HasMaxLength(512)
-                        .HasColumnType("nvarchar(512)");
+                        .HasColumnType("varchar(512)");
 
                     b.HasKey("Id");
 
@@ -72,36 +71,35 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(512)
-                        .HasColumnType("nvarchar(512)");
+                        .HasColumnType("varchar(512)");
 
                     b.Property<string>("PropertyId")
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("PropertyId", "Name")
                         .IsUnique()
-                        .HasDatabaseName("IX_PlatformDynamicPropertyDictionaryItem_PropertyId_Name")
-                        .HasFilter("[PropertyId] IS NOT NULL");
+                        .HasDatabaseName("IX_PlatformDynamicPropertyDictionaryItem_PropertyId_Name");
 
                     b.ToTable("PlatformDynamicPropertyDictionaryItem", (string)null);
                 });
@@ -111,39 +109,38 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("DictionaryItemId")
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("Locale")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(512)
-                        .HasColumnType("nvarchar(512)");
+                        .HasColumnType("varchar(512)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("DictionaryItemId", "Locale", "Name")
                         .IsUnique()
-                        .HasDatabaseName("IX_PlatformDynamicPropertyDictionaryItemName_DictionaryItemId_Locale_Name")
-                        .HasFilter("[DictionaryItemId] IS NOT NULL AND [Locale] IS NOT NULL AND [Name] IS NOT NULL");
+                        .HasDatabaseName("IX_PlatformDynamicPropertyDictionaryItemName_DictionaryItemId_Locale_Name");
 
                     b.ToTable("PlatformDynamicPropertyDictionaryItemName", (string)null);
                 });
@@ -153,60 +150,59 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Description")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("varchar(256)");
 
                     b.Property<int?>("DisplayOrder")
                         .HasColumnType("int");
 
                     b.Property<bool>("IsArray")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsDictionary")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsMultilingual")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<bool>("IsRequired")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("varchar(256)");
 
                     b.Property<string>("ObjectType")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("varchar(256)");
 
                     b.Property<string>("ValueType")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("ObjectType", "Name")
                         .IsUnique()
-                        .HasDatabaseName("IX_PlatformDynamicProperty_ObjectType_Name")
-                        .HasFilter("[ObjectType] IS NOT NULL AND [Name] IS NOT NULL");
+                        .HasDatabaseName("IX_PlatformDynamicProperty_ObjectType_Name");
 
                     b.ToTable("PlatformDynamicProperty", (string)null);
                 });
@@ -216,39 +212,38 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Locale")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("varchar(256)");
 
                     b.Property<string>("PropertyId")
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("PropertyId", "Locale", "Name")
                         .IsUnique()
-                        .HasDatabaseName("IX_PlatformDynamicPropertyName_PropertyId_Locale_Name")
-                        .HasFilter("[PropertyId] IS NOT NULL AND [Locale] IS NOT NULL AND [Name] IS NOT NULL");
+                        .HasDatabaseName("IX_PlatformDynamicPropertyName_PropertyId_Locale_Name");
 
                     b.ToTable("PlatformDynamicPropertyName", (string)null);
                 });
@@ -258,38 +253,38 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Detail")
                         .HasMaxLength(2048)
-                        .HasColumnType("nvarchar(2048)");
+                        .HasColumnType("varchar(2048)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ObjectId")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("varchar(200)");
 
                     b.Property<string>("ObjectType")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("varchar(50)");
 
                     b.Property<string>("OperationType")
                         .IsRequired()
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("varchar(20)");
 
                     b.HasKey("Id");
 
@@ -304,10 +299,10 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("Data")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.HasKey("Id");
 
@@ -319,33 +314,33 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("ObjectId")
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("ObjectType")
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.HasKey("Id");
 
@@ -360,20 +355,20 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<bool>("BooleanValue")
-                        .HasColumnType("bit");
+                        .HasColumnType("tinyint(1)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<DateTime?>("DateTimeValue")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<decimal>("DecimalValue")
                         .HasColumnType("decimal(18,5)");
@@ -382,26 +377,26 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                         .HasColumnType("int");
 
                     b.Property<string>("LongTextValue")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("longtext");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("datetime(6)");
 
                     b.Property<string>("SettingId")
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("varchar(128)");
 
                     b.Property<string>("ShortTextValue")
                         .HasMaxLength(512)
-                        .HasColumnType("nvarchar(512)");
+                        .HasColumnType("varchar(512)");
 
                     b.Property<string>("ValueType")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("varchar(64)");
 
                     b.HasKey("Id");
 

--- a/src/VirtoCommerce.Platform.Data.MySql/Migrations/Data/20231026084751_DynamicPropertyItemNameRequired.cs
+++ b/src/VirtoCommerce.Platform.Data.MySql/Migrations/Data/20231026084751_DynamicPropertyItemNameRequired.cs
@@ -1,0 +1,47 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtoCommerce.Platform.Data.MySql.Migrations.Data
+{
+    public partial class DynamicPropertyItemNameRequired : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.UpdateData(
+                table: "PlatformDynamicPropertyDictionaryItem",
+                keyColumn: "Name",
+                keyValue: null,
+                column: "Name",
+                value: "");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "PlatformDynamicPropertyDictionaryItem",
+                type: "varchar(512)",
+                maxLength: 512,
+                nullable: false,
+                oldClrType: typeof(string),
+                oldType: "varchar(512)",
+                oldMaxLength: 512,
+                oldNullable: true)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "PlatformDynamicPropertyDictionaryItem",
+                type: "varchar(512)",
+                maxLength: 512,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "varchar(512)",
+                oldMaxLength: 512)
+                .Annotation("MySql:CharSet", "utf8mb4")
+                .OldAnnotation("MySql:CharSet", "utf8mb4");
+        }
+    }
+}

--- a/src/VirtoCommerce.Platform.Data.MySql/Migrations/Data/PlatformDbContextModelSnapshot.cs
+++ b/src/VirtoCommerce.Platform.Data.MySql/Migrations/Data/PlatformDbContextModelSnapshot.cs
@@ -86,6 +86,7 @@ namespace VirtoCommerce.Platform.Data.MySql.Migrations.Data
                         .HasColumnType("datetime(6)");
 
                     b.Property<string>("Name")
+                        .IsRequired()
                         .HasMaxLength(512)
                         .HasColumnType("varchar(512)");
 

--- a/src/VirtoCommerce.Platform.Data.MySql/Readme.md
+++ b/src/VirtoCommerce.Platform.Data.MySql/Readme.md
@@ -3,15 +3,15 @@
 dotnet tool install --global dotnet-ef --version 6.0.13
 ```
 
-## Generate Migrations**
-
+## Generate PlatformDbContext Migrations
 ```
-dotnet ef migrations add Initial 
-dotnet ef migrations add Update1 
-dotnet ef migrations add Update2 
+dotnet ef migrations add Update1 --context PlatformDbContext --output-dir Migrations/Data
 ```
 
-etc..
+## Generate SecurityDbContext Migrations
+```
+dotnet ef migrations add Update2 --context SecurityDbContext --output-dir Migrations/Security
+```
 
 ## Apply Migrations**
 

--- a/src/VirtoCommerce.Platform.Data.PostgreSql/Migrations/Data/20231026085000_DynamicPropertyItemNameRequired.Designer.cs
+++ b/src/VirtoCommerce.Platform.Data.PostgreSql/Migrations/Data/20231026085000_DynamicPropertyItemNameRequired.Designer.cs
@@ -2,62 +2,64 @@
 using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
-using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
+using Npgsql.EntityFrameworkCore.PostgreSQL.Metadata;
 using VirtoCommerce.Platform.Data.Repositories;
 
 #nullable disable
 
-namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
+namespace VirtoCommerce.Platform.Data.PostgreSql.Migrations.Data
 {
     [DbContext(typeof(PlatformDbContext))]
-    partial class PlatformDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231026085000_DynamicPropertyItemNameRequired")]
+    partial class DynamicPropertyItemNameRequired
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder
                 .HasAnnotation("ProductVersion", "6.0.13")
-                .HasAnnotation("Relational:MaxIdentifierLength", 128);
+                .HasAnnotation("Relational:MaxIdentifierLength", 63);
 
-            SqlServerModelBuilderExtensions.UseIdentityColumns(modelBuilder, 1L, 1);
+            NpgsqlModelBuilderExtensions.UseIdentityByDefaultColumns(modelBuilder);
 
             modelBuilder.Entity("VirtoCommerce.Platform.Data.Localizations.LocalizedItemEntity", b =>
                 {
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Alias")
                         .HasMaxLength(512)
-                        .HasColumnType("nvarchar(512)");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("LanguageCode")
                         .HasMaxLength(512)
-                        .HasColumnType("nvarchar(512)");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Value")
                         .HasMaxLength(512)
-                        .HasColumnType("nvarchar(512)");
+                        .HasColumnType("character varying(512)");
 
                     b.HasKey("Id");
 
@@ -72,36 +74,35 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .IsRequired()
                         .HasMaxLength(512)
-                        .HasColumnType("nvarchar(512)");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("PropertyId")
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("PropertyId", "Name")
                         .IsUnique()
-                        .HasDatabaseName("IX_PlatformDynamicPropertyDictionaryItem_PropertyId_Name")
-                        .HasFilter("[PropertyId] IS NOT NULL");
+                        .HasDatabaseName("IX_PlatformDynamicPropertyDictionaryItem_PropertyId_Name");
 
                     b.ToTable("PlatformDynamicPropertyDictionaryItem", (string)null);
                 });
@@ -111,39 +112,38 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("DictionaryItemId")
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Locale")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .HasMaxLength(512)
-                        .HasColumnType("nvarchar(512)");
+                        .HasColumnType("character varying(512)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("DictionaryItemId", "Locale", "Name")
                         .IsUnique()
-                        .HasDatabaseName("IX_PlatformDynamicPropertyDictionaryItemName_DictionaryItemId_Locale_Name")
-                        .HasFilter("[DictionaryItemId] IS NOT NULL AND [Locale] IS NOT NULL AND [Name] IS NOT NULL");
+                        .HasDatabaseName("IX_PlatformDynamicPropertyDictionaryItemName_DictionaryItemId_Locale_Name");
 
                     b.ToTable("PlatformDynamicPropertyDictionaryItemName", (string)null);
                 });
@@ -153,60 +153,59 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Description")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<int?>("DisplayOrder")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<bool>("IsArray")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsDictionary")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsMultilingual")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<bool>("IsRequired")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("ObjectType")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("ValueType")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("ObjectType", "Name")
                         .IsUnique()
-                        .HasDatabaseName("IX_PlatformDynamicProperty_ObjectType_Name")
-                        .HasFilter("[ObjectType] IS NOT NULL AND [Name] IS NOT NULL");
+                        .HasDatabaseName("IX_PlatformDynamicProperty_ObjectType_Name");
 
                     b.ToTable("PlatformDynamicProperty", (string)null);
                 });
@@ -216,39 +215,38 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Locale")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .HasMaxLength(256)
-                        .HasColumnType("nvarchar(256)");
+                        .HasColumnType("character varying(256)");
 
                     b.Property<string>("PropertyId")
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.HasKey("Id");
 
                     b.HasIndex("PropertyId", "Locale", "Name")
                         .IsUnique()
-                        .HasDatabaseName("IX_PlatformDynamicPropertyName_PropertyId_Locale_Name")
-                        .HasFilter("[PropertyId] IS NOT NULL AND [Locale] IS NOT NULL AND [Name] IS NOT NULL");
+                        .HasDatabaseName("IX_PlatformDynamicPropertyName_PropertyId_Locale_Name");
 
                     b.ToTable("PlatformDynamicPropertyName", (string)null);
                 });
@@ -258,38 +256,38 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Detail")
                         .HasMaxLength(2048)
-                        .HasColumnType("nvarchar(2048)");
+                        .HasColumnType("character varying(2048)");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ObjectId")
                         .HasMaxLength(200)
-                        .HasColumnType("nvarchar(200)");
+                        .HasColumnType("character varying(200)");
 
                     b.Property<string>("ObjectType")
                         .HasMaxLength(50)
-                        .HasColumnType("nvarchar(50)");
+                        .HasColumnType("character varying(50)");
 
                     b.Property<string>("OperationType")
                         .IsRequired()
                         .HasMaxLength(20)
-                        .HasColumnType("nvarchar(20)");
+                        .HasColumnType("character varying(20)");
 
                     b.HasKey("Id");
 
@@ -304,10 +302,10 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("Data")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.HasKey("Id");
 
@@ -319,33 +317,33 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ObjectId")
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ObjectType")
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.HasKey("Id");
 
@@ -360,48 +358,48 @@ namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
                     b.Property<string>("Id")
                         .ValueGeneratedOnAdd()
                         .HasMaxLength(128)
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<bool>("BooleanValue")
-                        .HasColumnType("bit");
+                        .HasColumnType("boolean");
 
                     b.Property<string>("CreatedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime>("CreatedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<DateTime?>("DateTimeValue")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<decimal>("DecimalValue")
-                        .HasColumnType("decimal(18,5)");
+                        .HasColumnType("numeric(18,5)");
 
                     b.Property<int>("IntegerValue")
-                        .HasColumnType("int");
+                        .HasColumnType("integer");
 
                     b.Property<string>("LongTextValue")
-                        .HasColumnType("nvarchar(max)");
+                        .HasColumnType("text");
 
                     b.Property<string>("ModifiedBy")
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.Property<DateTime?>("ModifiedDate")
-                        .HasColumnType("datetime2");
+                        .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("SettingId")
-                        .HasColumnType("nvarchar(128)");
+                        .HasColumnType("character varying(128)");
 
                     b.Property<string>("ShortTextValue")
                         .HasMaxLength(512)
-                        .HasColumnType("nvarchar(512)");
+                        .HasColumnType("character varying(512)");
 
                     b.Property<string>("ValueType")
                         .IsRequired()
                         .HasMaxLength(64)
-                        .HasColumnType("nvarchar(64)");
+                        .HasColumnType("character varying(64)");
 
                     b.HasKey("Id");
 

--- a/src/VirtoCommerce.Platform.Data.PostgreSql/Migrations/Data/20231026085000_DynamicPropertyItemNameRequired.cs
+++ b/src/VirtoCommerce.Platform.Data.PostgreSql/Migrations/Data/20231026085000_DynamicPropertyItemNameRequired.cs
@@ -1,0 +1,37 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtoCommerce.Platform.Data.PostgreSql.Migrations.Data
+{
+    public partial class DynamicPropertyItemNameRequired : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "PlatformDynamicPropertyDictionaryItem",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512,
+                oldNullable: true);
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "PlatformDynamicPropertyDictionaryItem",
+                type: "character varying(512)",
+                maxLength: 512,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "character varying(512)",
+                oldMaxLength: 512);
+        }
+    }
+}

--- a/src/VirtoCommerce.Platform.Data.PostgreSql/Migrations/Data/PlatformDbContextModelSnapshot.cs
+++ b/src/VirtoCommerce.Platform.Data.PostgreSql/Migrations/Data/PlatformDbContextModelSnapshot.cs
@@ -89,6 +89,7 @@ namespace VirtoCommerce.Platform.Data.PostgreSql.Migrations.Data
                         .HasColumnType("timestamp with time zone");
 
                     b.Property<string>("Name")
+                        .IsRequired()
                         .HasMaxLength(512)
                         .HasColumnType("character varying(512)");
 

--- a/src/VirtoCommerce.Platform.Data.PostgreSql/Readme.md
+++ b/src/VirtoCommerce.Platform.Data.PostgreSql/Readme.md
@@ -3,15 +3,15 @@
 dotnet tool install --global dotnet-ef --version 6.0.13
 ```
 
-## Generate Migrations**
-
+## Generate PlatformDbContext Migrations
 ```
-dotnet ef migrations add Initial 
-dotnet ef migrations add Update1 
-dotnet ef migrations add Update2 
+dotnet ef migrations add Update1 --context PlatformDbContext --output-dir Migrations/Data
 ```
 
-etc..
+## Generate SecurityDbContext Migrations
+```
+dotnet ef migrations add Update2 --context SecurityDbContext --output-dir Migrations/Security
+```
 
 ## Apply Migrations**
 

--- a/src/VirtoCommerce.Platform.Data.SqlServer/Migrations/Data/20231026083345_DynamicPropertyItemNameRequired.Designer.cs
+++ b/src/VirtoCommerce.Platform.Data.SqlServer/Migrations/Data/20231026083345_DynamicPropertyItemNameRequired.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
 using Microsoft.EntityFrameworkCore.Metadata;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 using VirtoCommerce.Platform.Data.Repositories;
 
@@ -11,9 +12,10 @@ using VirtoCommerce.Platform.Data.Repositories;
 namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
 {
     [DbContext(typeof(PlatformDbContext))]
-    partial class PlatformDbContextModelSnapshot : ModelSnapshot
+    [Migration("20231026083345_DynamicPropertyItemNameRequired")]
+    partial class DynamicPropertyItemNameRequired
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder

--- a/src/VirtoCommerce.Platform.Data.SqlServer/Migrations/Data/20231026083345_DynamicPropertyItemNameRequired.cs
+++ b/src/VirtoCommerce.Platform.Data.SqlServer/Migrations/Data/20231026083345_DynamicPropertyItemNameRequired.cs
@@ -1,0 +1,61 @@
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace VirtoCommerce.Platform.Data.SqlServer.Migrations.Data
+{
+    public partial class DynamicPropertyItemNameRequired : Migration
+    {
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.Sql("UPDATE PlatformDynamicPropertyDictionaryItem SET Name = Id WHERE Name IS NULL or LEN(Name) = 0");
+
+            migrationBuilder.DropIndex(
+                name: "IX_PlatformDynamicPropertyDictionaryItem_PropertyId_Name",
+                table: "PlatformDynamicPropertyDictionaryItem");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "PlatformDynamicPropertyDictionaryItem",
+                type: "nvarchar(512)",
+                maxLength: 512,
+                nullable: false,
+                defaultValue: "",
+                oldClrType: typeof(string),
+                oldType: "nvarchar(512)",
+                oldMaxLength: 512,
+                oldNullable: true);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlatformDynamicPropertyDictionaryItem_PropertyId_Name",
+                table: "PlatformDynamicPropertyDictionaryItem",
+                columns: new[] { "PropertyId", "Name" },
+                unique: true,
+                filter: "[PropertyId] IS NOT NULL");
+        }
+
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropIndex(
+                name: "IX_PlatformDynamicPropertyDictionaryItem_PropertyId_Name",
+                table: "PlatformDynamicPropertyDictionaryItem");
+
+            migrationBuilder.AlterColumn<string>(
+                name: "Name",
+                table: "PlatformDynamicPropertyDictionaryItem",
+                type: "nvarchar(512)",
+                maxLength: 512,
+                nullable: true,
+                oldClrType: typeof(string),
+                oldType: "nvarchar(512)",
+                oldMaxLength: 512);
+
+            migrationBuilder.CreateIndex(
+                name: "IX_PlatformDynamicPropertyDictionaryItem_PropertyId_Name",
+                table: "PlatformDynamicPropertyDictionaryItem",
+                columns: new[] { "PropertyId", "Name" },
+                unique: true,
+                filter: "[PropertyId] IS NOT NULL AND [Name] IS NOT NULL");
+        }
+    }
+}

--- a/src/VirtoCommerce.Platform.Data.SqlServer/Readme.md
+++ b/src/VirtoCommerce.Platform.Data.SqlServer/Readme.md
@@ -3,15 +3,15 @@
 dotnet tool install --global dotnet-ef --version 6.0.13
 ```
 
-## Generate Migrations**
-
+## Generate PlatformDbContext Migrations
 ```
-dotnet ef migrations add Initial 
-dotnet ef migrations add Update1 
-dotnet ef migrations add Update2 
+dotnet ef migrations add Update1 --context PlatformDbContext --output-dir Migrations/Data
 ```
 
-etc..
+## Generate SecurityDbContext Migrations
+```
+dotnet ef migrations add Update2 --context SecurityDbContext --output-dir Migrations/Security
+```
 
 ## Apply Migrations**
 

--- a/src/VirtoCommerce.Platform.Data/DynamicProperties/DynamicPropertyDictionaryItemsService.cs
+++ b/src/VirtoCommerce.Platform.Data/DynamicProperties/DynamicPropertyDictionaryItemsService.cs
@@ -49,7 +49,7 @@ namespace VirtoCommerce.Platform.Data.DynamicProperties
             using (var repository = _repositoryFactory())
             {
                 var dbExistItems = await repository.GetDynamicPropertyDictionaryItemByIdsAsync(items.Where(x => !x.IsTransient()).Select(x => x.Id).ToArray());
-                foreach (var item in items)
+                foreach (var item in items.Where(x => !string.IsNullOrEmpty(x.Name)))
                 {
                     var originalEntity = dbExistItems.FirstOrDefault(x => x.Id == item.Id);
                     var modifiedEntity = AbstractTypeFactory<DynamicPropertyDictionaryItemEntity>.TryCreateInstance().FromModel(item);

--- a/src/VirtoCommerce.Platform.Data/DynamicProperties/DynamicPropertyDictionaryItemsService.cs
+++ b/src/VirtoCommerce.Platform.Data/DynamicProperties/DynamicPropertyDictionaryItemsService.cs
@@ -5,6 +5,7 @@ using Microsoft.Extensions.Caching.Memory;
 using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.DynamicProperties;
+using VirtoCommerce.Platform.Core.Exceptions;
 using VirtoCommerce.Platform.Data.Infrastructure;
 using VirtoCommerce.Platform.Data.Model;
 using VirtoCommerce.Platform.Data.Repositories;
@@ -22,10 +23,10 @@ namespace VirtoCommerce.Platform.Data.DynamicProperties
             _memoryCache = memoryCache;
         }
 
-        public virtual async Task<DynamicPropertyDictionaryItem[]> GetDynamicPropertyDictionaryItemsAsync(string[] ids)
+        public virtual Task<DynamicPropertyDictionaryItem[]> GetDynamicPropertyDictionaryItemsAsync(string[] ids)
         {
             var cacheKey = CacheKey.With(GetType(), "GetDynamicPropertyDictionaryItemsAsync", string.Join("-", ids));
-            return await _memoryCache.GetOrCreateExclusiveAsync(cacheKey, async (cacheEntry) =>
+            return _memoryCache.GetOrCreateExclusiveAsync(cacheKey, async (cacheEntry) =>
             {
                 cacheEntry.AddExpirationToken(DynamicPropertiesCacheRegion.CreateChangeToken());
                 using (var repository = _repositoryFactory())
@@ -45,11 +46,15 @@ namespace VirtoCommerce.Platform.Data.DynamicProperties
             {
                 throw new ArgumentNullException(nameof(items));
             }
+            if (items.Any(x => string.IsNullOrEmpty(x.Name)))
+            {
+                throw new InvalidCollectionItemException("One or more items in the collection have a null or empty Name.");
+            }
 
             using (var repository = _repositoryFactory())
             {
                 var dbExistItems = await repository.GetDynamicPropertyDictionaryItemByIdsAsync(items.Where(x => !x.IsTransient()).Select(x => x.Id).ToArray());
-                foreach (var item in items.Where(x => !string.IsNullOrEmpty(x.Name)))
+                foreach (var item in items)
                 {
                     var originalEntity = dbExistItems.FirstOrDefault(x => x.Id == item.Id);
                     var modifiedEntity = AbstractTypeFactory<DynamicPropertyDictionaryItemEntity>.TryCreateInstance().FromModel(item);

--- a/src/VirtoCommerce.Platform.Data/Model/DynamicPropertyDictionaryItemEntity.cs
+++ b/src/VirtoCommerce.Platform.Data/Model/DynamicPropertyDictionaryItemEntity.cs
@@ -18,6 +18,7 @@ namespace VirtoCommerce.Platform.Data.Model
         public virtual DynamicPropertyEntity Property { get; set; }
 
         [StringLength(512)]
+        [Required]
         public string Name { get; set; }
 
         public virtual ObservableCollection<DynamicPropertyDictionaryItemNameEntity> DisplayNames { get; set; }

--- a/src/VirtoCommerce.Platform.Web/Controllers/Api/DynamicPropertiesController.cs
+++ b/src/VirtoCommerce.Platform.Web/Controllers/Api/DynamicPropertiesController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using VirtoCommerce.Platform.Core;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.DynamicProperties;
+using VirtoCommerce.Platform.Core.Exceptions;
 
 namespace VirtoCommerce.Platform.Web.Controllers.Api
 {
@@ -105,7 +106,15 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
         [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
         public async Task<ActionResult> UpdatePropertyAsync([FromBody] DynamicProperty property)
         {
-            await _dynamicPropertyService.SaveDynamicPropertiesAsync(new[] { property });
+            try
+            {
+                await _dynamicPropertyService.SaveDynamicPropertiesAsync(new[] { property });
+            }
+            catch (ArgumentNullException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+
             return NoContent();
         }
 
@@ -119,7 +128,15 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
         [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
         public async Task<ActionResult> DeletePropertyAsync([FromQuery] string[] propertyIds)
         {
-            await _dynamicPropertyService.DeleteDynamicPropertiesAsync(propertyIds);
+            try
+            {
+                await _dynamicPropertyService.DeleteDynamicPropertiesAsync(propertyIds);
+            }
+            catch (ArgumentNullException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+
             return NoContent();
         }
 
@@ -152,7 +169,11 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
             {
                 await _dynamicPropertyDictionaryItemsService.SaveDictionaryItemsAsync(items);
             }
-            catch (Exception ex)
+            catch (ArgumentNullException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+            catch (InvalidCollectionItemException ex)
             {
                 return BadRequest(ex.Message);
             }
@@ -171,7 +192,15 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
         [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
         public async Task<ActionResult> DeleteDictionaryItemAsync([FromQuery] string[] ids)
         {
-            await _dynamicPropertyDictionaryItemsService.DeleteDictionaryItemsAsync(ids);
+            try
+            {
+                await _dynamicPropertyDictionaryItemsService.DeleteDictionaryItemsAsync(ids);
+            }
+            catch (ArgumentNullException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+
             return NoContent();
         }
 

--- a/src/VirtoCommerce.Platform.Web/Controllers/Api/DynamicPropertiesController.cs
+++ b/src/VirtoCommerce.Platform.Web/Controllers/Api/DynamicPropertiesController.cs
@@ -8,7 +8,6 @@ using Microsoft.AspNetCore.Mvc;
 using VirtoCommerce.Platform.Core;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.DynamicProperties;
-using VirtoCommerce.Platform.Core.Exceptions;
 
 namespace VirtoCommerce.Platform.Web.Controllers.Api
 {
@@ -153,15 +152,10 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
             {
                 await _dynamicPropertyDictionaryItemsService.SaveDictionaryItemsAsync(items);
             }
-            catch (ArgumentNullException ex)
+            catch (Exception ex)
             {
                 return BadRequest(ex.Message);
             }
-            catch (InvalidCollectionItemException ex)
-            {
-                BadRequest(ex.Message);
-            }
-
 
             return NoContent();
         }

--- a/src/VirtoCommerce.Platform.Web/Controllers/Api/DynamicPropertiesController.cs
+++ b/src/VirtoCommerce.Platform.Web/Controllers/Api/DynamicPropertiesController.cs
@@ -8,6 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using VirtoCommerce.Platform.Core;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.DynamicProperties;
+using VirtoCommerce.Platform.Core.Exceptions;
 
 namespace VirtoCommerce.Platform.Web.Controllers.Api
 {
@@ -148,7 +149,20 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
         [ProducesResponseType(typeof(void), StatusCodes.Status204NoContent)]
         public async Task<ActionResult> SaveDictionaryItemsAsync([FromBody] DynamicPropertyDictionaryItem[] items)
         {
-            await _dynamicPropertyDictionaryItemsService.SaveDictionaryItemsAsync(items);
+            try
+            {
+                await _dynamicPropertyDictionaryItemsService.SaveDictionaryItemsAsync(items);
+            }
+            catch (ArgumentNullException ex)
+            {
+                return BadRequest(ex.Message);
+            }
+            catch (InvalidCollectionItemException ex)
+            {
+                BadRequest(ex.Message);
+            }
+
+
             return NoContent();
         }
 


### PR DESCRIPTION
## Description
fix: Dynamic dictionary item name must be required. Throw InvalidCollectionItemException if One or more items in the collection have a null or empty Name. API returns BadRequest. 
fix: Fixs Name can be null or empty in DB. The update marks DynamicPropertyDictionaryItemEntity Name as required. Name with either Null or Empty value will be converted to unique id automatically.

## References
### QA-test:
### Jira-link:
### Artifact URL:
