### PR TITLE
VCST-2300: remove empty objects from ui grid state

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/common/uiGridUtils.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/common/uiGridUtils.js
@@ -61,7 +61,7 @@ angular.module('platformWebApp')
                             if (savedState) {
 
                                 Object.keys(savedState).forEach(function (key) {
-                                    let value = savedState[key];
+                                    const value = savedState[key];
                                     if (_.isEmpty(value)) {
                                         savedState[key] = undefined;
                                     }

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/common/uiGridUtils.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/common/uiGridUtils.js
@@ -59,9 +59,15 @@ angular.module('platformWebApp')
 
                         if (gridApi.saveState) {
                             if (savedState) {
-                                //$timeout(function () {
+
+                                Object.keys(savedState).forEach(function (key) {
+                                    let value = savedState[key];
+                                    if (_.isEmpty(value)) {
+                                        savedState[key] = undefined;
+                                    }
+                                });
+
                                 gridApi.saveState.restore($scope, savedState);
-                                //}, 10);
                             }
 
                             if (gridApi.colResizable)


### PR DESCRIPTION
## Description

Looks like a bug in ui grid. As a workaround I decided to remove empty objects and arrays before state restoring.

## References
### QA-test:
### Jira-link:


https://virtocommerce.atlassian.net/browse/VCST-2300
### Artifact URL:

Image tag:
ghcr.io/VirtoCommerce/platform:3.873.0-pr-2866-2792-vcst-2300-27928233