### PR TITLE
Update auth caption for Entra ID (formerly AAD)

### DIFF
--- a/src/VirtoCommerce.Platform.Web/appsettings.json
+++ b/src/VirtoCommerce.Platform.Web/appsettings.json
@@ -194,7 +194,7 @@
   "AzureAd": {
     "Enabled": false,
     "AuthenticationType": "AzureAD",
-    "AuthenticationCaption": "Azure Active Directory",
+    "AuthenticationCaption": "Microsoft Entra ID",
     "ApplicationId": "(Replace this with Application (client) ID, e.g. 01234567-89ab-cdef-0123-456789abcdef)",
     "TenantId": "(Replace this with Directory (tenant) ID, e.g. abcdef01-2345-6789-abcd-ef0123456789)",
     "AzureAdInstance": "https://login.microsoftonline.com/",


### PR DESCRIPTION
There's been a [rebranding ](https://learn.microsoft.com/en-us/entra/fundamentals/new-name) of Azure Active Directory to Microsoft Entra ID. This PR reflects this change in the most user-facing spot, that is the log-in page, but I think both documentation and the [AzureAd ](https://github.com/VirtoCommerce/vc-module-azure-ad) module will also need at least some rebranding too. 