### PR TITLE
VCST-1448: Added the ability to unregister meta fields by name, templateUrl or a custom search predicate callback.

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/metaform.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/metaform.js
@@ -13,13 +13,31 @@ angular.module('platformWebApp')
             getMetaFields: function (metaFormName) {
                 return registeredMetaFields[metaFormName];
             },
-            unregisterMetaFields: function (metaFormName, metaField) {
-                if (registeredMetaFields[metaFormName]) {
-                    var index = registeredMetaFields[metaFormName].indexOf(metaField);
-                    if (index !== -1) {
-                        registeredMetaFields[metaFormName].splice(index, 1);
-                    }
+            unregisterMetaFields: function (metaFormName, ...metaFieldsToFind) {
+                metaFieldsToFind.forEach(metaFieldToFind => this.unregisterMetaField(metaFormName, metaFieldToFind));
+            },
+            unregisterMetaField: function (metaFormName, metaFieldToFind, metaFieldDescription) {
+                let metaFieldIndex = -1;
+                let metaFields = registeredMetaFields[metaFormName];
+
+                // metaFieldToFind can be a search filter, a metaField name or the metaField object itself (which is the previous way of unregistering a metaField)
+                if (_.isFunction(metaFieldToFind)) {
+                    metaFieldIndex = _.findIndex(metaFields, metaFieldToFind);
+                } else if (typeof metaFieldToFind === 'string') {
+                    metaFieldIndex = _.findIndex(metaFields, x => x.name === metaFieldToFind);
+                    metaFieldDescription ??= `name "${metaFieldToFind}"`;
+                } else {
+                    metaFieldIndex = _.findIndex(metaFields, metaFieldToFind);
                 }
+
+                if (metaFieldIndex <= 0) {
+                    throw new Error(metaFieldDescription ? `The metaForm "${metaFormName}" doesn't contain a field with ${metaFieldDescription}, the field could not be removed.` : `The metaForm "${metaFormName}" doesn't contain the field to be removed.`);
+                }
+
+                metaFields.splice(metaFieldIndex, 1);
+            },
+            unregisterMetaFieldWithTemplateUrl: function (metaFormName, templateUrl) {
+                this.unregisterMetaField(metaFormName, x => x.templateUrl === templateUrl, `template url "${templateUrl}"`)
             },
             clearMetaFields: function (metaFormName) {
                 registeredMetaFields[metaFormName] = [];

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/metaform.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/metaform.js
@@ -21,7 +21,7 @@ angular.module('platformWebApp')
             },
             unregisterMetaField: function (metaFormName, metaFieldToFind, metaFieldDescription) {
                 let metaFieldIndex;
-                let metaFields = registeredMetaFields[metaFormName];
+                const metaFields = registeredMetaFields[metaFormName];
 
                 // metaFieldToFind can be a search filter, a metaField name or the metaField object itself (which is the previous way of unregistering a metaField)
                 if (_.isFunction(metaFieldToFind)) {

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/metaform.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/metaform.js
@@ -16,8 +16,11 @@ angular.module('platformWebApp')
             unregisterMetaFields: function (metaFormName, ...metaFieldsToFind) {
                 metaFieldsToFind.forEach(metaFieldToFind => this.unregisterMetaField(metaFormName, metaFieldToFind));
             },
+            unregisterMetaFieldWithTemplateUrl: function (metaFormName, templateUrl) {
+                this.unregisterMetaField(metaFormName, x => x.templateUrl === templateUrl, `template URL '${templateUrl}'`);
+            },
             unregisterMetaField: function (metaFormName, metaFieldToFind, metaFieldDescription) {
-                let metaFieldIndex = -1;
+                let metaFieldIndex;
                 let metaFields = registeredMetaFields[metaFormName];
 
                 // metaFieldToFind can be a search filter, a metaField name or the metaField object itself (which is the previous way of unregistering a metaField)
@@ -25,19 +28,18 @@ angular.module('platformWebApp')
                     metaFieldIndex = _.findIndex(metaFields, metaFieldToFind);
                 } else if (typeof metaFieldToFind === 'string') {
                     metaFieldIndex = _.findIndex(metaFields, x => x.name === metaFieldToFind);
-                    metaFieldDescription ??= `name "${metaFieldToFind}"`;
+                    metaFieldDescription ??= `name '${metaFieldToFind}'`;
                 } else {
                     metaFieldIndex = _.findIndex(metaFields, metaFieldToFind);
                 }
 
                 if (metaFieldIndex <= 0) {
-                    throw new Error(metaFieldDescription ? `The metaForm "${metaFormName}" doesn't contain a field with ${metaFieldDescription}, the field could not be removed.` : `The metaForm "${metaFormName}" doesn't contain the field to be removed.`);
+                    throw new Error(metaFieldDescription
+                        ? `The metaForm '${metaFormName}' doesn't contain a field with ${metaFieldDescription}, the field could not be removed.`
+                        : `The metaForm '${metaFormName}' doesn't contain the field to be removed.`);
                 }
 
                 metaFields.splice(metaFieldIndex, 1);
-            },
-            unregisterMetaFieldWithTemplateUrl: function (metaFormName, templateUrl) {
-                this.unregisterMetaField(metaFormName, x => x.templateUrl === templateUrl, `template url "${templateUrl}"`)
             },
             clearMetaFields: function (metaFormName) {
                 registeredMetaFields[metaFormName] = [];


### PR DESCRIPTION
## Description
Original PR by @SamBauwensPM: https://github.com/VirtoCommerce/vc-platform/pull/2812

Added the ability to unregister meta fields by `name`, `templateUrl` or a custom search predicate callback

We originally did that in a custom module of ours, and @EugeneOkhriemnko suggested I create a PR here so everyone can benefit. 

Since there is no real method overloading in js, I did some `_.isFunction` magic to allow the same method ~group to accept the 3 different types of values for `metaFieldToFind`: name, function callback or object reference.

I added an error message because I think it's better t have an error than to silently not remove a field, but that could be considered a breaking change since the previous code didn't throw an error, if preferred this could be changed so that it only throws on error if `metaFieldDescription`, or not throw at all, or having this error throwing behaviour configured somewhere I don't know.

I tried to stay backwards compatible with the way `unregisterMetaFields` worked before, i.e it accepts an object reference in `metaFieldToFind`.## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1448
### Artifact URL:

Image tag:
3.839.0-pr-2813-72ba-vcst-1448-72baae9b