### PR TITLE
VCST-410: Incorrect validation for decimal fields in settings

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/smartFloat.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/smartFloat.js
@@ -1,45 +1,44 @@
 'use strict';
 
 angular.module('platformWebApp')
-    // TODO: Replace with tested localized version (see below)
-    .directive('smartFloat', ['$filter', '$compile', 'platformWebApp.userProfile', function ($filter, $compile, userProfile) {
-        var INTEGER_REGEXP = /^\-?\d+$/; //Integer number
-        var INTEGER_MAX_VALUE = 2147483647;
-        var INTEGER_MIN_VALUE = -2147483648;
-        var FLOAT_REGEXP_1 = /^[-+]?\$?\d{1,3}(\.\d{3})+(,\d*)$/; //Numbers like: 1.234,5678
-        var FLOAT_REGEXP_2 = /^[-+]?\$?\d{1,3}(,\d{3})+(\.\d*)$/; //Numbers like: 1,234.5678
-        var FLOAT_REGEXP_3 = /^[-+]?\$?\d+(\.\d*)?$/; //Numbers like: 1234.5678
-        var FLOAT_REGEXP_4 = /^[-+]?\$?\d+(,\d*)?$/; //Numbers like: 1234,5678
+	// TODO: Replace with tested localized version (see below)
+	.directive('smartFloat', ['$filter', '$compile', 'platformWebApp.userProfile', function ($filter, $compile, userProfile) {
+		var INTEGER_REGEXP = /^\-?\d+$/; //Integer number
+		var INTEGER_MAX_VALUE = 2147483647;
+		var INTEGER_MIN_VALUE = -2147483648;
+		var FLOAT_REGEXP_1 = /^[-+]?\$?\d{1,3}(\.\d{3})+(,\d*)$/; //Numbers like: 1.234,5678
+		var FLOAT_REGEXP_2 = /^[-+]?\$?\d{1,3}(,\d{3})+(\.\d*)$/; //Numbers like: 1,234.5678
+		var FLOAT_REGEXP_3 = /^[-+]?\$?\d+(\.\d*)?$/; //Numbers like: 1234.5678
+		var FLOAT_REGEXP_4 = /^[-+]?\$?\d+(,\d*)?$/; //Numbers like: 1234,5678
 
-        return {
-            require: 'ngModel',
-            link: function (scope, elm, attrs, ctrl) {
+		return {
+			require: 'ngModel',
+			link: function (scope, elm, attrs, ctrl) {
 				// possible values for fraction are: 0, positive number, negative number, none
 				// when fraction is a negative number result has maximum length of the fractional part of the value
-                var fraction = (attrs.fraction || Number(attrs.fraction) === 0) ? attrs.fraction : 2;
-                if (attrs.numType === "float") {
-                    ctrl.$parsers.unshift(function (viewValue) {
-                        if (FLOAT_REGEXP_1.test(viewValue)) {
-                            ctrl.$setValidity('float', true);
-                            return parseFloat(viewValue.replace('.', '').replace(',', '.'));
-                        } else if (FLOAT_REGEXP_2.test(viewValue)) {
-                            ctrl.$setValidity('float', true);
-                            return parseFloat(viewValue.replace(',', ''));
-                        } else if (FLOAT_REGEXP_3.test(viewValue)) {
-                            ctrl.$setValidity('float', true);
-                            return parseFloat(viewValue);
-                        } else if (FLOAT_REGEXP_4.test(viewValue)) {
-                            ctrl.$setValidity('float', true);
-                            return parseFloat(viewValue.replace(',', '.'));
-                        } else {
-                            //Allow to use empty values
-                            ctrl.$setValidity('float', !viewValue);
-                            return viewValue;
-                        }
-                    });
+				var fraction = (attrs.fraction || Number(attrs.fraction) === 0) ? attrs.fraction : 2;
+				if (attrs.numType === "float") {
+					ctrl.$parsers.unshift(function (viewValue) {
+						if (FLOAT_REGEXP_1.test(viewValue)) {
+							ctrl.$setValidity('float', true);
+							return parseFloat(viewValue.replace('.', '').replace(',', '.'));
+						} else if (FLOAT_REGEXP_2.test(viewValue)) {
+							ctrl.$setValidity('float', true);
+							return parseFloat(viewValue.replace(',', ''));
+						} else if (FLOAT_REGEXP_3.test(viewValue)) {
+							ctrl.$setValidity('float', true);
+							return parseFloat(viewValue);
+						} else if (FLOAT_REGEXP_4.test(viewValue)) {
+							ctrl.$setValidity('float', true);
+							return parseFloat(viewValue.replace(',', '.'));
+						} else {
+                            ctrl.$setValidity('float', false);
+							return viewValue;
+						}
+					});
 
-                    ctrl.$formatters.unshift(
-                        function (modelValue) {
+					ctrl.$formatters.unshift(
+						function (modelValue) {
 							if (modelValue == null) {
 								return modelValue;
 							}
@@ -51,29 +50,29 @@ angular.module('platformWebApp')
 								return new Intl.NumberFormat(userProfile.language || 'default', { maximumFractionDigits: -fraction }).format(resultValue);
 							}
 							// default behavior
-                            return $filter('number')(resultValue, fraction);
-                        }
-                    );
-                }
-                else if (attrs.numType === "positiveInteger") {
-                    ctrl.$parsers.unshift(function (viewValue) {
-                        ctrl.$setValidity('positiveInteger', INTEGER_REGEXP.test(viewValue) && viewValue > 0);
-                        return viewValue;
-                    });
-                }
-                else {
-                    ctrl.$parsers.unshift(function (viewValue) {
-                        if (INTEGER_REGEXP.test(viewValue) && viewValue >= INTEGER_MIN_VALUE && viewValue <= INTEGER_MAX_VALUE) {
-                            ctrl.$setValidity('integer', true);
-                            return viewValue;
-                        }
-                        else {
-                            //Allow to use empty values
-                            ctrl.$setValidity('integer', !viewValue);
-                            return viewValue;
-                        }
-                    });
-                }
-            }
-        };
-    }]);
+							return $filter('number')(resultValue, fraction);
+						}
+					);
+				}
+				else if (attrs.numType === "positiveInteger") {
+					ctrl.$parsers.unshift(function (viewValue) {
+						ctrl.$setValidity('positiveInteger', INTEGER_REGEXP.test(viewValue) && viewValue > 0);
+						return viewValue;
+					});
+				}
+				else {
+					ctrl.$parsers.unshift(function (viewValue) {
+						if (INTEGER_REGEXP.test(viewValue) && viewValue >= INTEGER_MIN_VALUE && viewValue <= INTEGER_MAX_VALUE) {
+							ctrl.$setValidity('integer', true);
+							return viewValue;
+						}
+						else {
+							//Allow to use empty values
+							ctrl.$setValidity('integer', !viewValue);
+							return viewValue;
+						}
+					});
+				}
+			}
+		};
+	}]);


### PR DESCRIPTION
## Description
fix: Incorrect validation for decimal fields in settings if value is empty string.

After the fix:
![image](https://github.com/VirtoCommerce/vc-platform/assets/7639413/58ad744f-0d01-48ed-963f-fcb9daa0fd7b)

## References
### QA-test:
### Jira-link:
### Artifact URL:
