### PR TITLE
VCST-2213: Cannot save empty field for catalog  property with type decimal number

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/smartFloat.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/smartFloat.js
@@ -17,7 +17,7 @@ angular.module('platformWebApp')
 				// possible values for fraction are: 0, positive number, negative number, none
 				// when fraction is a negative number result has maximum length of the fractional part of the value
 				var fraction = (attrs.fraction || Number(attrs.fraction) === 0) ? attrs.fraction : 2;
-				if (attrs.numType === "float") {
+				if (attrs.numType === 'float') {
 					ctrl.$parsers.unshift(function (viewValue) {
 						if (FLOAT_REGEXP_1.test(viewValue)) {
 							ctrl.$setValidity('float', true);
@@ -32,7 +32,8 @@ angular.module('platformWebApp')
 							ctrl.$setValidity('float', true);
 							return parseFloat(viewValue.replace(',', '.'));
 						} else {
-                            ctrl.$setValidity('float', false);
+							//Allow to use empty values
+							ctrl.$setValidity('float', !viewValue);
 							return viewValue;
 						}
 					});
@@ -54,7 +55,7 @@ angular.module('platformWebApp')
 						}
 					);
 				}
-				else if (attrs.numType === "positiveInteger") {
+				else if (attrs.numType === 'positiveInteger') {
 					ctrl.$parsers.unshift(function (viewValue) {
 						ctrl.$setValidity('positiveInteger', INTEGER_REGEXP.test(viewValue) && viewValue > 0);
 						return viewValue;


### PR DESCRIPTION
## Description
fix: Allow to save empty field for catalog property with type decimal number

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-2213
### Artifact URL:

Image tag:
ghcr.io/VirtoCommerce/platform:3.862.0-pr-2859-a4bf-vcst-2213-a4bfb288