### PR TITLE
fix: didn't remove fields at index 0

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/metaform.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/metaform.js
@@ -33,7 +33,7 @@ angular.module('platformWebApp')
                     metaFieldIndex = _.findIndex(metaFields, metaFieldToFind);
                 }
 
-                if (metaFieldIndex <= 0) {
+                if (metaFieldIndex < 0) {
                     throw new Error(metaFieldDescription
                         ? `The metaForm '${metaFormName}' doesn't contain a field with ${metaFieldDescription}, the field could not be removed.`
                         : `The metaForm '${metaFormName}' doesn't contain the field to be removed.`);


### PR DESCRIPTION
## Description

In my [previous pull request](https://github.com/VirtoCommerce/vc-platform/pull/2812/files) I introduced a regression, where if you unregister the first metaField inn the array (index 0) it will throw an error.

## References
### QA-test:
### Jira-link:
### Artifact URL:
