### PR TITLE
PT-14600: Update hangfire to 1.8.6

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -9,7 +9,7 @@
   </PropertyGroup>
 
   <PropertyGroup>
-    <VersionPrefix>3.444.0</VersionPrefix>
+    <VersionPrefix>3.445.0</VersionPrefix>
     <VersionSuffix></VersionSuffix>
     <VersionSuffix Condition=" '$(VersionSuffix)' != '' AND '$(BuildNumber)' != '' ">$(VersionSuffix)-$(BuildNumber)</VersionSuffix>
     <NoWarn>$(NoWarn);S3875;S4457</NoWarn>

--- a/src/VirtoCommerce.Platform.Data.SqlServer/VirtoCommerce.Platform.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.Platform.Data.SqlServer/VirtoCommerce.Platform.Data.SqlServer.csproj
@@ -12,6 +12,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="6.0.13" />
     <PackageReference Include="Microsoft.SqlServer.Server" Version="1.0.0" />
+    <PackageReference Include="System.Data.SqlClient" Version="4.4.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.Platform.Hangfire/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Hangfire/Extensions/ServiceCollectionExtensions.cs
@@ -19,7 +19,12 @@ namespace VirtoCommerce.Platform.Hangfire.Extensions
             switch (databaseProvider)
             {
                 case "PostgreSql":
-                    globalConfiguration.UsePostgreSqlStorage(connectionString, hangfireOptions.PostgreSqlStorageOptions);
+                    globalConfiguration.UsePostgreSqlStorage(
+                        configure =>
+                        {
+                            configure.UseNpgsqlConnection(connectionString);
+                        },
+                        hangfireOptions.PostgreSqlStorageOptions);
                     break;
                 case "MySql":
                     globalConfiguration.UseStorage(new MySqlStorage(connectionString, hangfireOptions.MySqlStorageOptions));

--- a/src/VirtoCommerce.Platform.Hangfire/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Hangfire/Extensions/ServiceCollectionExtensions.cs
@@ -48,7 +48,7 @@ namespace VirtoCommerce.Platform.Hangfire.Extensions
             if (hangfireOptions.JobStorageType == HangfireJobStorageType.SqlServer ||
                 hangfireOptions.JobStorageType == HangfireJobStorageType.Database)
             {
-                services.AddHangfire(c => c.SetDataCompatibilityLevel(CompatibilityLevel.Version_170)
+                services.AddHangfire(c => c.SetDataCompatibilityLevel(CompatibilityLevel.Version_180)
                     .UseSimpleAssemblyNameTypeSerializer()
                     .UseRecommendedSerializerSettings()
                     .AddHangfireStorage(configuration, hangfireOptions));

--- a/src/VirtoCommerce.Platform.Hangfire/VirtoCommerce.Platform.Hangfire.csproj
+++ b/src/VirtoCommerce.Platform.Hangfire/VirtoCommerce.Platform.Hangfire.csproj
@@ -19,13 +19,13 @@
     </PropertyGroup>
 
     <ItemGroup>
-        <PackageReference Include="Hangfire" Version="1.7.31" />
-        <PackageReference Include="Hangfire.AspNetCore" Version="1.7.31" />
+        <PackageReference Include="Hangfire" Version="1.8.6" />
+        <PackageReference Include="Hangfire.AspNetCore" Version="1.8.6" />
         <PackageReference Include="Hangfire.Console" Version="1.4.2" />
-        <PackageReference Include="Hangfire.MemoryStorage" Version="1.7.0" />
+        <PackageReference Include="Hangfire.MemoryStorage" Version="1.8.0" />
         <PackageReference Include="Hangfire.MySqlStorage" Version="2.0.3" />
-        <PackageReference Include="Hangfire.PostgreSql" Version="1.9.9" />
-        <PackageReference Include="HangFire.SqlServer" Version="1.7.31" />
+        <PackageReference Include="Hangfire.PostgreSql" Version="1.20.4" />
+        <PackageReference Include="HangFire.SqlServer" Version="1.8.6" />
         <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="6.0.13" />
         <PackageReference Include="Microsoft.SourceLink.GitHub" Version="1.0.0" PrivateAssets="All" />
     </ItemGroup>

--- a/src/VirtoCommerce.Platform.Web/Security/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Web/Security/ApplicationBuilderExtensions.cs
@@ -73,7 +73,7 @@ namespace VirtoCommerce.Platform.Web.Security
         {
             if (lockoutOptions.AutoAccountsLockoutJobEnabled)
             {
-                RecurringJob.AddOrUpdate<AutoAccountLockoutJob>(j => j.Process(), lockoutOptions.CronAutoAccountsLockoutJob);
+                RecurringJob.AddOrUpdate<AutoAccountLockoutJob>("AutoAccountLockoutJob", j => j.Process(), lockoutOptions.CronAutoAccountsLockoutJob);
             }
             else
             {

--- a/src/VirtoCommerce.Platform.Web/Security/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Web/Security/ApplicationBuilderExtensions.cs
@@ -77,7 +77,7 @@ namespace VirtoCommerce.Platform.Web.Security
             }
             else
             {
-                RecurringJob.RemoveIfExists("AutoAccountLockoutJob.Process");
+                RecurringJob.RemoveIfExists("AutoAccountLockoutJob");
             }
 
             return appBuilder;

--- a/src/VirtoCommerce.Platform.Web/appsettings.json
+++ b/src/VirtoCommerce.Platform.Web/appsettings.json
@@ -56,7 +56,8 @@
         "UseRecommendedIsolationLevel": true,
         "UsePageLocksOnDequeue": true,
         "DisableGlobalLocks": true,
-        "EnableHeavyMigrations": true
+        "EnableHeavyMigrations": true,
+        "InactiveStateExpirationTimeout":  "7.00:00:00"
       },
       "MySqlStorageOptions": {
         "InvisibilityTimeout": "00:05:00",


### PR DESCRIPTION
## Description
feat: [Update Hangfire to 1.8.0](https://www.hangfire.io/blog/2023/04/28/hangfire-1.8.0.html). It offers a set of great new features like first-class queue support for background jobs, the enhanced role of the Deleted state that now supports exceptions, more options for continuations to implement even try/catch/finally semantics, better defaults to simplify the initial configuration and various Dashboard UI improvements.
feat: Bump Hangfire to 1.8.6,  Hangfire.AspNetCore to 1.8.6, Hangfire.MemoryStorage to 1.8.0 , Hangfire.PostgreSql to 1.20.4 and HangFire.SqlServer to 1.8.6.
feat: Added  Hangfire:SqlServerStorageOptions:InactiveStateExpirationTimeout. It cleans up the old state entries of a non-finished job when InactiveStateExpirationTimeout is set. By default, 7 days.

## References
### QA-test:
### Jira-link:
### Artifact URL:
