### PR TITLE
VCST-2892: Add minimal TLS version to storage account config

### DIFF
--- a/azuredeploy.json
+++ b/azuredeploy.json
@@ -84,9 +84,10 @@
                 "tier": "Standard"
             },
             "kind": "StorageV2",
-            "properties": {
-                "allowBlobPublicAccess": true
-                }
+          "properties": {
+            "allowBlobPublicAccess": true,
+            "minimalTlsVersion": "TLS1_2"
+          }
         },
         {
             "apiVersion": "2014-04-01",


### PR DESCRIPTION
## Description
fix: Updated azuredeploy.json to include minimalTlsVersion set to "TLS1_2" for enhanced security. Retained allowBlobPublicAccess property.

## References
### QA-test:
### Jira-link:
### Artifact URL:
