### PR TITLE
VCST-822: fix swagger schemaId generator  for documentType

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Swagger/CustomSwaggerGenerator.cs
+++ b/src/VirtoCommerce.Platform.Web/Swagger/CustomSwaggerGenerator.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Diagnostics;
 using System.Reflection;
 using Microsoft.AspNetCore.Mvc.ApiExplorer;
 using Microsoft.OpenApi.Models;
@@ -14,34 +15,48 @@ namespace VirtoCommerce.Platform.Web.Swagger
     public class CustomSwaggerGenerator : ISwaggerProvider
     {
         private readonly SwaggerGenerator _swaggerGenerator;
-        private string _documentName;
+        private readonly SchemaGeneratorOptions _schemaGeneratorOptions;
+        private readonly MethodInfo _defaultSchemaIdSelectorMethodInfo;
 
         public CustomSwaggerGenerator(SwaggerGeneratorOptions options, IApiDescriptionGroupCollectionProvider apiDescriptionsProvider, ISchemaGenerator schemaGenerator)
         {
             // We change schema generator options to replace SchemaIdSelector function to a document-dependent implementation
             // Unfortunately this member declared as private, there is no another way to obtain options in this member.
             var optionsFieldInfo = schemaGenerator.GetType().GetField("_generatorOptions", BindingFlags.Instance | BindingFlags.NonPublic);
-            var schemaGeneratorOptions = (SchemaGeneratorOptions)optionsFieldInfo.GetValue(schemaGenerator);
+            _schemaGeneratorOptions = (SchemaGeneratorOptions)optionsFieldInfo.GetValue(schemaGenerator);
 
-            var defaultSchemaIdSelectorMethodInfo = schemaGeneratorOptions.GetType().GetMethod("DefaultSchemaIdSelector", BindingFlags.Instance | BindingFlags.NonPublic);
-            schemaGeneratorOptions.SchemaIdSelector = (
-                type =>
-                (Attribute.GetCustomAttribute(type, typeof(SwaggerSchemaIdAttribute)) as SwaggerSchemaIdAttribute)?.Id ??
-                (
-                    _documentName == SwaggerServiceCollectionExtensions.platformUIDocName ?
-                     type.FullName :
-                    (string)defaultSchemaIdSelectorMethodInfo.Invoke(schemaGeneratorOptions, new object[] { type })
-                )
-                );
+            _defaultSchemaIdSelectorMethodInfo = _schemaGeneratorOptions.GetType().GetMethod("DefaultSchemaIdSelector", BindingFlags.Instance | BindingFlags.NonPublic);
 
             _swaggerGenerator = new SwaggerGenerator(options, apiDescriptionsProvider, schemaGenerator);
         }
 
         public OpenApiDocument GetSwagger(string documentName, string host = null, string basePath = null)
         {
-            // Just catch document name
-            _documentName = documentName;
+            SetSchemaIdSelector(documentName);
             return _swaggerGenerator.GetSwagger(documentName, host, basePath);
+        }
+
+        private void SetSchemaIdSelector(string documentName)
+        {
+            _schemaGeneratorOptions.SchemaIdSelector = type =>
+                {
+                    string result;
+                    var attribute = (SwaggerSchemaIdAttribute)Attribute.GetCustomAttribute(type, typeof(SwaggerSchemaIdAttribute));
+                    if (attribute != null)
+                    {
+                        result = attribute.Id;
+                    }
+                    else if (documentName == SwaggerServiceCollectionExtensions.platformUIDocName)
+                    {
+                        result = type.FullName;
+                    }
+                    else
+                    {
+                        result = (string)_defaultSchemaIdSelectorMethodInfo.Invoke(_schemaGeneratorOptions, new object[] { type });
+                    }
+                    Trace.WriteLine($"SchemaIdSelector: {type.FullName} => {result}");
+                    return result;
+                };
         }
     }
 }


### PR DESCRIPTION
## Description

* remove class field which stored a documentName for current schema generator
* reformat code

## References
### QA-test:
### Jira-link:
### Artifact URL:
