### PR TITLE
VCST-781: Publish two different events when changing password

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Security/Events/UserChangedPasswordEvent.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/Events/UserChangedPasswordEvent.cs
@@ -2,6 +2,9 @@ using VirtoCommerce.Platform.Core.Events;
 
 namespace VirtoCommerce.Platform.Core.Security.Events
 {
+    /// <summary>
+    /// This event is published when a user has changed their password.
+    /// </summary>
     public class UserChangedPasswordEvent : DomainEvent
     {
         public UserChangedPasswordEvent(string userId, string customPasswordHash)

--- a/src/VirtoCommerce.Platform.Core/Security/Events/UserChangedPasswordEvent.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/Events/UserChangedPasswordEvent.cs
@@ -2,9 +2,9 @@ using VirtoCommerce.Platform.Core.Events;
 
 namespace VirtoCommerce.Platform.Core.Security.Events
 {
-    public class UserResetPasswordEvent : DomainEvent
+    public class UserChangedPasswordEvent : DomainEvent
     {
-        public UserResetPasswordEvent(string userId, string customPasswordHash)
+        public UserChangedPasswordEvent(string userId, string customPasswordHash)
         {
             UserId = userId;
             CustomPasswordHash = customPasswordHash;

--- a/src/VirtoCommerce.Platform.Core/Security/Events/UserPasswordChangedEvent.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/Events/UserPasswordChangedEvent.cs
@@ -19,7 +19,7 @@ namespace VirtoCommerce.Platform.Core.Security.Events
         public string UserId { get; set; }
 
         /// <summary>
-        /// Password hash for external hash storage. This provided as workaround until password hash storage would implemented
+        /// Password hash for external hash storage. This provided as workaround until password hash storage is implemented
         /// </summary>         
         public string CustomPasswordHash { get; set; }
     }

--- a/src/VirtoCommerce.Platform.Core/Security/Events/UserPasswordChangedEvent.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/Events/UserPasswordChangedEvent.cs
@@ -2,6 +2,9 @@ using VirtoCommerce.Platform.Core.Events;
 
 namespace VirtoCommerce.Platform.Core.Security.Events
 {
+    /// <summary>
+    /// This event is published when a user's password is changed for any reason, including when the user changes or resets the password.
+    /// </summary>
     public class UserPasswordChangedEvent : DomainEvent
     {
         public UserPasswordChangedEvent(string userId, string customPasswordHash)

--- a/src/VirtoCommerce.Platform.Core/Security/Events/UserResetPasswordEvent.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/Events/UserResetPasswordEvent.cs
@@ -2,6 +2,9 @@ using VirtoCommerce.Platform.Core.Events;
 
 namespace VirtoCommerce.Platform.Core.Security.Events
 {
+    /// <summary>
+    /// This event is published when a user has reset their password.
+    /// </summary>
     public class UserResetPasswordEvent : DomainEvent
     {
         public UserResetPasswordEvent(string userId, string customPasswordHash)

--- a/src/VirtoCommerce.Platform.Security/CustomUserManager.cs
+++ b/src/VirtoCommerce.Platform.Security/CustomUserManager.cs
@@ -119,7 +119,7 @@ namespace VirtoCommerce.Platform.Security
         {
             return UpdatePasswordAsync(user, newPassword,
                 (user, newPassword) => base.ChangePasswordAsync(user, currentPassword, newPassword),
-                (userId, customPasswordHash) => new UserPasswordChangedEvent(userId, customPasswordHash));
+                (userId, customPasswordHash) => new UserChangedPasswordEvent(userId, customPasswordHash));
         }
 
         protected virtual async Task<IdentityResult> UpdatePasswordAsync<TEvent>(

--- a/src/VirtoCommerce.Platform.Security/Handlers/LogChangesUserChangedEventHandler.cs
+++ b/src/VirtoCommerce.Platform.Security/Handlers/LogChangesUserChangedEventHandler.cs
@@ -8,10 +8,15 @@ using VirtoCommerce.Platform.Core.Security.Events;
 
 namespace VirtoCommerce.Platform.Security.Handlers
 {
-    public class LogChangesUserChangedEventHandler : IEventHandler<UserChangedEvent>, IEventHandler<UserLoginEvent>,
-                                                     IEventHandler<UserLogoutEvent>, IEventHandler<UserPasswordChangedEvent>,
-                                                     IEventHandler<UserResetPasswordEvent>, IEventHandler<UserRoleAddedEvent>,
-                                                     IEventHandler<UserRoleRemovedEvent>
+    public class LogChangesUserChangedEventHandler :
+        IEventHandler<UserChangedEvent>,
+        IEventHandler<UserLoginEvent>,
+        IEventHandler<UserLogoutEvent>,
+        IEventHandler<UserPasswordChangedEvent>,
+        IEventHandler<UserResetPasswordEvent>,
+        IEventHandler<UserChangedPasswordEvent>,
+        IEventHandler<UserRoleAddedEvent>,
+        IEventHandler<UserRoleRemovedEvent>
     {
         private readonly IChangeLogService _changeLogService;
 
@@ -64,7 +69,12 @@ namespace VirtoCommerce.Platform.Security.Handlers
 
         public virtual async Task Handle(UserResetPasswordEvent message)
         {
-            await SaveOperationLogAsync(message.UserId, "Password resets", EntryState.Modified);
+            await SaveOperationLogAsync(message.UserId, "Reset password", EntryState.Modified);
+        }
+
+        public async Task Handle(UserChangedPasswordEvent message)
+        {
+            await SaveOperationLogAsync(message.UserId, "Changed password", EntryState.Modified);
         }
 
         public virtual Task Handle(UserRoleAddedEvent message)

--- a/src/VirtoCommerce.Platform.Web/Security/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Web/Security/ApplicationBuilderExtensions.cs
@@ -29,10 +29,12 @@ namespace VirtoCommerce.Platform.Web.Security
 
         public static IApplicationBuilder UseSecurityHandlers(this IApplicationBuilder appBuilder)
         {
-            appBuilder.RegisterEventHandler<UserChangedEvent, LogChangesUserChangedEventHandler>();
             appBuilder.RegisterEventHandler<UserChangedEvent, UserApiKeyActualizeEventHandler>();
+
+            appBuilder.RegisterEventHandler<UserChangedEvent, LogChangesUserChangedEventHandler>();
             appBuilder.RegisterEventHandler<UserPasswordChangedEvent, LogChangesUserChangedEventHandler>();
             appBuilder.RegisterEventHandler<UserResetPasswordEvent, LogChangesUserChangedEventHandler>();
+            appBuilder.RegisterEventHandler<UserChangedPasswordEvent, LogChangesUserChangedEventHandler>();
             appBuilder.RegisterEventHandler<UserLoginEvent, LogChangesUserChangedEventHandler>();
             appBuilder.RegisterEventHandler<UserLogoutEvent, LogChangesUserChangedEventHandler>();
             appBuilder.RegisterEventHandler<UserRoleAddedEvent, LogChangesUserChangedEventHandler>();

--- a/tests/VirtoCommerce.Platform.Web.Tests/Security/CustomUserManagerEventsUnitTests.cs
+++ b/tests/VirtoCommerce.Platform.Web.Tests/Security/CustomUserManagerEventsUnitTests.cs
@@ -6,6 +6,7 @@ using System.Threading.Tasks;
 using FluentAssertions;
 using Microsoft.AspNetCore.Identity;
 using Moq;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Events;
 using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Core.Security.Events;
@@ -23,7 +24,7 @@ namespace VirtoCommerce.Platform.Web.Tests.Security
             //Arrange
 
             var userStoreMock = new Mock<IUserStore<ApplicationUser>>();
-            userStoreMock.Setup(x => x.FindByIdAsync(user.Id, CancellationToken.None)).ReturnsAsync(user);
+            userStoreMock.Setup(x => x.FindByIdAsync(user.Id, CancellationToken.None)).ReturnsAsync(user.CloneTyped());
             userStoreMock.Setup(x => x.CreateAsync(It.IsAny<ApplicationUser>(), CancellationToken.None))
                 .ReturnsAsync(IdentityResult.Success);
             var eventPublisher = new EventPublisherStub();
@@ -63,10 +64,7 @@ namespace VirtoCommerce.Platform.Web.Tests.Security
         {
             //Arrange
             var userStoreMock = new Mock<IUserStore<ApplicationUser>>();
-            userStoreMock.Setup(x => x.FindByIdAsync(user.Id, CancellationToken.None)).ReturnsAsync(user);
-            userStoreMock.As<IUserPasswordStore<ApplicationUser>>()
-                         .Setup(x => x.SetPasswordHashAsync(user, user.PasswordHash, CancellationToken.None))
-                         .Returns(Task.CompletedTask);
+            userStoreMock.Setup(x => x.FindByIdAsync(user.Id, CancellationToken.None)).ReturnsAsync(user.CloneTyped());
             var eventPublisher = new EventPublisherStub();
 
             var userManager = SecurityMockHelper.TestCustomUserManager(userStoreMock, eventPublisher);
@@ -88,10 +86,7 @@ namespace VirtoCommerce.Platform.Web.Tests.Security
         {
             //Arrange
             var userStoreMock = new Mock<IUserStore<ApplicationUser>>();
-            userStoreMock.Setup(x => x.FindByIdAsync(user.Id, CancellationToken.None)).ReturnsAsync(user);
-            userStoreMock.As<IUserPasswordStore<ApplicationUser>>()
-                         .Setup(x => x.GetPasswordHashAsync(It.IsAny<ApplicationUser>(), It.IsAny<CancellationToken>()))
-                         .ReturnsAsync(user.PasswordHash);
+            userStoreMock.Setup(x => x.FindByIdAsync(user.Id, CancellationToken.None)).ReturnsAsync(user.CloneTyped());
             var eventPublisher = new EventPublisherStub();
 
             var userManager = SecurityMockHelper.TestCustomUserManager(userStoreMock, eventPublisher);
@@ -164,6 +159,7 @@ namespace VirtoCommerce.Platform.Web.Tests.Security
                         new Action<IEvent>[]
                         {
                             x => x.GetType().Should().Be<UserChangingEvent>(),
+                            x => x.GetType().Should().Be<UserPasswordChangedEvent>(),
                             x => x.GetType().Should().Be<UserResetPasswordEvent>(),
                         }
                     };
@@ -183,6 +179,7 @@ namespace VirtoCommerce.Platform.Web.Tests.Security
                         {
                             x => x.GetType().Should().Be<UserChangingEvent>(),
                             x => x.GetType().Should().Be<UserPasswordChangedEvent>(),
+                            x => x.GetType().Should().Be<UserChangedPasswordEvent>(),
                         }
                     };
             }


### PR DESCRIPTION
## Description
Previously, when a user changed their password, the platform would publish the `UserPasswordChangedEvent` event twice: once for the operation itself, and once for the detected changes to the user properties.

This PR introduces a separate event for the `change password` operation - the `UserChangedPasswordEvent`.

So, now there are three events related to the password change:
- `UserResetPasswordEvent` - user has reset their password
- `UserChangedPasswordEvent` - user has changed their password
- `UserPasswordChangedEvent` - password has been changed for whatever reason. This event is published for both `reset password` and `change password` operations.
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-781
### Artifact URL:
