### PR TITLE
VCST-1128: Add Configuration for iframe security policy

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Extensions/StringExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Extensions/StringExtensions.cs
@@ -122,6 +122,11 @@ namespace VirtoCommerce.Platform.Core.Common
             return string.Equals(str1, str2, StringComparison.OrdinalIgnoreCase);
         }
 
+        public static bool EqualsIgnoreCase(this string str1, string str2)
+        {
+            return string.Equals(str1, str2, StringComparison.OrdinalIgnoreCase);
+        }
+
 
         public static string GetCurrencyName(this string isoCurrencySymbol)
         {

--- a/src/VirtoCommerce.Platform.Web/Security/SecurityHeadersOptions.cs
+++ b/src/VirtoCommerce.Platform.Web/Security/SecurityHeadersOptions.cs
@@ -1,0 +1,16 @@
+namespace VirtoCommerce.Platform.Web.Security;
+
+public class SecurityHeadersOptions
+{
+    /// <summary>
+    /// Allows to configure X-Frame-Options header.
+    /// Allowed values: Deny - default, SameOrigin, or custom uri.
+    /// </summary>
+    public string FrameOptions { get; set; } = "Deny";
+
+    /// <summary>
+    /// Allows to configure values for FrameAncestors in Content-Security-Header header.
+    /// Allowed values: None - default, Self, or custom uri.
+    /// </summary>
+    public string FrameAncestors { get; set; } = "None";
+}

--- a/src/VirtoCommerce.Platform.Web/Security/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Web/Security/ServiceCollectionExtensions.cs
@@ -120,46 +120,44 @@ namespace VirtoCommerce.Platform.Web.Security
             }
         }
 
-        public static void UseSecurityPolicyHeaders(this IApplicationBuilder app)
+        public static void UseCustomSecurityHeaders(this IApplicationBuilder app)
         {
-            var securityHeadersOptions = app.ApplicationServices.GetService<IOptions<SecurityHeadersOptions>>().Value;
+            var policies = new HeaderPolicyCollection().AddDefaultSecurityHeaders();
+            var options = app.ApplicationServices.GetService<IOptions<SecurityHeadersOptions>>().Value;
 
-            var policyCollection = new HeaderPolicyCollection()
-                .AddDefaultSecurityHeaders();
-
-            if (string.Equals(securityHeadersOptions.FrameOptions, "SameOrigin", StringComparison.OrdinalIgnoreCase))
+            if (options.FrameOptions.EqualsIgnoreCase("SameOrigin"))
             {
-                policyCollection = policyCollection.AddFrameOptionsSameOrigin();
+                policies.AddFrameOptionsSameOrigin();
             }
-            else if (string.Equals(securityHeadersOptions.FrameOptions, "Deny", StringComparison.OrdinalIgnoreCase))
+            else if (options.FrameOptions.EqualsIgnoreCase("Deny"))
             {
-                policyCollection = policyCollection.AddFrameOptionsDeny();
+                policies.AddFrameOptionsDeny();
             }
-            else if (!string.IsNullOrEmpty(securityHeadersOptions.FrameOptions))
+            else if (!string.IsNullOrEmpty(options.FrameOptions))
             {
-                policyCollection = policyCollection.AddFrameOptionsSameOrigin(securityHeadersOptions.FrameOptions);
+                policies.AddFrameOptionsSameOrigin(options.FrameOptions);
             }
 
-            policyCollection = policyCollection.AddContentSecurityPolicy(builder =>
+            policies.AddContentSecurityPolicy(builder =>
             {
                 builder.AddObjectSrc().None();
                 builder.AddFormAction().Self();
 
-                if (string.Equals(securityHeadersOptions.FrameAncestors, "None", StringComparison.OrdinalIgnoreCase))
+                if (options.FrameAncestors.EqualsIgnoreCase("None"))
                 {
                     builder.AddFrameAncestors().None();
                 }
-                else if (string.Equals(securityHeadersOptions.FrameAncestors, "Self", StringComparison.OrdinalIgnoreCase))
+                else if (options.FrameAncestors.EqualsIgnoreCase("Self"))
                 {
                     builder.AddFrameAncestors().Self();
                 }
-                else if (!string.IsNullOrEmpty(securityHeadersOptions.FrameAncestors))
+                else if (!string.IsNullOrEmpty(options.FrameAncestors))
                 {
-                    builder.AddFrameAncestors().From(securityHeadersOptions.FrameAncestors);
+                    builder.AddFrameAncestors().From(options.FrameAncestors);
                 }
             });
 
-            app.UseSecurityHeaders(policyCollection);
+            app.UseSecurityHeaders(policies);
         }
     }
 }

--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -121,6 +121,8 @@ namespace VirtoCommerce.Platform.Web
             {
                 options.PlatformTranslationFolderPath = WebHostEnvironment.MapPath(options.PlatformTranslationFolderPath);
             });
+            services.AddOptions<SecurityHeadersOptions>().Bind(Configuration.GetSection("SecurityHeaders")).ValidateDataAnnotations();
+
             //Get platform version from GetExecutingAssembly
             PlatformVersion.CurrentVersion = SemanticVersion.Parse(FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).ProductVersion);
 
@@ -561,7 +563,7 @@ namespace VirtoCommerce.Platform.Web
                 app.UseHsts();
             }
 
-            app.UseSecurityHeaders();
+            app.UseSecurityPolicyHeaders();
 
             //Return all errors as Json response
             app.UseMiddleware<ApiErrorWrappingMiddleware>();

--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -563,7 +563,7 @@ namespace VirtoCommerce.Platform.Web
                 app.UseHsts();
             }
 
-            app.UseSecurityPolicyHeaders();
+            app.UseCustomSecurityHeaders();
 
             //Return all errors as Json response
             app.UseMiddleware<ApiErrorWrappingMiddleware>();

--- a/src/VirtoCommerce.Platform.Web/appsettings.json
+++ b/src/VirtoCommerce.Platform.Web/appsettings.json
@@ -194,6 +194,12 @@
     "LimitedCookiePermissions": "platform:asset:read;platform:export;content:read;platform:asset:create;licensing:issue;export:download",
     "AllowApiAccessForCustomers": false
   },
+  "SecurityHeaders": {
+    // X-Frame-Options header configuration. Allowed values: Deny - default, SameOrigin, or custom uri.
+    "FrameOptions": "Deny",
+    // FrameAncestors configuration in Content-Security-Header header. Allowed values: None - default, Self, or custom uri.
+    "FrameAncestors": "None"
+  },
   "AzureAd": {
     "Enabled": false,
     "AuthenticationType": "AzureAD",


### PR DESCRIPTION
## Description
feat: Adds SecurityHeaders configuration to configure iframe security policy.

appsettings.json
```json
  "SecurityHeaders": {
    // X-Frame-Options header configuration. Allowed values: Deny - default, SameOrigin, or custom uri.
    "FrameOptions": "Deny",
    // FrameAncestors configuration in Content-Security-Header header. Allowed values: None - default, Self, or custom uri.
    "FrameAncestors": "None"
  },
```

![image](https://github.com/VirtoCommerce/vc-platform/assets/7639413/80b88345-4975-41ac-8c59-7916befb042a)


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1128

### Artifact URL:
