### PR TITLE
VCST-430: Simplify event handlers registration

### DIFF
--- a/src/VirtoCommerce.Platform.Caching/PlatformMemoryCache.cs
+++ b/src/VirtoCommerce.Platform.Caching/PlatformMemoryCache.cs
@@ -21,7 +21,7 @@ namespace VirtoCommerce.Platform.Caching
             SlidingExpiration = cachingOptions.CacheSlidingExpiration;
             _log = log;
         }
-        
+
         public virtual ICacheEntry CreateEntry(object key)
         {
             var result = _memoryCache.CreateEntry(key);
@@ -88,7 +88,7 @@ namespace VirtoCommerce.Platform.Caching
         {
             Dispose(true);
             // This object will be cleaned up by the Dispose method.
-            // Therefore, you should call GC.SupressFinalize to
+            // Therefore, you should call GC.SuppressFinalize to
             // take this object off the finalization queue
             // and prevent finalization code for this object
             // from executing a second time.
@@ -107,10 +107,10 @@ namespace VirtoCommerce.Platform.Caching
             }
         }
 
-        
+
         protected virtual void EvictionCallback(object key, object value, EvictionReason reason, object state)
         {
             _log.LogTrace($"EvictionCallback: Cache entry with key:{key} has been removed.");
-        }        
+        }
     }
 }

--- a/src/VirtoCommerce.Platform.Core/Bus/HandlerWrapper.cs
+++ b/src/VirtoCommerce.Platform.Core/Bus/HandlerWrapper.cs
@@ -8,9 +8,10 @@ using VirtoCommerce.Platform.Core.Messages;
 
 namespace VirtoCommerce.Platform.Core.Bus
 {
+    [DebuggerDisplay("{HandlerModuleName} {EventType.Name}")]
     public sealed class HandlerWrapper
     {
-        public string EventName { get; set; }
+        public Type EventType { get; set; }
 
         public string HandlerModuleName { get; set; }
 
@@ -26,8 +27,9 @@ namespace VirtoCommerce.Platform.Core.Bus
                 Handler(@event, cancellationToken).GetAwaiter().GetResult();
                 stopWatch.Stop();
 
-                Logger.LogInformation($"event:{EventName} module:{HandlerModuleName} overall_elapsed:{stopWatch.ElapsedMilliseconds}");
-            });
+                Logger.LogInformation("event:{Event} module:{Handler} overall_elapsed:{Elapsed}",
+                    @event.GetType().Name, HandlerModuleName, stopWatch.ElapsedMilliseconds);
+            }, cancellationToken);
         }
     }
 }

--- a/src/VirtoCommerce.Platform.Core/Bus/IHandlerRegistrar.cs
+++ b/src/VirtoCommerce.Platform.Core/Bus/IHandlerRegistrar.cs
@@ -7,6 +7,7 @@ namespace VirtoCommerce.Platform.Core.Bus
 {
     public interface IHandlerRegistrar
     {
+        void RegisterHandler<T>(Func<T, Task> handler) where T : IMessage;
         void RegisterHandler<T>(Func<T, CancellationToken, Task> handler) where T : IMessage;
     }
 }

--- a/src/VirtoCommerce.Platform.Core/Bus/IHandlerRegistrar.cs
+++ b/src/VirtoCommerce.Platform.Core/Bus/IHandlerRegistrar.cs
@@ -7,6 +7,7 @@ namespace VirtoCommerce.Platform.Core.Bus
 {
     public interface IHandlerRegistrar
     {
+        [Obsolete("Use IApplicationBuilder.RegisterEventHandler<>()", DiagnosticId = "VC0008", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
         void RegisterHandler<T>(Func<T, CancellationToken, Task> handler) where T : IMessage;
     }
 }

--- a/src/VirtoCommerce.Platform.Core/Bus/IHandlerRegistrar.cs
+++ b/src/VirtoCommerce.Platform.Core/Bus/IHandlerRegistrar.cs
@@ -7,6 +7,6 @@ namespace VirtoCommerce.Platform.Core.Bus
 {
     public interface IHandlerRegistrar
     {
-        void RegisterHandler<T>(Func<T, CancellationToken,Task> handler) where T : class, IMessage;
+        void RegisterHandler<T>(Func<T, CancellationToken, Task> handler) where T : IMessage;
     }
 }

--- a/src/VirtoCommerce.Platform.Core/Bus/IHandlerRegistrar.cs
+++ b/src/VirtoCommerce.Platform.Core/Bus/IHandlerRegistrar.cs
@@ -7,7 +7,6 @@ namespace VirtoCommerce.Platform.Core.Bus
 {
     public interface IHandlerRegistrar
     {
-        void RegisterHandler<T>(Func<T, Task> handler) where T : IMessage;
         void RegisterHandler<T>(Func<T, CancellationToken, Task> handler) where T : IMessage;
     }
 }

--- a/src/VirtoCommerce.Platform.Core/Bus/InProcessBus.cs
+++ b/src/VirtoCommerce.Platform.Core/Bus/InProcessBus.cs
@@ -68,16 +68,15 @@ namespace VirtoCommerce.Platform.Core.Bus
                 return;
             }
 
-            var eventType = typeof(T);
+            var eventType = @event.GetType();
 
-            var tasks = _handlers
+            var handlers = _handlers
                 .Where(x => x.EventType.IsAssignableFrom(eventType))
-                .Select(x => x.Handle(@event, cancellationToken))
                 .ToList();
 
-            if (tasks.Count > 0)
+            if (handlers.Count > 0)
             {
-                await Task.WhenAll(tasks);
+                await Task.WhenAll(handlers.Select(x => x.Handle(@event, cancellationToken)));
             }
         }
     }

