### PR TITLE
VCST-3370: Set SqlServer.CompatibilityLevel=120 by default

### DIFF
--- a/src/VirtoCommerce.Platform.Web/appsettings.json
+++ b/src/VirtoCommerce.Platform.Web/appsettings.json
@@ -8,7 +8,7 @@
   "SqlServer": {
     // Set compatibility level to 120 (SQL Server 2014) to prevent the use of OPENJSON, which has poor performance.
     // https://github.com/dotnet/efcore/issues/32394
-    // "CompatibilityLevel": 120
+    "CompatibilityLevel": 120
   },
   "Serilog": {
     "Using": [


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-3370
### Artifact URL:

Image tag:
ghcr.io/VirtoCommerce/platform:3.890.0-pr-2918-469c-vcst-3370-469c8336