### PR TITLE
VCST-1209: Bump Microsoft.Identity.Client and Npgsql to latest version.

### DIFF
--- a/src/VirtoCommerce.Platform.Data.PostgreSql/VirtoCommerce.Platform.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.Platform.Data.PostgreSql/VirtoCommerce.Platform.Data.PostgreSql.csproj
@@ -15,8 +15,8 @@
     <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="8.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql" Version="8.0.1" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.0" />
+    <PackageReference Include="Npgsql" Version="8.0.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="8.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
+++ b/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk.Web">
+﻿<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -38,10 +38,11 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="8.0.0" />
     <PackageReference Include="Microsoft.Extensions.PlatformAbstractions" Version="1.1.0" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.58.0" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.61.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.19.5" />
     <PackageReference Include="Microsoft.VisualStudio.Web.BrowserLink" Version="2.2.0" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="0.21.0" />
+    <PackageReference Include="Npgsql" Version="8.0.3" />
     <PackageReference Include="OpenIddict.AspNetCore" Version="4.10.1" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="4.10.1" />
     <PackageReference Include="Serilog.AspNetCore" Version="8.0.0" />


### PR DESCRIPTION
## Description
fix: Bump Microsoft.Identity.Client to 4.61.0, Npgsql to 8.0.3 and Npgsql.EntityFrameworkCore.PostgreSQL to 8.0.2.

## References
### QA-test:
### Jira-link:
### Artifact URL:

Image tag:
3.825.0-pr-2792-8478-vcst-1209-bump-npgsql-8478bff6