### PR TITLE
VCST-3621: Could not load file or assembly for some System packages.

### DIFF
--- a/src/VirtoCommerce.Platform.Modules/LoadContextAssemblyResolver.cs
+++ b/src/VirtoCommerce.Platform.Modules/LoadContextAssemblyResolver.cs
@@ -177,7 +177,7 @@ namespace VirtoCommerce.Platform.Modules
         private bool SearchForLibrary(ManagedLibrary library, ManagedAssemblyLoadContext loadContext, out string path)
         {
             // 1. Check for in _basePath + app local path
-            var localFile = Path.Combine(loadContext.BasePath, library.AppLocalPath);
+            var localFile = Path.Combine(loadContext.BasePath, Path.GetFileName(library.AppLocalPath));
             if (File.Exists(localFile))
             {
                 path = localFile;


### PR DESCRIPTION
## Description
fix: Could not load file or assembly issue. For example:  Could not load file or assembly System.Diagnostics.PerformanceCounter, Version=8.0.0.0 because AppLocalPath has runtimes/win/lib/net6.0/System.Diagnostics.PerformanceCounter.dll value.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-3621
### Artifact URL:

Image tag:
ghcr.io/VirtoCommerce/platform:3.895.0-pr-2926-a268-vcst-3621-a2686ce8