--- a/src/VirtoCommerce.Platform.Core/Bus/InProcessBus.cs
+++ b/src/VirtoCommerce.Platform.Core/Bus/InProcessBus.cs
@@ -19,6 +19,22 @@ namespace VirtoCommerce.Platform.Core.Bus
             _logger = logger;
         }
 
+        public void RegisterHandler<T>(Func<T, Task> handler)
+            where T : IMessage
+        {
+            var eventType = typeof(T);
+
+            var handlerWrapper = new HandlerWrapper
+            {
+                EventType = eventType,
+                HandlerModuleName = handler.Target?.GetType().Module.Assembly.GetName().Name,
+                Handler = (message, _) => handler((T)message),
+                Logger = _logger
+            };
+
+            _handlers.Add(handlerWrapper);
+        }
+
         public void RegisterHandler<T>(Func<T, CancellationToken, Task> handler)
             where T : IMessage
         {

--- a/src/VirtoCommerce.Platform.Core/Bus/InProcessBus.cs
+++ b/src/VirtoCommerce.Platform.Core/Bus/InProcessBus.cs
@@ -9,7 +9,7 @@ using VirtoCommerce.Platform.Core.Messages;
 
 namespace VirtoCommerce.Platform.Core.Bus
 {
-    public class InProcessBus : IEventPublisher, IHandlerRegistrar, IEventHandlerRegistrar
+    public class InProcessBus : IEventHandlerRegistrar, IEventPublisher, IHandlerRegistrar
     {
         private readonly ILogger<InProcessBus> _logger;
         private readonly List<HandlerWrapper> _handlers = [];
@@ -17,22 +17,6 @@ namespace VirtoCommerce.Platform.Core.Bus
         public InProcessBus(ILogger<InProcessBus> logger)
         {
             _logger = logger;
-        }
-
-        public void RegisterHandler<T>(Func<T, CancellationToken, Task> handler)
-            where T : IMessage
-        {
-            var eventType = typeof(T);
-
-            var handlerWrapper = new HandlerWrapper
-            {
-                EventType = eventType,
-                HandlerModuleName = handler.Target?.GetType().Module.Assembly.GetName().Name,
-                Handler = (message, token) => handler((T)message, token),
-                Logger = _logger
-            };
-
-            _handlers.Add(handlerWrapper);
         }
 
         public void RegisterEventHandler<T>(Func<T, Task> handler)
@@ -53,6 +37,12 @@ namespace VirtoCommerce.Platform.Core.Bus
 
         public void RegisterEventHandler<T>(Func<T, CancellationToken, Task> handler)
             where T : IEvent
+        {
+            RegisterHandler(handler);
+        }
+
+        public void RegisterHandler<T>(Func<T, CancellationToken, Task> handler)
+            where T : IMessage
         {
             var eventType = typeof(T);
 

--- a/src/VirtoCommerce.Platform.Core/Bus/InProcessBus.cs
+++ b/src/VirtoCommerce.Platform.Core/Bus/InProcessBus.cs
@@ -38,9 +38,12 @@ namespace VirtoCommerce.Platform.Core.Bus
         public void RegisterEventHandler<T>(Func<T, CancellationToken, Task> handler)
             where T : IEvent
         {
+#pragma warning disable VC0008 // Type or member is obsolete
             RegisterHandler(handler);
+#pragma warning restore VC0008 // Type or member is obsolete
         }
 
+        [Obsolete("Use IApplicationBuilder.RegisterEventHandler<>()", DiagnosticId = "VC0008", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
         public void RegisterHandler<T>(Func<T, CancellationToken, Task> handler)
             where T : IMessage
         {

--- a/src/VirtoCommerce.Platform.Core/Events/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Events/ApplicationBuilderExtensions.cs
@@ -1,0 +1,32 @@
+using Microsoft.AspNetCore.Builder;
+using Microsoft.Extensions.DependencyInjection;
+using VirtoCommerce.Platform.Core.Bus;
+
+namespace VirtoCommerce.Platform.Core.Events;
+
+public static class ApplicationBuilderExtensions
+{
+    public static IApplicationBuilder RegisterHandler<TEvent, THandler>(this IApplicationBuilder applicationBuilder)
+        where TEvent : IEvent
+        where THandler : IEventHandler<TEvent>
+    {
+        var handlerRegistrar = applicationBuilder.ApplicationServices.GetService<IHandlerRegistrar>();
+        var handler = applicationBuilder.ApplicationServices.GetService<THandler>();
+
+        handlerRegistrar.RegisterHandler<TEvent>((@event, _) => handler.Handle(@event));
+
+        return applicationBuilder;
+    }
+
+    public static IApplicationBuilder RegisterCancellableHandler<TEvent, THandler>(this IApplicationBuilder applicationBuilder)
+        where TEvent : IEvent
+        where THandler : ICancellableEventHandler<TEvent>
+    {
+        var handlerRegistrar = applicationBuilder.ApplicationServices.GetService<IHandlerRegistrar>();
+        var handler = applicationBuilder.ApplicationServices.GetService<THandler>();
+
+        handlerRegistrar.RegisterHandler<TEvent>(handler.Handle);
+
+        return applicationBuilder;
+    }
+}

--- a/src/VirtoCommerce.Platform.Core/Events/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Events/ApplicationBuilderExtensions.cs
@@ -1,31 +1,30 @@
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
-using VirtoCommerce.Platform.Core.Bus;
 
 namespace VirtoCommerce.Platform.Core.Events;
 
 public static class ApplicationBuilderExtensions
 {
-    public static IApplicationBuilder RegisterHandler<TEvent, THandler>(this IApplicationBuilder applicationBuilder)
+    public static IApplicationBuilder RegisterEventHandler<TEvent, THandler>(this IApplicationBuilder applicationBuilder)
         where TEvent : IEvent
         where THandler : IEventHandler<TEvent>
     {
-        var handlerRegistrar = applicationBuilder.ApplicationServices.GetService<IHandlerRegistrar>();
-        var handler = applicationBuilder.ApplicationServices.GetService<THandler>();
+        var registrar = applicationBuilder.ApplicationServices.GetRequiredService<IEventHandlerRegistrar>();
+        var handler = applicationBuilder.ApplicationServices.GetRequiredService<THandler>();
 
-        handlerRegistrar.RegisterHandler<TEvent>(handler.Handle);
+        registrar.RegisterEventHandler<TEvent>(handler.Handle);
 
         return applicationBuilder;
     }
 
-    public static IApplicationBuilder RegisterCancellableHandler<TEvent, THandler>(this IApplicationBuilder applicationBuilder)
+    public static IApplicationBuilder RegisterCancellableEventHandler<TEvent, THandler>(this IApplicationBuilder applicationBuilder)
         where TEvent : IEvent
         where THandler : ICancellableEventHandler<TEvent>
     {
-        var handlerRegistrar = applicationBuilder.ApplicationServices.GetService<IHandlerRegistrar>();
-        var handler = applicationBuilder.ApplicationServices.GetService<THandler>();
+        var registrar = applicationBuilder.ApplicationServices.GetRequiredService<IEventHandlerRegistrar>();
+        var handler = applicationBuilder.ApplicationServices.GetRequiredService<THandler>();
 
-        handlerRegistrar.RegisterHandler<TEvent>(handler.Handle);
+        registrar.RegisterEventHandler<TEvent>(handler.Handle);
 
         return applicationBuilder;
     }

--- a/src/VirtoCommerce.Platform.Core/Events/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Events/ApplicationBuilderExtensions.cs
@@ -13,7 +13,7 @@ public static class ApplicationBuilderExtensions
         var handlerRegistrar = applicationBuilder.ApplicationServices.GetService<IHandlerRegistrar>();
         var handler = applicationBuilder.ApplicationServices.GetService<THandler>();
 
-        handlerRegistrar.RegisterHandler<TEvent>((@event, _) => handler.Handle(@event));
+        handlerRegistrar.RegisterHandler<TEvent>(handler.Handle);
 
         return applicationBuilder;
     }

--- a/src/VirtoCommerce.Platform.Core/Events/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Events/ApplicationBuilderExtensions.cs
@@ -1,3 +1,6 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 
@@ -9,11 +12,15 @@ public static class ApplicationBuilderExtensions
         where TEvent : IEvent
         where THandler : IEventHandler<TEvent>
     {
-        var registrar = applicationBuilder.ApplicationServices.GetRequiredService<IEventHandlerRegistrar>();
         var handler = applicationBuilder.ApplicationServices.GetRequiredService<THandler>();
+        return applicationBuilder.RegisterEventHandler<TEvent>(handler.Handle);
+    }
 
-        registrar.RegisterEventHandler<TEvent>(handler.Handle);
-
+    public static IApplicationBuilder RegisterEventHandler<TEvent>(this IApplicationBuilder applicationBuilder, Func<TEvent, Task> handler)
+        where TEvent : IEvent
+    {
+        var registrar = applicationBuilder.ApplicationServices.GetRequiredService<IEventHandlerRegistrar>();
+        registrar.RegisterEventHandler(handler);
         return applicationBuilder;
     }
 
@@ -21,11 +28,15 @@ public static class ApplicationBuilderExtensions
         where TEvent : IEvent
         where THandler : ICancellableEventHandler<TEvent>
     {
-        var registrar = applicationBuilder.ApplicationServices.GetRequiredService<IEventHandlerRegistrar>();
         var handler = applicationBuilder.ApplicationServices.GetRequiredService<THandler>();
+        return applicationBuilder.RegisterCancellableEventHandler<TEvent>(handler.Handle);
+    }
 
-        registrar.RegisterEventHandler<TEvent>(handler.Handle);
-
+    public static IApplicationBuilder RegisterCancellableEventHandler<TEvent>(this IApplicationBuilder applicationBuilder, Func<TEvent, CancellationToken, Task> handler)
+        where TEvent : IEvent
+    {
+        var registrar = applicationBuilder.ApplicationServices.GetRequiredService<IEventHandlerRegistrar>();
+        registrar.RegisterEventHandler(handler);
         return applicationBuilder;
     }
 }

--- a/src/VirtoCommerce.Platform.Core/Events/EventSuppressor.cs
+++ b/src/VirtoCommerce.Platform.Core/Events/EventSuppressor.cs
@@ -31,20 +31,23 @@ namespace VirtoCommerce.Platform.Core.Events
             }
         }
 
-        private static readonly AsyncLocal<bool> EventsSuppressedStorage = new AsyncLocal<bool>();
+        private static readonly AsyncLocal<bool> _eventsSuppressedStorage = new();
 
         /// <summary>
         /// The flag indicates that events are suppressed for the current asynchronous control flow
         /// </summary>
-        public static bool EventsSuppressed => EventsSuppressedStorage.Value;
+        public static bool EventsSuppressed => _eventsSuppressedStorage.Value;
+
+        [Obsolete("Use SuppressEvents()", DiagnosticId = "VC0008", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions/")]
+        public static IDisposable SupressEvents() => SuppressEvents();
 
         /// <summary>
         /// The flag indicates that events are suppressed for the current asynchronous control flow
         /// </summary>
-        public static IDisposable SupressEvents()
+        public static IDisposable SuppressEvents()
         {
-            EventsSuppressedStorage.Value = true;
-            return new DisposableActionGuard(() => { EventsSuppressedStorage.Value = false; });
+            _eventsSuppressedStorage.Value = true;
+            return new DisposableActionGuard(() => { _eventsSuppressedStorage.Value = false; });
         }
     }
 }

--- a/src/VirtoCommerce.Platform.Core/Events/IEventHandlerRegistrar.cs
+++ b/src/VirtoCommerce.Platform.Core/Events/IEventHandlerRegistrar.cs
@@ -1,0 +1,11 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VirtoCommerce.Platform.Core.Events;
+
+public interface IEventHandlerRegistrar
+{
+    void RegisterEventHandler<T>(Func<T, Task> handler) where T : IEvent;
+    void RegisterEventHandler<T>(Func<T, CancellationToken, Task> handler) where T : IEvent;
+}

--- a/src/VirtoCommerce.Platform.Core/Events/IEventPublisher.cs
+++ b/src/VirtoCommerce.Platform.Core/Events/IEventPublisher.cs
@@ -5,6 +5,6 @@ namespace VirtoCommerce.Platform.Core.Events
 {
     public interface IEventPublisher
     {
-        Task Publish<T>(T @event, CancellationToken cancellationToken = default(CancellationToken)) where T : class, IEvent;
+        Task Publish<T>(T @event, CancellationToken cancellationToken = default) where T : IEvent;
     }
 }

--- a/src/VirtoCommerce.Platform.Data/ExportImport/PlatformExportImportManager.cs
+++ b/src/VirtoCommerce.Platform.Data/ExportImport/PlatformExportImportManager.cs
@@ -129,7 +129,7 @@ namespace VirtoCommerce.Platform.Data.ExportImport
             progressCallback(progressInfo);
 
             using (var zipArchive = new ZipArchive(inputStream, ZipArchiveMode.Read, true))
-            using (EventSuppressor.SupressEvents())
+            using (EventSuppressor.SuppressEvents())
             {
                 //Import selected platform entries
                 await ImportPlatformEntriesInternalAsync(zipArchive, importOptions, progressCallback, сancellationToken);

--- a/src/VirtoCommerce.Platform.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Data/Extensions/ServiceCollectionExtensions.cs
@@ -39,6 +39,7 @@ namespace VirtoCommerce.Platform.Data.Extensions
 
             services.AddSingleton<InProcessBus>();
             services.AddSingleton<IHandlerRegistrar>(x => x.GetRequiredService<InProcessBus>());
+            services.AddSingleton<IEventHandlerRegistrar>(x => x.GetRequiredService<InProcessBus>());
             services.AddSingleton<IEventPublisher>(x => x.GetRequiredService<InProcessBus>());
             services.AddTransient<IChangeLogService, ChangeLogService>();
             services.AddTransient<ILastModifiedDateTime, ChangeLogService>();

--- a/src/VirtoCommerce.Platform.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Data/Extensions/ServiceCollectionExtensions.cs
@@ -38,8 +38,8 @@ namespace VirtoCommerce.Platform.Data.Extensions
             services.AddDynamicProperties();
 
             services.AddSingleton<InProcessBus>();
-            services.AddSingleton<IHandlerRegistrar>(x => x.GetRequiredService<InProcessBus>());
             services.AddSingleton<IEventHandlerRegistrar>(x => x.GetRequiredService<InProcessBus>());
+            services.AddSingleton<IHandlerRegistrar>(x => x.GetRequiredService<InProcessBus>());
             services.AddSingleton<IEventPublisher>(x => x.GetRequiredService<InProcessBus>());
             services.AddTransient<IChangeLogService, ChangeLogService>();
             services.AddTransient<ILastModifiedDateTime, ChangeLogService>();

--- a/src/VirtoCommerce.Platform.Hangfire/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Hangfire/Extensions/ApplicationBuilderExtensions.cs
@@ -61,10 +61,9 @@ namespace VirtoCommerce.Platform.Hangfire.Extensions
             var mvcJsonOptions = appBuilder.ApplicationServices.GetService<IOptions<MvcNewtonsoftJsonOptions>>();
             GlobalConfiguration.Configuration.UseSerializerSettings(mvcJsonOptions.Value.SerializerSettings);
 
-            var eventHandlerRegistrar = appBuilder.ApplicationServices.GetService<IEventHandlerRegistrar>();
             var recurringJobManager = appBuilder.ApplicationServices.GetService<IRecurringJobManager>();
             var settingsManager = appBuilder.ApplicationServices.GetService<ISettingsManager>();
-            eventHandlerRegistrar.RegisterEventHandler<ObjectSettingChangedEvent>(async (message, _) =>
+            appBuilder.RegisterEventHandler<ObjectSettingChangedEvent>(async message =>
                 await recurringJobManager.HandleSettingChangeAsync(settingsManager, message));
 
             // Add Hangfire filters/middlewares

--- a/src/VirtoCommerce.Platform.Hangfire/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Hangfire/Extensions/ApplicationBuilderExtensions.cs
@@ -63,8 +63,7 @@ namespace VirtoCommerce.Platform.Hangfire.Extensions
 
             var recurringJobManager = appBuilder.ApplicationServices.GetService<IRecurringJobManager>();
             var settingsManager = appBuilder.ApplicationServices.GetService<ISettingsManager>();
-            appBuilder.RegisterEventHandler<ObjectSettingChangedEvent>(async message =>
-                await recurringJobManager.HandleSettingChangeAsync(settingsManager, message));
+            appBuilder.RegisterEventHandler<ObjectSettingChangedEvent>(message => recurringJobManager.HandleSettingChangeAsync(settingsManager, message));
 
             // Add Hangfire filters/middlewares
             var userNameResolver = appBuilder.ApplicationServices.CreateScope().ServiceProvider.GetRequiredService<IUserNameResolver>();

--- a/src/VirtoCommerce.Platform.Hangfire/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Hangfire/Extensions/ApplicationBuilderExtensions.cs
@@ -8,7 +8,7 @@ using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Configuration;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.Options;
-using VirtoCommerce.Platform.Core.Bus;
+using VirtoCommerce.Platform.Core.Events;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Settings;
 using VirtoCommerce.Platform.Core.Settings.Events;
@@ -61,10 +61,11 @@ namespace VirtoCommerce.Platform.Hangfire.Extensions
             var mvcJsonOptions = appBuilder.ApplicationServices.GetService<IOptions<MvcNewtonsoftJsonOptions>>();
             GlobalConfiguration.Configuration.UseSerializerSettings(mvcJsonOptions.Value.SerializerSettings);
 
-            var inProcessBus = appBuilder.ApplicationServices.GetService<IHandlerRegistrar>();
+            var eventHandlerRegistrar = appBuilder.ApplicationServices.GetService<IEventHandlerRegistrar>();
             var recurringJobManager = appBuilder.ApplicationServices.GetService<IRecurringJobManager>();
             var settingsManager = appBuilder.ApplicationServices.GetService<ISettingsManager>();
-            inProcessBus.RegisterHandler<ObjectSettingChangedEvent>(async (message, token) => await recurringJobManager.HandleSettingChangeAsync(settingsManager, message));
+            eventHandlerRegistrar.RegisterEventHandler<ObjectSettingChangedEvent>(async (message, _) =>
+                await recurringJobManager.HandleSettingChangeAsync(settingsManager, message));
 
             // Add Hangfire filters/middlewares
             var userNameResolver = appBuilder.ApplicationServices.CreateScope().ServiceProvider.GetRequiredService<IUserNameResolver>();

--- a/src/VirtoCommerce.Platform.Web/Security/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Web/Security/ApplicationBuilderExtensions.cs
@@ -29,14 +29,14 @@ namespace VirtoCommerce.Platform.Web.Security
 
         public static IApplicationBuilder UseSecurityHandlers(this IApplicationBuilder appBuilder)
         {
-            appBuilder.RegisterHandler<UserChangedEvent, LogChangesUserChangedEventHandler>();
-            appBuilder.RegisterHandler<UserChangedEvent, UserApiKeyActualizeEventHandler>();
-            appBuilder.RegisterHandler<UserPasswordChangedEvent, LogChangesUserChangedEventHandler>();
-            appBuilder.RegisterHandler<UserResetPasswordEvent, LogChangesUserChangedEventHandler>();
-            appBuilder.RegisterHandler<UserLoginEvent, LogChangesUserChangedEventHandler>();
-            appBuilder.RegisterHandler<UserLogoutEvent, LogChangesUserChangedEventHandler>();
-            appBuilder.RegisterHandler<UserRoleAddedEvent, LogChangesUserChangedEventHandler>();
-            appBuilder.RegisterHandler<UserRoleRemovedEvent, LogChangesUserChangedEventHandler>();
+            appBuilder.RegisterEventHandler<UserChangedEvent, LogChangesUserChangedEventHandler>();
+            appBuilder.RegisterEventHandler<UserChangedEvent, UserApiKeyActualizeEventHandler>();
+            appBuilder.RegisterEventHandler<UserPasswordChangedEvent, LogChangesUserChangedEventHandler>();
+            appBuilder.RegisterEventHandler<UserResetPasswordEvent, LogChangesUserChangedEventHandler>();
+            appBuilder.RegisterEventHandler<UserLoginEvent, LogChangesUserChangedEventHandler>();
+            appBuilder.RegisterEventHandler<UserLogoutEvent, LogChangesUserChangedEventHandler>();
+            appBuilder.RegisterEventHandler<UserRoleAddedEvent, LogChangesUserChangedEventHandler>();
+            appBuilder.RegisterEventHandler<UserRoleRemovedEvent, LogChangesUserChangedEventHandler>();
 
             return appBuilder;
         }

--- a/src/VirtoCommerce.Platform.Web/Security/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Web/Security/ApplicationBuilderExtensions.cs
@@ -3,8 +3,8 @@ using Hangfire;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
 using VirtoCommerce.Platform.Core;
-using VirtoCommerce.Platform.Core.Bus;
 using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Events;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Security.Events;
 using VirtoCommerce.Platform.Core.Settings;
@@ -29,15 +29,14 @@ namespace VirtoCommerce.Platform.Web.Security
 
         public static IApplicationBuilder UseSecurityHandlers(this IApplicationBuilder appBuilder)
         {
-            var inProcessBus = appBuilder.ApplicationServices.GetService<IHandlerRegistrar>();
-            inProcessBus.RegisterHandler<UserChangedEvent>(async (message, token) => await appBuilder.ApplicationServices.GetService<LogChangesUserChangedEventHandler>().Handle(message));
-            inProcessBus.RegisterHandler<UserChangedEvent>(async (message, token) => await appBuilder.ApplicationServices.GetService<UserApiKeyActualizeEventHandler>().Handle(message));
-            inProcessBus.RegisterHandler<UserPasswordChangedEvent>(async (message, token) => await appBuilder.ApplicationServices.GetService<LogChangesUserChangedEventHandler>().Handle(message));
-            inProcessBus.RegisterHandler<UserResetPasswordEvent>(async (message, token) => await appBuilder.ApplicationServices.GetService<LogChangesUserChangedEventHandler>().Handle(message));
-            inProcessBus.RegisterHandler<UserLoginEvent>(async (message, token) => await appBuilder.ApplicationServices.GetService<LogChangesUserChangedEventHandler>().Handle(message));
-            inProcessBus.RegisterHandler<UserLogoutEvent>(async (message, token) => await appBuilder.ApplicationServices.GetService<LogChangesUserChangedEventHandler>().Handle(message));
-            inProcessBus.RegisterHandler<UserRoleAddedEvent>(async (message, token) => await appBuilder.ApplicationServices.GetService<LogChangesUserChangedEventHandler>().Handle(message));
-            inProcessBus.RegisterHandler<UserRoleRemovedEvent>(async (message, token) => await appBuilder.ApplicationServices.GetService<LogChangesUserChangedEventHandler>().Handle(message));
+            appBuilder.RegisterHandler<UserChangedEvent, LogChangesUserChangedEventHandler>();
+            appBuilder.RegisterHandler<UserChangedEvent, UserApiKeyActualizeEventHandler>();
+            appBuilder.RegisterHandler<UserPasswordChangedEvent, LogChangesUserChangedEventHandler>();
+            appBuilder.RegisterHandler<UserResetPasswordEvent, LogChangesUserChangedEventHandler>();
+            appBuilder.RegisterHandler<UserLoginEvent, LogChangesUserChangedEventHandler>();
+            appBuilder.RegisterHandler<UserLogoutEvent, LogChangesUserChangedEventHandler>();
+            appBuilder.RegisterHandler<UserRoleAddedEvent, LogChangesUserChangedEventHandler>();
+            appBuilder.RegisterHandler<UserRoleRemovedEvent, LogChangesUserChangedEventHandler>();
 
             return appBuilder;
         }

--- a/src/VirtoCommerce.Platform.Web/Security/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Web/Security/ServiceCollectionExtensions.cs
@@ -4,7 +4,6 @@ using Microsoft.AspNetCore.HttpOverrides;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.DependencyInjection;
 using Microsoft.Extensions.DependencyInjection.Extensions;
-using VirtoCommerce.Platform.Core.ChangeLog;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Security.Search;
@@ -57,8 +56,8 @@ namespace VirtoCommerce.Platform.Web.Security
                 services.Configure(setupAction);
             }
 
-            services.AddSingleton(provider => new LogChangesUserChangedEventHandler(provider.CreateScope().ServiceProvider.GetService<IChangeLogService>()));
-            services.AddSingleton(provider => new UserApiKeyActualizeEventHandler(provider.CreateScope().ServiceProvider.GetService<IUserApiKeyService>()));
+            services.AddSingleton<LogChangesUserChangedEventHandler>();
+            services.AddSingleton<UserApiKeyActualizeEventHandler>();
 
             services.AddTransient<IServerCertificateService, ServerCertificateService>();
 

--- a/src/VirtoCommerce.Platform.Web/Security/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Web/Security/ServiceCollectionExtensions.cs
@@ -22,8 +22,8 @@ namespace VirtoCommerce.Platform.Web.Security
             services.AddTransient<ISecurityRepository, SecurityRepository>();
             services.AddTransient<Func<ISecurityRepository>>(provider => () => provider.CreateScope().ServiceProvider.GetService<ISecurityRepository>());
 
-            services.AddScoped<IUserApiKeyService, UserApiKeyService>();
-            services.AddScoped<IUserApiKeySearchService, UserApiKeySearchService>();
+            services.AddSingleton<IUserApiKeyService, UserApiKeyService>();
+            services.AddSingleton<IUserApiKeySearchService, UserApiKeySearchService>();
 
             services.AddScoped<IUserNameResolver, HttpContextUserResolver>();
             services.AddSingleton<IPermissionsRegistrar, DefaultPermissionProvider>();

--- a/tests/VirtoCommerce.Platform.Tests/Common/CountriesServiceTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/Common/CountriesServiceTests.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading.Tasks;
 using Moq;
 using Nager.Country;
 using VirtoCommerce.Platform.Core.Common;
@@ -10,12 +11,12 @@ namespace VirtoCommerce.Platform.Tests.Common
     public class CountriesServiceTests
     {
         [Fact]
-        public void CanGetCountries()
+        public async Task CanGetCountries()
         {
             var filesystemCountryService = new Mock<ICountriesService>();
             var service = new CountriesService(filesystemCountryService.Object as FileSystemCountriesService);
 
-            var countries = service.GetCountriesAsync().GetAwaiter().GetResult();
+            var countries = await service.GetCountriesAsync();
 
             Assert.Equal(249, countries.Count);
         }

--- a/tests/VirtoCommerce.Platform.Tests/Events/EventHandlerTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/Events/EventHandlerTests.cs
@@ -1,0 +1,39 @@
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.Extensions.Logging;
+using Moq;
+using VirtoCommerce.Platform.Core.Bus;
+using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Core.Security.Events;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Tests.Events;
+
+[Trait("Category", "Unit")]
+public class EventHandlerTests
+{
+    [Fact]
+    public async Task HandleMultipleEventTypesWithSingleRegistration()
+    {
+        var bus = new InProcessBus(new Mock<ILogger<InProcessBus>>().Object);
+
+        var domainHandlerEvents = new List<string>();
+        var userLoginHandlerEvents = new List<string>();
+        var userChangedHandlerEvents = new List<string>();
+
+        // This handler should handle all event types
+        bus.RegisterHandler<DomainEvent>((message, _) => { domainHandlerEvents.Add(message.GetType().Name); return Task.CompletedTask; });
+
+        // These handlers should handle only specific event types
+        bus.RegisterHandler<UserLoginEvent>((message, _) => { userLoginHandlerEvents.Add(message.GetType().Name); return Task.CompletedTask; });
+        bus.RegisterHandler<UserChangedEvent>((message, _) => { userChangedHandlerEvents.Add(message.GetType().Name); return Task.CompletedTask; });
+
+        await bus.Publish(new UserLoginEvent(user: null));
+        await bus.Publish(new UserChangedEvent(changedEntries: null));
+
+        domainHandlerEvents.Should().BeEquivalentTo([nameof(UserLoginEvent), nameof(UserChangedEvent)]);
+        userLoginHandlerEvents.Should().BeEquivalentTo([nameof(UserLoginEvent)]);
+        userChangedHandlerEvents.Should().BeEquivalentTo([nameof(UserChangedEvent)]);
+    }
+}

--- a/tests/VirtoCommerce.Platform.Tests/Events/EventHandlerTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/Events/EventHandlerTests.cs
@@ -23,11 +23,11 @@ public class EventHandlerTests
         var userChangedHandlerEvents = new List<string>();
 
         // This handler should handle all event types
-        bus.RegisterHandler<DomainEvent>((message, _) => { domainHandlerEvents.Add(message.GetType().Name); return Task.CompletedTask; });
+        bus.RegisterEventHandler<DomainEvent>(message => Handle(message, domainHandlerEvents));
 
         // These handlers should handle only specific event types
-        bus.RegisterHandler<UserLoginEvent>((message, _) => { userLoginHandlerEvents.Add(message.GetType().Name); return Task.CompletedTask; });
-        bus.RegisterHandler<UserChangedEvent>((message, _) => { userChangedHandlerEvents.Add(message.GetType().Name); return Task.CompletedTask; });
+        bus.RegisterEventHandler<UserLoginEvent>(message => Handle(message, userLoginHandlerEvents));
+        bus.RegisterEventHandler<UserChangedEvent>(message => Handle(message, userChangedHandlerEvents));
 
         await bus.Publish(new UserLoginEvent(user: null));
         await bus.Publish(new UserChangedEvent(changedEntries: null));
@@ -35,5 +35,12 @@ public class EventHandlerTests
         domainHandlerEvents.Should().BeEquivalentTo([nameof(UserLoginEvent), nameof(UserChangedEvent)]);
         userLoginHandlerEvents.Should().BeEquivalentTo([nameof(UserLoginEvent)]);
         userChangedHandlerEvents.Should().BeEquivalentTo([nameof(UserChangedEvent)]);
+    }
+
+    private static Task Handle<T>(T message, List<string> events) where T : IEvent
+    {
+        events.Add(message.GetType().Name);
+
+        return Task.CompletedTask;
     }
 }

--- a/tests/VirtoCommerce.Platform.Tests/Events/EventSuppressorTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/Events/EventSuppressorTests.cs
@@ -6,14 +6,14 @@ using Xunit;
 namespace VirtoCommerce.Platform.Tests.Events
 {
     [Trait("Category", "Unit")]
-    public class EventSupressorTests
+    public class EventSuppressorTests
     {
         [Fact]
         public void SuppressInCurrentThread()
         {
             Assert.False(EventSuppressor.EventsSuppressed, "EventSuppressor shouldn't be active in this thread before test.");
 
-            using (EventSuppressor.SupressEvents())
+            using (EventSuppressor.SuppressEvents())
             {
                 Assert.True(EventSuppressor.EventsSuppressed, "EventSuppressor should be active in this thread.");
             }
@@ -27,7 +27,7 @@ namespace VirtoCommerce.Platform.Tests.Events
             Assert.False(EventSuppressor.EventsSuppressed,
                 "EventSuppressor shouldn't be active in this thread before test.");
 
-            using (EventSuppressor.SupressEvents())
+            using (EventSuppressor.SuppressEvents())
             {
                 Assert.True(EventSuppressor.EventsSuppressed, "EventSuppressor should be active in this thread.");
                 Task.Run(() =>
@@ -54,7 +54,7 @@ namespace VirtoCommerce.Platform.Tests.Events
 
             var checkTask = notInteritedAction();
 
-            using (EventSuppressor.SupressEvents())
+            using (EventSuppressor.SuppressEvents())
             {
                 Assert.True(EventSuppressor.EventsSuppressed, "EventSuppressor inherits value in another thread!");
                 taskCompletionSource.TrySetResult(null);
@@ -81,7 +81,7 @@ namespace VirtoCommerce.Platform.Tests.Events
 
             Task.Run(async () =>
             {
-                using (EventSuppressor.SupressEvents())
+                using (EventSuppressor.SuppressEvents())
                 {
                     Assert.True(EventSuppressor.EventsSuppressed, "EventSuppressor inherits value in another thread!");
                     taskCompletionSource.TrySetResult(null);


### PR DESCRIPTION
## Description
### Before
```csharp
var handlerRegistrar = appBuilder.ApplicationServices.GetService<IHandlerRegistrar>();
handlerRegistrar.RegisterHandler<UserChangedEvent>(async (message, token) => await appBuilder.ApplicationServices.GetService<LogChangesUserChangedEventHandler>().Handle(message));
```
### After
```csharp
appBuilder.RegisterEventHandler<UserChangedEvent, LogChangesUserChangedEventHandler>();
```

Also, now it's possible to register a handler for all event types:
```csharp
appBuilder.RegisterEventHandler<DomainEvent, AllEventsHandler>();
```

> [!Note]
> If you register an event handler for UserChangedEvent, this handler will receive UserChangedEvent and all events derived from UserChangedEvent.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-430
### Artifact URL:
