### PR TITLE
VCST-1213: make optional dependencies inactive if no module info is found

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/modularity/blades/module-detail.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/modularity/blades/module-detail.js
@@ -66,6 +66,12 @@ angular.module('platformWebApp')
         return result;
     }
 
+    $scope.isModulePresent = function (dependencyId) {
+        return _.any(moduleHelper.allmodules, function (x) {
+            return x.id === dependencyId;
+        });
+    }
+
     $scope.formDependencyVersion = function (dependency) {
         return dependency.version.major + '.' + dependency.version.minor + '.' + dependency.version.patch;
     };

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/modularity/blades/module-detail.tpl.html
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/modularity/blades/module-detail.tpl.html
@@ -89,7 +89,8 @@
                     <div class="list-t">{{ 'platform.blades.module-detail.labels.optional-dependencies' | translate }}</div>
                     <div class="list-descr">
                       <div ng-repeat="dependency in blade.currentEntity.dependencies | filter:{ optional: true }">
-                        <a class="__link" ng-click="openDependencyModule(dependency)">{{dependency.id}}</a> {{formDependencyVersion(dependency)}}
+                        <div ng-if="isModulePresent(dependency.id)"><a class="__link" ng-click="openDependencyModule(dependency)">{{dependency.id}}</a> {{formDependencyVersion(dependency)}}</div>
+                        <div ng-if="!isModulePresent(dependency.id)">{{ dependency.id }} {{formDependencyVersion(dependency)}}</div> 
                       </div>
                     </div>
                   </li>


### PR DESCRIPTION
## Description
![image](https://github.com/VirtoCommerce/vc-platform/assets/20122385/9613f5aa-16d6-43fc-918d-147d459c1ded)

## References
### QA-test:
### Jira-link:
### Artifact URL:

Image tag:
3.827.0-pr-2793-00a8-vcst-1213-00a8ee69