### PR TITLE
Update a code sample to match current scope value picker version

### DIFF
--- a/docs/fundamentals/make-secure-webapi.md
+++ b/docs/fundamentals/make-secure-webapi.md
@@ -275,7 +275,7 @@ angular.module(moduleName, []).run( ['platformWebApp.permissionScopeResolver', '
                     subtitle: 'Select stores',
                     currentEntity: this,
                     onChangesConfirmedFn: callback,
-                    dataPromise: stores.query().$promise,
+                    dataService: stores,
                     controller: 'platformWebApp.security.scopeValuePickFromSimpleListController',
                     template: '$(Platform)/Scripts/app/security/blades/common/scope-value-pick-from-simple-list.tpl.html'
                 };


### PR DESCRIPTION
The code sample for scope resolver registration is outdated and invalid due to a past change in [scope-value-pick-from-simple-list.js](https://github.com/VirtoCommerce/vc-platform/commit/c90610cc620a09916c12ed6e98376f710ea4cd33#diff-aae3ee4d81cc71640c46bf9a84c06c16816242f2bf4e5a7346651b69eb88c099). The current usage is as in this example from Catalog Module:
https://github.com/VirtoCommerce/vc-module-catalog/blob/bf81c3ea0a5d7cb56dc8a72842ee7715e522cf03/src/VirtoCommerce.CatalogModule.Web/Scripts/catalog.js#L274