### PR TITLE
VCST-2599: Add NoCacheForApiMiddleware to prevent API response caching

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Middleware/NoCacheForApiMiddleware.cs
+++ b/src/VirtoCommerce.Platform.Web/Middleware/NoCacheForApiMiddleware.cs
@@ -1,0 +1,32 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Http;
+
+namespace VirtoCommerce.Platform.Web.Middleware;
+
+public class NoCacheForApiMiddleware
+{
+    private const string NoCache = "no-cache";
+    private const string ExpiresMinusOne = "-1";
+
+    private readonly RequestDelegate _next;
+
+    public NoCacheForApiMiddleware(RequestDelegate next)
+    {
+        _next = next;
+    }
+
+    public Task InvokeAsync(HttpContext context)
+    {
+        // Apply Cache-Control header for API responses
+        if (context.Request.Path.StartsWithSegments("/api", StringComparison.OrdinalIgnoreCase))
+        {
+            context.Response.Headers.CacheControl = NoCache;
+            context.Response.Headers.Pragma = NoCache;
+            context.Response.Headers.Expires = ExpiresMinusOne;
+        }
+
+        // Proceed with the request pipeline
+        return _next(context);
+    }
+}

--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -597,6 +597,8 @@ namespace VirtoCommerce.Platform.Web
 
             app.UseSecurityHeaders();
 
+            app.UseMiddleware<NoCacheForApiMiddleware>();
+
             //Return all errors as Json response
             app.UseMiddleware<ApiErrorWrappingMiddleware>();
 


### PR DESCRIPTION
## Description
feat: Introduced NoCacheForApiMiddleware to set HTTP headers (Cache-Control, Pragma, Expires) to prevent caching for API responses if hosting doesn't set it automatically.

## References
### QA-test:
### Jira-link:



https://virtocommerce.atlassian.net/browse/VCST-2599
### Artifact URL:

Image tag:
ghcr.io/VirtoCommerce/platform:3.878.0-pr-2877-b5e4-vcst-2599-b5e47801