### PR TITLE
PT-14585: Rename Identity cookie

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -413,6 +413,8 @@ namespace VirtoCommerce.Platform.Web
             //always  return 401 instead of 302 for unauthorized  requests
             services.ConfigureApplicationCookie(options =>
             {
+                options.Cookie.Name = ".VirtoCommerce.Identity.Application";
+
                 options.Events.OnRedirectToLogin = context =>
                 {
                     context.Response.StatusCode = (int)HttpStatusCode.Unauthorized;


### PR DESCRIPTION
## Description
fix: Rename .AspNetCore.Identity.Application cookie's name to .VirtoCommerce.Identity.Application to prevent from cookie's name conflict between storefront and backend on same domain.

![image](https://github.com/VirtoCommerce/vc-platform/assets/7639413/7e4520dd-55b4-4dce-aad0-86245d441c1f)

## References
### QA-test:
### Jira-link:
### Artifact URL:
