### PR TITLE
VCST-3739: Add .zip extension to AssemblyServiceFileExtensions

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Modularity/LocalStorageModuleCatalogOptions.cs
+++ b/src/VirtoCommerce.Platform.Core/Modularity/LocalStorageModuleCatalogOptions.cs
@@ -20,9 +20,9 @@ namespace VirtoCommerce.Platform.Core.Modularity
         /// If the probing folder is absent at platform startup, it will be forcibly refreshed regardless of RefreshProbingFolderOnStart value. 
         /// </summary>
         public bool RefreshProbingFolderOnStart { get; set; } = true;
-        public string[] LocalizationFileExtensions { get; set; } = new[] { "resources.dll" };
-        public string[] AssemblyFileExtensions { get; set; } = new[] { ".dll", ".exe" };
-        public string[] AssemblyServiceFileExtensions { get; set; } = new[] { ".pdb", ".xml", ".deps.json", ".runtimeconfig.json", ".runtimeconfig.dev.json", ".dep" };
-        public string[] ReferenceAssemblyFolders { get; set; } = new[] { "ref" };
+        public string[] LocalizationFileExtensions { get; set; } = ["resources.dll"];
+        public string[] AssemblyFileExtensions { get; set; } = [".dll", ".exe"];
+        public string[] AssemblyServiceFileExtensions { get; set; } = [".pdb", ".xml", ".deps.json", ".runtimeconfig.json", ".runtimeconfig.dev.json", ".dep", ".zip"];
+        public string[] ReferenceAssemblyFolders { get; set; } = ["ref"];
     }
 }


### PR DESCRIPTION
## Description
fix: Add .zip extension to copy into app_data\modules folder. For example, it allows Azure Monitor access to TraceUpload.zip.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-3739
### Artifact URL:

Image tag:
ghcr.io/VirtoCommerce/platform:3.902.0-pr-2931-87b0-vcst-3739-87b05e5b