### PR TITLE
Fix environment folder breaking changes for macOS in .Net8

### DIFF
--- a/src/VirtoCommerce.Platform.Modules/AssemblyLoading/PlatformInformation.cs
+++ b/src/VirtoCommerce.Platform.Modules/AssemblyLoading/PlatformInformation.cs
@@ -35,7 +35,7 @@ namespace VirtoCommerce.Platform.Modules.AssemblyLoading
             {
                 NativeLibraryPrefixes = new[] { "", "lib", };
                 NativeLibraryExtensions = new[] { ".dylib" };
-                NuGetPackagesCache = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.Personal), ".nuget", "packages");
+                NuGetPackagesCache = Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.UserProfile), ".nuget", "packages");
                 DirectorySeparator = Path.AltDirectorySeparatorChar;
             }
             else if (RuntimeInformation.IsOSPlatform(OSPlatform.Linux))


### PR DESCRIPTION
Fixes the following problem: After updating to .Net8 on macOS, DLL dependencies of custom modules are not loaded, because the default search folder is now wrong.

See: https://learn.microsoft.com/en-us/dotnet/core/compatibility/core-libraries/8.0/getfolderpath-unix