### PR TITLE
VCST-565: Bump Microsoft.Bcl.AsyncInterfaces to 8.0.0

### DIFF
--- a/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
+++ b/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
@@ -29,6 +29,7 @@
         <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="8.0.0" />
         <PackageReference Include="Microsoft.Azure.AppConfiguration.AspNetCore" Version="7.0.0" />
         <PackageReference Include="Microsoft.Azure.SignalR" Version="1.22.0" />
+        <PackageReference Include="Microsoft.Bcl.AsyncInterfaces" Version="8.0.0" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
           <PrivateAssets>all</PrivateAssets>
           <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>


### PR DESCRIPTION
## Description
feat: Bump Microsoft.Bcl.AsyncInterfaces to 8.0.0

## References
### QA-test:
### Jira-link:
### Artifact URL:
