### PR TITLE
VCST-1047: login-on-begalf for token auth

### DIFF
--- a/src/VirtoCommerce.Platform.Core/PlatformConstants.cs
+++ b/src/VirtoCommerce.Platform.Core/PlatformConstants.cs
@@ -18,6 +18,8 @@ namespace VirtoCommerce.Platform.Core
                 public const string UserNameClaimType = "username";
                 public const string LimitedPermissionsClaimType = "limited_permissions";
                 public const string MemberIdClaimType = "memberId";
+                public const string ImpersonatedUserId = "vc_impersonated_user_id";
+                public const string ImpersonatedUserName = "vc_impersonated_user_name";
             }
 
             public static class SystemRoles

--- a/src/VirtoCommerce.Platform.Core/PlatformConstants.cs
+++ b/src/VirtoCommerce.Platform.Core/PlatformConstants.cs
@@ -11,6 +11,11 @@ namespace VirtoCommerce.Platform.Core
     {
         public static class Security
         {
+            public static class GrantTypes
+            {
+                public const string Impersonate = "impersonate";
+            }
+
             public static class Claims
             {
                 public const string PermissionClaimType = "permission";
@@ -18,8 +23,14 @@ namespace VirtoCommerce.Platform.Core
                 public const string UserNameClaimType = "username";
                 public const string LimitedPermissionsClaimType = "limited_permissions";
                 public const string MemberIdClaimType = "memberId";
-                public const string ImpersonatedUserId = "vc_impersonated_user_id";
-                public const string ImpersonatedUserName = "vc_impersonated_user_name";
+                /// <summary>
+                /// Represents Operator User Id after impersonation 
+                /// </summary>
+                public const string OperatorUserId = "vc_operator_user_id";
+                /// <summary>
+                /// Represents Operator User Name after impersonation
+                /// </summary>
+                public const string OperatorUserName = "vc_operator_name";
             }
 
             public static class SystemRoles

--- a/src/VirtoCommerce.Platform.Security/HttpContextUserResolver.cs
+++ b/src/VirtoCommerce.Platform.Security/HttpContextUserResolver.cs
@@ -1,5 +1,7 @@
+using System.Security.Claims;
 using System.Threading;
 using Microsoft.AspNetCore.Http;
+using VirtoCommerce.Platform.Core;
 using VirtoCommerce.Platform.Core.Security;
 using static VirtoCommerce.Platform.Data.Constants.DefaultEntityNames;
 
@@ -36,15 +38,21 @@ namespace VirtoCommerce.Platform.Security
                 var identity = context.User.Identity;
                 if (identity != null && identity.IsAuthenticated)
                 {
-                    // Login-on-behalf operator user has a priority over an actual user
-                    var userHeader = context.Request.Headers.ContainsKey(OperatorUserNameHeader) ?
-                        OperatorUserNameHeader :
-                        CurrentUserNameHeader;
+                    // Login-on-behalf operator from token
+                    result = context.User.FindFirstValue(PlatformConstants.Security.Claims.OperatorUserName);
 
-                    result = context.Request.Headers[userHeader];
                     if (string.IsNullOrEmpty(result))
                     {
-                        result = identity.Name;
+                        // Login-on-behalf operator user has a priority over an actual user
+                        var userHeader = context.Request.Headers.ContainsKey(OperatorUserNameHeader) ?
+                            OperatorUserNameHeader :
+                            CurrentUserNameHeader;
+
+                        result = context.Request.Headers[userHeader];
+                        if (string.IsNullOrEmpty(result))
+                        {
+                            result = identity.Name;
+                        }
                     }
                 }
             }

--- a/src/VirtoCommerce.Platform.Web/Extensions/OpenIddictExtensions.cs
+++ b/src/VirtoCommerce.Platform.Web/Extensions/OpenIddictExtensions.cs
@@ -1,0 +1,15 @@
+using System;
+using OpenIddict.Abstractions;
+using VirtoCommerce.Platform.Core;
+
+namespace VirtoCommerce.Platform.Web.Extensions;
+
+public static class OpenIddictExtensions
+{
+    public static bool IsImpersonateGrantType(this OpenIddictRequest request)
+    {
+        ArgumentNullException.ThrowIfNull(request);
+
+        return string.Equals(request.GrantType, PlatformConstants.Security.GrantTypes.Impersonate, StringComparison.Ordinal);
+    }
+}

--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -352,7 +352,8 @@ namespace VirtoCommerce.Platform.Web
                     // can enable the other flows if you need to support implicit or client credentials.
                     options.AllowPasswordFlow()
                         .AllowRefreshTokenFlow()
-                        .AllowClientCredentialsFlow();
+                        .AllowClientCredentialsFlow()
+                        .AllowCustomFlow("impersonate");
 
                     options.SetRefreshTokenLifetime(authorizationOptions?.RefreshTokenLifeTime);
                     options.SetAccessTokenLifetime(authorizationOptions?.AccessTokenLifeTime);

--- a/src/VirtoCommerce.Platform.Web/Swagger/OpenIDEndpointDescriptionFilter.cs
+++ b/src/VirtoCommerce.Platform.Web/Swagger/OpenIDEndpointDescriptionFilter.cs
@@ -34,6 +34,7 @@ namespace VirtoCommerce.Platform.Web.Swagger
                     { "username", new OpenApiSchema() { Type = "string" } },
                     { "password", new OpenApiSchema() { Type = "string" } },
                     { "storeId", new OpenApiSchema() { Type = "string" } },
+                    { "user_id", new OpenApiSchema() { Type = "string" } },
                 };
                 mediaType.Schema.Required = new HashSet<string>
                 {


### PR DESCRIPTION
## Description
feat: Adds the capability to perform login-on-behalf (impersonation) using token authentication within the XAPI framework. The new feature extends the /connect/token flow by adding support for a custom grant type called impersonate. Users can now leverage the grant_type=impersonate&user_id={user_id} parameter to set the vc_xapi_impersonated_customerid for impersonation purposes. Ensure that the account initiating the impersonation has the necessary platform:security:loginOnBehalf permission. To reset the impersonation , use the grant_type=impersonate and empty user_id.

## References
### QA-test:
### Jira-link:
### Artifact URL:
