### PR TITLE
VCST-846: Fix QuerySplittingBehavior.SingleQuery Warning in Platform

### DIFF
--- a/src/VirtoCommerce.Platform.Data/Repositories/PlatformRepository.cs
+++ b/src/VirtoCommerce.Platform.Data/Repositories/PlatformRepository.cs
@@ -35,7 +35,9 @@ namespace VirtoCommerce.Platform.Data.Repositories
         {
             var properties = await DynamicProperties.Include(x => x.DisplayNames)
                                               .OrderBy(x => x.Name)
-                                              .Where(x => objectTypes.Contains(x.ObjectType)).ToArrayAsync();
+                                              .Where(x => objectTypes.Contains(x.ObjectType))
+                                              .AsSplitQuery()
+                                              .ToArrayAsync();
             return properties;
         }
 
@@ -48,6 +50,7 @@ namespace VirtoCommerce.Platform.Data.Repositories
 
             var retVal = await DynamicPropertyDictionaryItems.Include(x => x.DisplayNames)
                                      .Where(x => ids.Contains(x.Id))
+                                     .AsSplitQuery()
                                      .ToArrayAsync();
             return retVal;
         }
@@ -62,6 +65,7 @@ namespace VirtoCommerce.Platform.Data.Repositories
             var retVal = await DynamicProperties.Include(x => x.DisplayNames)
                                           .Where(x => ids.Contains(x.Id))
                                           .OrderBy(x => x.Name)
+                                          .AsSplitQuery()
                                           .ToArrayAsync();
             return retVal;
         }
@@ -76,6 +80,7 @@ namespace VirtoCommerce.Platform.Data.Repositories
             var retVal = await DynamicProperties.Include(p => p.DisplayNames)
                                           .Where(p => objectTypes.Contains(p.ObjectType))
                                           .OrderBy(p => p.Name)
+                                          .AsSplitQuery()
                                           .ToArrayAsync();
             return retVal;
         }
@@ -87,6 +92,7 @@ namespace VirtoCommerce.Platform.Data.Repositories
                                  .Where(x => x.ObjectId == objectId && x.ObjectType == objectType)
                                  .Where(x => names.Contains(x.Name))
                                  .OrderBy(x => x.Name)
+                                 .AsSplitQuery()
                                  .ToArrayAsync();
             return result;
         }

--- a/src/VirtoCommerce.Platform.Data/Settings/SettingsManager.cs
+++ b/src/VirtoCommerce.Platform.Data/Settings/SettingsManager.cs
@@ -168,6 +168,7 @@ namespace VirtoCommerce.Platform.Data.Settings
                 var alreadyExistDbSettings = (await repository.Settings
                     .Include(s => s.SettingValues)
                     .Where(x => settingNames.Contains(x.Name))
+                    .AsSplitQuery()
                     .ToListAsync());
 
                 var validator = new ObjectSettingEntryValidator();

--- a/src/VirtoCommerce.Platform.Security/Services/UserSearchService.cs
+++ b/src/VirtoCommerce.Platform.Security/Services/UserSearchService.cs
@@ -85,7 +85,11 @@ namespace VirtoCommerce.Platform.Security.Services
             {
                 sortInfos = new[] { new SortInfo { SortColumn = ReflectionUtility.GetPropertyName<ApplicationUser>(x => x.UserName), SortDirection = SortDirection.Descending } };
             }
-            result.Results = await query.OrderBySortInfos(sortInfos).Skip(criteria.Skip).Take(criteria.Take).ToArrayAsync();
+            result.Results = await query.OrderBySortInfos(sortInfos)
+                .Skip(criteria.Skip)
+                .Take(criteria.Take)
+                .AsSplitQuery()
+                .ToArrayAsync();
 
             foreach (var user in result.Results)
             {

--- a/src/VirtoCommerce.Platform.Security/Services/UserSearchService.cs
+++ b/src/VirtoCommerce.Platform.Security/Services/UserSearchService.cs
@@ -85,7 +85,9 @@ namespace VirtoCommerce.Platform.Security.Services
             {
                 sortInfos = new[] { new SortInfo { SortColumn = ReflectionUtility.GetPropertyName<ApplicationUser>(x => x.UserName), SortDirection = SortDirection.Descending } };
             }
-            result.Results = await query.OrderBySortInfos(sortInfos)
+
+            result.Results = await query
+                .OrderBySortInfos(sortInfos)
                 .Skip(criteria.Skip)
                 .Take(criteria.Take)
                 .AsSplitQuery()

--- a/src/VirtoCommerce.Platform.Web/Licensing/LicenseProvider.cs
+++ b/src/VirtoCommerce.Platform.Web/Licensing/LicenseProvider.cs
@@ -23,7 +23,7 @@ namespace VirtoCommerce.Platform.Web.Licensing
 
             using (var repository = _platformRepositoryFactory())
             {
-                rawLicenseData = repository.RawLicenses?.FirstOrDefault()?.Data;
+                rawLicenseData = repository.RawLicenses.OrderBy(x => x.Id).FirstOrDefault()?.Data;
             }
 
             var license = License.Parse(rawLicenseData, _platformOptions.LicensePublicKeyResourceName);
@@ -40,13 +40,13 @@ namespace VirtoCommerce.Platform.Web.Licensing
         {
             using (var repository = _platformRepositoryFactory())
             {
-                var rawLicense = repository.RawLicenses?.FirstOrDefault();
+                var rawLicense = repository.RawLicenses.OrderBy(x => x.Id).FirstOrDefault();
                 if (rawLicense == null)
                 {
                     rawLicense = new Data.Model.RawLicenseEntity();
                     repository.Add(rawLicense);
                 }
-                rawLicense.Data = license.RawLicense;                
+                rawLicense.Data = license.RawLicense;
                 repository.UnitOfWork.Commit();
             }
         }


### PR DESCRIPTION
## Description
fix: The query uses the 'First'/'FirstOrDefault' operator without 'OrderBy' and filter operators. This may lead to unpredictable results.
feat: Enables AsSplitQuery policy for queries. This behavior can improve performance when the query ApplicationUser, Settings and Dynamic Properties.

## References
### QA-test:
### Jira-link:
### Artifact URL:

Image tag:
3.837.0-pr-2804-b0ea-vcst-846-b0eaa4a9