### PR TITLE
VCST-3950: Inconsistent spacing between icon and title for vcshell applications in the menu

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/navigation/menu/mainMenu-item.tpl.html
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/navigation/menu/mainMenu-item.tpl.html
@@ -1,5 +1,5 @@
 <a class="list-link" ng-if="!menuItem.template" href="" tabindex="-1">
-  <span class="list-ico" ng-if="menuItem.iconUrl">
+  <span ng-if="menuItem.iconUrl">
     <img class="list-ico" ng-src="{{menuItem.iconUrl}}" />
   </span>
   <span class="list-ico fa-fw" ng-if="!menuItem.iconUrl" ng-class="menuItem.icon"></span>


### PR DESCRIPTION
## Description
fix: Inconsistent spacing between icon and title for vcshell applications in the menu

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-3950
### Artifact URL:

Image tag:
ghcr.io/VirtoCommerce/platform:3.906.0-pr-2939-1026-vcst-3950-1026c4e3