### PR TITLE
VCST-275: set correct permission to get global settings

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Controllers/Api/SettingController.cs
+++ b/src/VirtoCommerce.Platform.Web/Controllers/Api/SettingController.cs
@@ -59,7 +59,7 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
         /// <returns></returns>
         [HttpGet]
         [Route("{name}")]
-        [Authorize(PlatformConstants.Security.Permissions.SettingAccess)]
+        [Authorize(PlatformConstants.Security.Permissions.SettingQuery)]
         public async Task<ActionResult<ObjectSettingEntry>> GetGlobalSettingAsync(string name)
         {
             var result = await _settingsManager.GetObjectSettingAsync(name);


### PR DESCRIPTION
## Description

use platform:setting:read permission to restrict endpoint GetGlobalSetting

## References
### QA-test:
### Jira-link:
### Artifact URL:
