### PR TITLE
VCST-3952: Hangfire version upgrade to 1.8.21

### DIFF
--- a/src/VirtoCommerce.Platform.Hangfire/VirtoCommerce.Platform.Hangfire.csproj
+++ b/src/VirtoCommerce.Platform.Hangfire/VirtoCommerce.Platform.Hangfire.csproj
@@ -19,13 +19,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Hangfire" Version="1.8.15" />
-    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.15" />
+    <PackageReference Include="Hangfire" Version="1.8.21" />
+    <PackageReference Include="Hangfire.AspNetCore" Version="1.8.21" />
     <PackageReference Include="Hangfire.Console" Version="1.4.3" />
     <PackageReference Include="Hangfire.MemoryStorage" Version="1.8.1.1" />
     <PackageReference Include="Hangfire.MySqlStorage" Version="2.0.3" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.20.10" />
-    <PackageReference Include="HangFire.SqlServer" Version="1.8.15" />
+    <PackageReference Include="HangFire.SqlServer" Version="1.8.21" />
     <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="[8.0.11,9)" />
     <PackageReference Include="Microsoft.SourceLink.GitHub" Version="8.0.0" PrivateAssets="All" />
   </ItemGroup>


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-3952
### Artifact URL:

Image tag:
ghcr.io/VirtoCommerce/platform:3.907.0-pr-2940-aeda-vcst-3952-hangfire-update-aeda8908