### PR TITLE
VCST-2960: Add language toggle for dynamic property display names.

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/de.VirtoCommerce.Platform.json
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/de.VirtoCommerce.Platform.json
@@ -84,7 +84,9 @@
           "display-name": "Anzeigename",
           "value-type": "Werttyp",
           "dictionary-values": "Wörterbuch-Werte",
-          "manage-dictionary": "Wörterbuch verwalten"
+          "manage-dictionary": "Wörterbuch verwalten",
+          "show-more-languages": "Mehr Sprachen anzeigen",
+          "show-less-languages": "Weniger Sprachen anzeigen"
         },
         "placeholders": {
           "description": "Eigenschaftsbeschreibung eingeben",

--- a/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/en.VirtoCommerce.Platform.json
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/en.VirtoCommerce.Platform.json
@@ -84,7 +84,9 @@
           "display-name": "Display name",
           "value-type": "Value type",
           "dictionary-values": "Dictionary values",
-          "manage-dictionary": "Manage dictionary"
+          "manage-dictionary": "Manage dictionary",
+          "show-more-languages": "Show more languages",
+          "show-less-languages": "Show less languages"
         },
         "placeholders": {
           "description": "Enter property description",

--- a/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/es.VirtoCommerce.Platform.json
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/es.VirtoCommerce.Platform.json
@@ -84,7 +84,9 @@
           "display-name": "Nombre para mostrar",
           "value-type": "Tipo de valor",
           "dictionary-values": "Valores del diccionario",
-          "manage-dictionary": "Gestionar diccionario"
+          "manage-dictionary": "Gestionar diccionario",
+          "show-more-languages": "Mostrar más idiomas",
+          "show-less-languages": "Mostrar menos idiomas"
         },
         "placeholders": {
           "description": "Introducir descripción de la propiedad",

--- a/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/fr.VirtoCommerce.Platform.json
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/fr.VirtoCommerce.Platform.json
@@ -84,7 +84,9 @@
           "display-name": "Nom d'affichage",
           "value-type": "Type de valeur",
           "dictionary-values": "Valeurs du dictionnaire",
-          "manage-dictionary": "Gérer le dictionnaire"
+          "manage-dictionary": "Gérer le dictionnaire",
+          "show-more-languages": "Afficher plus de langues",
+          "show-less-languages": "Afficher moins de langues"
         },
         "placeholders": {
           "description": "Entrer la description de la propriété",

--- a/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/it.VirtoCommerce.Platform.json
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/it.VirtoCommerce.Platform.json
@@ -84,7 +84,9 @@
           "display-name": "Nome visualizzato",
           "value-type": "Tipo di valore",
           "dictionary-values": "Valori del dizionario",
-          "manage-dictionary": "Gestisci dizionario"
+          "manage-dictionary": "Gestisci dizionario",
+          "show-more-languages": "Mostra più lingue",
+          "show-less-languages": "Mostra meno lingue"
         },
         "placeholders": {
           "description": "Inserisci la descrizione della proprietà",

--- a/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/ja.VirtoCommerce.Platform.json
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/ja.VirtoCommerce.Platform.json
@@ -84,7 +84,9 @@
           "display-name": "表示名",
           "value-type": "値タイプ",
           "dictionary-values": "辞書の値",
-          "manage-dictionary": "辞書を管理"
+          "manage-dictionary": "辞書を管理",
+          "show-more-languages": "さらに多くの言語を表示",
+          "show-less-languages": "少ない言語を表示"
         },
         "placeholders": {
           "description": "プロパティの説明を入力",

--- a/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/pl.VirtoCommerce.Platform.json
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/pl.VirtoCommerce.Platform.json
@@ -84,7 +84,9 @@
           "display-name": "Nazwa wyświetlana",
           "value-type": "Typ wartości",
           "dictionary-values": "Wartości słownikowe",
-          "manage-dictionary": "Zarządzaj słownikiem"
+          "manage-dictionary": "Zarządzaj słownikiem",
+          "show-more-languages": "Pokaż więcej języków",
+          "show-less-languages": "Pokaż mniej języków"
         },
         "placeholders": {
           "description": "Wprowadź opis właściwości",

--- a/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/pt.VirtoCommerce.Platform.json
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/pt.VirtoCommerce.Platform.json
@@ -84,7 +84,9 @@
           "display-name": "Nome de exibição",
           "value-type": "Tipo de valor",
           "dictionary-values": "Valores do dicionário",
-          "manage-dictionary": "Gerenciar dicionário"
+          "manage-dictionary": "Gerenciar dicionário",
+          "show-more-languages": "Mostrar mais idiomas",
+          "show-less-languages": "Mostrar menos idiomas"
         },
         "placeholders": {
           "description": "Digite a descrição da propriedade",

--- a/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/ru.VirtoCommerce.Platform.json
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/ru.VirtoCommerce.Platform.json
@@ -84,7 +84,9 @@
           "display-name": "Отображаемое имя",
           "value-type": "Тип значения",
           "dictionary-values": "Словарные значения",
-          "manage-dictionary": "Управление словарем"
+          "manage-dictionary": "Управление словарем",
+          "show-more-languages": "Показать больше языков",
+          "show-less-languages": "Показать меньше языков"
         },
         "placeholders": {
           "description": "Введите описание свойства",

--- a/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/zh.VirtoCommerce.Platform.json
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/Localizations/zh.VirtoCommerce.Platform.json
@@ -84,7 +84,9 @@
           "display-name": "显示名称",
           "value-type": "值类型",
           "dictionary-values": "字典值",
-          "manage-dictionary": "管理字典"
+          "manage-dictionary": "管理字典",
+          "show-more-languages": "显示更多语言",
+          "show-less-languages": "显示更少语言"
         },
         "placeholders": {
           "description": "输入属性描述",

--- a/src/VirtoCommerce.Platform.Web/wwwroot/css/themes/main/sass/modules/_forms.sass
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/css/themes/main/sass/modules/_forms.sass
@@ -145,6 +145,8 @@ fieldset + fieldset
   z-index: 100
   line-height: 34px
   padding-right: 15px
+  font-size: 13px
+  color: #999
 .form-input.__currency input,
 .form-input.__currency textarea,
 .form-input.__currency select

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/dynamicProperties/blades/dynamicProperty-detail.tpl.html
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/dynamicProperties/blades/dynamicProperty-detail.tpl.html
@@ -9,6 +9,18 @@
                         <input focus-on="" required ng-model="blade.currentEntity.name" placeholder="{{ 'platform.genericValueInput.placeholders.short-text' | translate}}" />
                     </div>
                 </div>
+                <div class="form-group">
+                    <label class="form-label" for="">{{ 'platform.blades.dynamicProperty-detail.labels.display-name' | translate }}</label>
+                    <div class="form-input __langs" ng-repeat="data in blade.currentEntity.displayNames | limitTo: blade.showAllLanguages ? blade.currentEntity.displayNames.length : 2">
+                        <label class="lang-code">{{data.locale}}</label>
+                        <input ng-model="data.name" placeholder="{{ 'platform.blades.dynamicProperty-detail.placeholders.display-name' | translate }}" />
+                    </div>
+                    <div ng-if="blade.currentEntity.displayNames.length > 2">
+                        <a href="" ng-click="blade.showAllLanguages = !blade.showAllLanguages">
+                          {{ (blade.showAllLanguages ? 'platform.blades.dynamicProperty-detail.labels.show-less-languages' : 'platform.blades.dynamicProperty-detail.labels.show-more-languages' ) | translate }}
+                        </a>
+                    </div>
+                </div>
                 <div class="columns clearfix">
                     <div class="column">
                         <div class="columns">
@@ -109,18 +121,7 @@
                         <input ng-model="blade.currentEntity.description" placeholder="{{ 'platform.blades.dynamicProperty-detail.placeholders.description' | translate}}" />
                     </div>
                 </div>
-                <div class="form-group">
-                    <label class="form-label" for="">{{ 'platform.blades.dynamicProperty-detail.labels.display-name' | translate }}</label>
-                    <div class="form-input __langs" ng-repeat="data in blade.currentEntity.displayNames | limitTo: blade.showAllLanguages ? blade.currentEntity.displayNames.length : 2">
-                        <label class="lang-code">{{data.locale}}</label>
-                        <input ng-model="data.name" placeholder="{{ 'platform.blades.dynamicProperty-detail.placeholders.display-name' | translate }}" />
-                    </div>
-                    <div ng-if="blade.currentEntity.displayNames.length > 2">
-                        <a href="" ng-click="blade.showAllLanguages = !blade.showAllLanguages">
-                          {{ (blade.showAllLanguages ? 'platform.blades.dynamicProperty-detail.labels.show-less-languages' : 'platform.blades.dynamicProperty-detail.labels.show-more-languages' ) | translate }}
-                        </a>
-                    </div>
-                </div>
+
             </form>
 
             <ul class="list __items">

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/dynamicProperties/blades/dynamicProperty-detail.tpl.html
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/dynamicProperties/blades/dynamicProperty-detail.tpl.html
@@ -111,9 +111,14 @@
                 </div>
                 <div class="form-group">
                     <label class="form-label" for="">{{ 'platform.blades.dynamicProperty-detail.labels.display-name' | translate }}</label>
-                    <div class="form-input __langs" ng-repeat="data in blade.currentEntity.displayNames | orderBy: 'locale'">
+                    <div class="form-input __langs" ng-repeat="data in blade.currentEntity.displayNames | limitTo: blade.showAllLanguages ? blade.currentEntity.displayNames.length : 2">
                         <label class="lang-code">{{data.locale}}</label>
                         <input ng-model="data.name" placeholder="{{ 'platform.blades.dynamicProperty-detail.placeholders.display-name' | translate }}" />
+                    </div>
+                    <div ng-if="blade.currentEntity.displayNames.length > 2">
+                        <a href="" ng-click="blade.showAllLanguages = !blade.showAllLanguages">
+                          {{ (blade.showAllLanguages ? 'platform.blades.dynamicProperty-detail.labels.show-less-languages' : 'platform.blades.dynamicProperty-detail.labels.show-more-languages' ) | translate }}
+                        </a>
                     </div>
                 </div>
             </form>


### PR DESCRIPTION
## Description
feat: Add language toggle for dynamic property display names.

![VCST-2960](https://github.com/user-attachments/assets/bbd184cd-d216-4a0a-a121-b8fb6f819134)

## References:
### QA-test:
### Jira-link:


### Artifact URL:


[VCST-2960]: https://virtocommerce.atlassian.net/browse/VCST-2960?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
Image tag:
ghcr.io/VirtoCommerce/platform:3.883.0-pr-2903-d3c8-vcst-2960-d3c82e63