### PR TITLE
VCST-2048: Extend ClaimsPrincipalExtensions with GetUserId and GetUserName

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Security/ClaimsPrincipalExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/ClaimsPrincipalExtensions.cs
@@ -10,16 +10,28 @@ namespace VirtoCommerce.Platform.Core.Security
     {
         public static string[] UserIdClaimTypes { get; set; } = [];
 
-        public static string GetCurrentUserId(this ClaimsPrincipal claimsPrincipal)
+        public static string[] UserNameClaimTypes { get; set; } = [];
+
+        public static string GetUserId(this ClaimsPrincipal claimsPrincipal)
+        {
+            return GetClaimValue(claimsPrincipal, UserIdClaimTypes);
+        }
+
+        public static string GetUserName(this ClaimsPrincipal claimsPrincipal)
+        {
+            return GetClaimValue(claimsPrincipal, UserNameClaimTypes);
+        }
+
+        private static string GetClaimValue(ClaimsPrincipal claimsPrincipal, string[] claimTypes)
         {
             if (claimsPrincipal != null)
             {
-                foreach (var claimType in UserIdClaimTypes)
+                foreach (var claimType in claimTypes)
                 {
-                    var userId = claimsPrincipal.FindFirstValue(claimType);
-                    if (!string.IsNullOrEmpty(userId))
+                    var value = claimsPrincipal.FindFirstValue(claimType);
+                    if (!string.IsNullOrEmpty(value))
                     {
-                        return userId;
+                        return value;
                     }
                 }
             }
@@ -45,7 +57,6 @@ namespace VirtoCommerce.Platform.Core.Security
             }
             return result;
         }
-
 
         public static bool HasGlobalPermission(this ClaimsPrincipal principal, string permissionName)
         {

--- a/src/VirtoCommerce.Platform.Core/Security/ClaimsPrincipalExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/ClaimsPrincipalExtensions.cs
@@ -8,6 +8,25 @@ namespace VirtoCommerce.Platform.Core.Security
 {
     public static class ClaimsPrincipalExtensions
     {
+        public static string[] UserIdClaimTypes { get; set; } = [];
+
+        public static string GetCurrentUserId(this ClaimsPrincipal claimsPrincipal)
+        {
+            if (claimsPrincipal != null)
+            {
+                foreach (var claimType in UserIdClaimTypes)
+                {
+                    var userId = claimsPrincipal.FindFirstValue(claimType);
+                    if (!string.IsNullOrEmpty(userId))
+                    {
+                        return userId;
+                    }
+                }
+            }
+
+            return null;
+        }
+
         public static Permission FindPermission(this ClaimsPrincipal principal, string permissionName, JsonSerializerSettings jsonSettings)
         {
             return FindPermissions(principal, permissionName, jsonSettings).FirstOrDefault();

--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -277,6 +277,7 @@ namespace VirtoCommerce.Platform.Web
                 options.ClaimsIdentity.RoleClaimType = OpenIddictConstants.Claims.Role;
 
                 ClaimsPrincipalExtensions.UserIdClaimTypes = [ClaimTypes.NameIdentifier, options.ClaimsIdentity.UserIdClaimType];
+                ClaimsPrincipalExtensions.UserNameClaimTypes = [options.ClaimsIdentity.UserNameClaimType];
             });
 
             services.ConfigureOptions<ConfigureSecurityStampValidatorOptions>();

--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -6,6 +6,7 @@ using System.Linq;
 using System.Net;
 using System.Reflection;
 using System.Runtime.InteropServices;
+using System.Security.Claims;
 using System.Security.Cryptography.X509Certificates;
 using System.Text;
 using System.Threading.Tasks;
@@ -274,6 +275,8 @@ namespace VirtoCommerce.Platform.Web
                 options.ClaimsIdentity.UserNameClaimType = OpenIddictConstants.Claims.Subject;
                 options.ClaimsIdentity.UserIdClaimType = OpenIddictConstants.Claims.Name;
                 options.ClaimsIdentity.RoleClaimType = OpenIddictConstants.Claims.Role;
+
+                ClaimsPrincipalExtensions.UserIdClaimTypes = [ClaimTypes.NameIdentifier, options.ClaimsIdentity.UserIdClaimType];
             });
 
             services.ConfigureOptions<ConfigureSecurityStampValidatorOptions>();

--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -276,7 +276,7 @@ namespace VirtoCommerce.Platform.Web
                 options.ClaimsIdentity.UserIdClaimType = OpenIddictConstants.Claims.Name;
                 options.ClaimsIdentity.RoleClaimType = OpenIddictConstants.Claims.Role;
 
-                ClaimsPrincipalExtensions.UserIdClaimTypes = [ClaimTypes.NameIdentifier, options.ClaimsIdentity.UserIdClaimType];
+                ClaimsPrincipalExtensions.UserIdClaimTypes = [options.ClaimsIdentity.UserIdClaimType, ClaimTypes.NameIdentifier];
                 ClaimsPrincipalExtensions.UserNameClaimTypes = [options.ClaimsIdentity.UserNameClaimType];
             });
 


### PR DESCRIPTION
## Description
feat: Extend ClaimsPrincipalExtensions with GetCurrentUserId and resolving of UserIdClaimTypes based on IdentityOptions settings.

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/VCST-2048
### Artifact URL:

Image tag:
ghcr.io/VirtoCommerce/platform:3.861.0-pr-2855-d6b6-vcst-2048-d6b67d91