### PR TITLE
VCST-3436: Add account lockout check in SecurityController

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Controllers/Api/SecurityController.cs
+++ b/src/VirtoCommerce.Platform.Web/Controllers/Api/SecurityController.cs
@@ -484,11 +484,22 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
                 return Ok(IdentityResultExtensions.CreateErrorResult(UserNotFound));
             }
 
+            if (await UserManager.IsLockedOutAsync(user))
+            {
+                return BadRequest(new SecurityResult { Errors = ["Your account is locked due to multiple failed attempts. Please try again later."] });
+            }
+
             var result = await UserManager.ChangePasswordAsync(user, changePassword.OldPassword, changePassword.NewPassword);
             if (result.Succeeded && user.PasswordExpired)
             {
                 user.PasswordExpired = false;
                 await UserManager.UpdateAsync(user);
+                await UserManager.ResetAccessFailedCountAsync(user);
+            }
+            else
+            {
+                // Register failed attempt
+                await UserManager.AccessFailedAsync(user);
             }
 
             return Ok(result.ToSecurityResult());

--- a/src/VirtoCommerce.Platform.Web/appsettings.json
+++ b/src/VirtoCommerce.Platform.Web/appsettings.json
@@ -165,7 +165,8 @@
       "RemindPasswordExpiryInDay": 7
     },
     "Lockout": {
-      "DefaultLockoutTimeSpan": "0:15:0"
+      "DefaultLockoutTimeSpan": "0:15:0",
+      "MaxFailedAccessAttempts": 5
     }
   },
   "ExternalModules": {


### PR DESCRIPTION
## Description
fix: Introduce a check for locked-out user accounts in the SecurityController. If a user is locked out due to multiple failed login attempts, a BadRequest response is returned with an error message.

## References
### QA-test:
### Jira-link:
### Artifact URL:
