### PR TITLE
VCST-1125: Bump Azure.Core and Azure.Messaging.EventGrid

### DIFF
--- a/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
+++ b/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
@@ -1,4 +1,4 @@
-﻿<Project Sdk="Microsoft.NET.Sdk.Web">
+<Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
@@ -15,8 +15,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.36.0" />
-    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.21.0" />
+    <PackageReference Include="Azure.Core" Version="1.37.0" />
+    <PackageReference Include="Azure.Messaging.EventGrid" Version="4.22.0" />
     <PackageReference Include="FluentValidation" Version="11.8.1" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="8.0.2" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="8.0.0" />


### PR DESCRIPTION
## Description
feat: Bump Azure.Core  to 1.37.0 and Azure.Messaging.EventGrid to 4.22 to fit MS modules dependencies that use Azure.Core  to 1.37.0

## References
### QA-test:
### Jira-link:
### Artifact URL:

Image tag:
3.826.0-pr-2794-6c10-vcst-1125-azure-core-1-37-6c109f27