### PR TITLE
Fix a bug where the dropdown with available dictionary items has only the first item

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/genericValueInput.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/genericValueInput.js
@@ -100,7 +100,7 @@ angular.module('platformWebApp')
                         angular.forEach(allDictionaryValues, function (dictValue) {
                             scope.context.allDictionaryValues.push(dictValue);
                             //Need to select already selected values. Dictionary values have same type as standard values.
-                            if (_.any(selectedValues, function (x) { return x.value.id == dictValue.id || x.valueId == dictValue.id })) {
+                            if (_.any(selectedValues, function (x) { return (x.value && x.value.id == dictValue.id) || x.valueId == dictValue.id })) {
                                 //add selected value
                                 scope.context.currentPropValues.push(dictValue);
                             }


### PR DESCRIPTION
## Description

We've run into a rare bug where some of our organization objects did not display full list of available dictionary items for one of the dynamic properties in the management -> _Dynamic properties_ blade. The dropdown had just the first item. This turned out to happen when the API sent a value object with `valueType` of `Undefined` and no actual `value` property, something like this:
```json
{
    ...
    "dynamicProperties": [
        {
            "values": [
                {
                    "objectType": "VirtoCommerce.CustomerModule.Core.Model.Organization",
                    "objectId": "1234",
                    "valueId": "xyz",
                    "valueType": "Undefined",
                    "propertyId": "MyCustomObject_VirtoCommerce.Domain.Customer.Model.Organization",
                    "propertyName": "MyCustomObject"
                }
            ],
            ...
        }
    ],
    ...
}
```

We don't know why the value was like that (maybe a side effect of migrating from VC 2), but it caused the following piece of JS to fail:
https://github.com/VirtoCommerce/vc-platform/blob/a872fba8eb5bf4cc2289d3fe3a13576bd8a8e1b9/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/genericValueInput.js#L103
Specifically, dereferencing `x.value.id` breaks the loop (as there is no `value` property) in its first iteration, hence only one item ends up in the dropdown.
