### PR TITLE
VCST-1107: Use latest zaproxy/action-baseline

### DIFF
--- a/.github/workflows/platfotm-owasp.yml
+++ b/.github/workflows/platfotm-owasp.yml
@@ -38,9 +38,9 @@ jobs:
           validateSwagger: 'false'
 
       - name: OWASP ZAP Full Scan
-        uses: zaproxy/action-baseline@v0.4.0
+        uses: zaproxy/action-baseline@v0.12.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          docker_name: 'owasp/zap2docker-stable'
+          # docker_name: 'owasp/zap2docker-stable'
           target: 'http://localhost:8090'
           cmd_options: '-a -d'

--- a/.github/workflows/platfotm-owasp.yml
+++ b/.github/workflows/platfotm-owasp.yml
@@ -41,6 +41,5 @@ jobs:
         uses: zaproxy/action-baseline@v0.12.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # docker_name: 'owasp/zap2docker-stable'
           target: 'http://localhost:8090'
           cmd_options: '-a -d'

--- a/.github/workflows/platfotm-owasp.yml
+++ b/.github/workflows/platfotm-owasp.yml
@@ -22,9 +22,9 @@ jobs:
         uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
       - name: Docker Login
-        uses: azure/docker-login@v1
+        uses: docker/login-action@v3
         with:
-          login-server: ghcr.io
+          registry: ghcr.io
           username: $GITHUB_ACTOR
           password: ${{ secrets.GITHUB_TOKEN }}
 


### PR DESCRIPTION
## Description
Used latest version of GH action `zaproxy/action-baseline`, removed `docker_name` option as by default the action runs the stable version of ZAP.
## References
https://github.com/zaproxy/action-baseline/blob/master/README.md#docker_name
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1107
### Artifact URL:
