### PR TITLE
fix: Ignore fixed settings in SaveObjectSettingsAsync()

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Domain/IRepository.cs
+++ b/src/VirtoCommerce.Platform.Core/Domain/IRepository.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Generic;
 using VirtoCommerce.Platform.Core.Domain;
 
 namespace VirtoCommerce.Platform.Core.Common
@@ -6,8 +7,8 @@ namespace VirtoCommerce.Platform.Core.Common
     /// <summary>
     /// Repository interface. Provides base interface for all repositories used in the framework.
     /// </summary>
-	public interface IRepository : IDisposable
-	{
+    public interface IRepository : IDisposable
+    {
         /// <summary>
         /// Gets the unit of work. This class actually saves the data into underlying storage.
         /// </summary>
@@ -21,27 +22,35 @@ namespace VirtoCommerce.Platform.Core.Common
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="item">The item.</param>
-		void Attach<T>(T item) where T : class;
-      
+        void Attach<T>(T item) where T : class;
+
         /// <summary>
         /// Adds the specified item to the context in the Added state. Meaning item will be created in the underlying storage.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="item">The item.</param>
-		void Add<T>(T item) where T : class;
+        void Add<T>(T item) where T : class;
 
         /// <summary>
         /// Updates the specified item. Marks the item for the update.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="item">The item.</param>
-		void Update<T>(T item) where T : class;
+        void Update<T>(T item) where T : class;
 
         /// <summary>
         /// Removes the specified item. Item marked for deletion and will be removed from the underlying storage on save.
         /// </summary>
         /// <typeparam name="T"></typeparam>
         /// <param name="item">The item.</param>
-		void Remove<T>(T item) where T : class;
-	}
+        void Remove<T>(T item) where T : class;
+
+        /// <summary>
+        /// Gets the enumeration of modified property names for the specified item.
+        /// </summary>
+        /// <param name="item"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The item.</returns>
+        IEnumerable<string> GetModifiedProperties<T>(T item) where T : class;
+    }
 }

--- a/src/VirtoCommerce.Platform.Core/Domain/IRepository.cs
+++ b/src/VirtoCommerce.Platform.Core/Domain/IRepository.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using VirtoCommerce.Platform.Core.Domain;
 
 namespace VirtoCommerce.Platform.Core.Common
@@ -44,13 +43,5 @@ namespace VirtoCommerce.Platform.Core.Common
         /// <typeparam name="T"></typeparam>
         /// <param name="item">The item.</param>
         void Remove<T>(T item) where T : class;
-
-        /// <summary>
-        /// Gets the enumeration of modified property names for the specified item.
-        /// </summary>
-        /// <param name="item"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns>The item.</returns>
-        IEnumerable<string> GetModifiedProperties<T>(T item) where T : class;
     }
 }

--- a/src/VirtoCommerce.Platform.Data/Infrastructure/DbContextRepositoryBase.cs
+++ b/src/VirtoCommerce.Platform.Data/Infrastructure/DbContextRepositoryBase.cs
@@ -1,4 +1,6 @@
 using System;
+using System.Collections.Generic;
+using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using VirtoCommerce.Platform.Core.Common;
@@ -18,7 +20,7 @@ namespace VirtoCommerce.Platform.Data.Infrastructure
             // Mitigations the breaking changes with cascade deletion introduced in EF Core 3.0
             // https://docs.microsoft.com/en-us/ef/core/what-is-new/ef-core-3.0/breaking-changes#cascade
             // The new CascadeTiming.Immediate that is used by default in EF Core 3.0 is lead wrong track as Added  for Deleted dependent/child entities during
-            // work of Patch method for data entities  
+            // work of Patch method for data entities
             DbContext.ChangeTracker.CascadeDeleteTiming = CascadeTiming.OnSaveChanges;
             DbContext.ChangeTracker.DeleteOrphansTiming = CascadeTiming.OnSaveChanges;
 
@@ -80,6 +82,17 @@ namespace VirtoCommerce.Platform.Data.Infrastructure
         public void Remove<T>(T item) where T : class
         {
             DbContext.Remove(item);
+        }
+
+        /// <summary>
+        /// Gets the enumeration of modified property names for the specified item.
+        /// </summary>
+        /// <param name="item"></param>
+        /// <typeparam name="T"></typeparam>
+        /// <returns>The item.</returns>
+        public IEnumerable<string> GetModifiedProperties<T>(T item) where T : class
+        {
+            return DbContext.Entry(item).Properties.Where(x => x.IsModified).Select(x => x.Metadata.Name);
         }
 
         // Dispose() calls Dispose(true)

--- a/src/VirtoCommerce.Platform.Data/Infrastructure/DbContextRepositoryBase.cs
+++ b/src/VirtoCommerce.Platform.Data/Infrastructure/DbContextRepositoryBase.cs
@@ -1,6 +1,4 @@
 using System;
-using System.Collections.Generic;
-using System.Linq;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.ChangeTracking;
 using VirtoCommerce.Platform.Core.Common;
@@ -82,17 +80,6 @@ namespace VirtoCommerce.Platform.Data.Infrastructure
         public void Remove<T>(T item) where T : class
         {
             DbContext.Remove(item);
-        }
-
-        /// <summary>
-        /// Gets the enumeration of modified property names for the specified item.
-        /// </summary>
-        /// <param name="item"></param>
-        /// <typeparam name="T"></typeparam>
-        /// <returns>The item.</returns>
-        public IEnumerable<string> GetModifiedProperties<T>(T item) where T : class
-        {
-            return DbContext.Entry(item).Properties.Where(x => x.IsModified).Select(x => x.Metadata.Name);
         }
 
         // Dispose() calls Dispose(true)

--- a/src/VirtoCommerce.Platform.Data/Settings/SettingsManager.cs
+++ b/src/VirtoCommerce.Platform.Data/Settings/SettingsManager.cs
@@ -157,9 +157,11 @@ namespace VirtoCommerce.Platform.Data.Settings
 
             var changedEntries = new List<GenericChangedEntry<ObjectSettingEntry>>();
 
-            // Ignore settings without values and fixed settings
+            // Ignore unregistered settings, fixed settings, and settings without values
             var settings = objectSettings
-                .Where(x => x.ItHasValues && !_fixedSettingsDict.ContainsKey(x.Name))
+                .Where(x => _registeredSettingsByNameDict.ContainsKey(x.Name) &&
+                            !_fixedSettingsDict.ContainsKey(x.Name) &&
+                            x.ItHasValues)
                 .ToArray();
 
             using (var repository = _repositoryFactory())
@@ -176,12 +178,7 @@ namespace VirtoCommerce.Platform.Data.Settings
 
                 foreach (var setting in settings)
                 {
-                    // Skip when Setting is not registered
                     var settingDescriptor = _registeredSettingsByNameDict[setting.Name];
-                    if (settingDescriptor == null)
-                    {
-                        continue;
-                    }
 
                     if (!(await validator.ValidateAsync(setting)).IsValid)
                     {


### PR DESCRIPTION
## Description
- SettingsManager throws an exception when saving object settings only with modified properties
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-1791
### Artifact URL:
Image tag:
ghcr.io/VirtoCommerce/platform:3.851.0-pr-2835-9621-vcps-readonly-settings-96213d2f