### PR TITLE
VCST-4910:  More button in toolbar

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/css/themes/main/sass/modules/_base-modules.sass
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/css/themes/main/sass/modules/_base-modules.sass
@@ -1781,10 +1781,9 @@ tags-input
       top: 79px
       z-index: 50
 
-      transition: height .3s ease
       .menu
         margin: 0 0 0 7px
-        white-space: normal
+        white-space: nowrap
       .menu-item
         margin: 7px 0
         &.separator
@@ -1827,6 +1826,47 @@ tags-input
         display: block
         font-size: 18px
         margin: 0 0 3px
+      .toolbar-dropdown
+        background: $bladeHeadBg
+        border: 1px solid rgba(255,255,255,.2)
+        border-top: none
+        box-shadow: 0 4px 8px rgba(0,0,0,.3)
+        position: fixed
+        z-index: 1000
+        min-width: 160px
+        max-height: 300px
+        overflow-y: auto
+        padding: 5px 0
+        white-space: nowrap
+        .menu-item
+          display: block
+          margin: 0
+          &.separator
+            border-bottom: 1px solid rgba(255,255,255,.2)
+            border-right: none
+        .menu-btn
+          background: none
+          border: none
+          color: $whiteColor
+          cursor: pointer
+          font-size: 11px
+          font-weight: 300
+          display: flex
+          align-items: center
+          padding: 8px 15px
+          text-align: left
+          width: 100%
+          white-space: nowrap
+          &:hover
+            background: rgba(255,255,255,.1)
+            color: $baseColor
+          &:disabled
+            color: rgba(255,255,255,.4)
+            cursor: not-allowed
+        .menu-ico
+          display: inline-block
+          font-size: 16px
+          margin: 0 8px 0 0
     .blade-switch
       bottom: 4px
       position: absolute

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/navigation/blade/bladeContainer.tpl.html
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/navigation/blade/bladeContainer.tpl.html
@@ -66,6 +66,14 @@
                         </button>
                     </li>
                 </ul>
+                <ul class="menu toolbar-dropdown" ng-show="moreToolsOpen" ng-style="dropdownStyle">
+                    <li class="menu-item" ng-class="{'__disabled': !toolbarCommand.canExecuteMethod(blade), 'separator': toolbarCommand.showSeparator}" ng-click='toolbarCommand.executeMethod(blade)' ng-repeat="toolbarCommand in overflowCommands" ng-disabled="!toolbarCommand.canExecuteMethod(blade)" ng-show="!toolbarCommand.hide(blade)" va-permission="{{toolbarCommand.permission}}" security-scopes="blade.securityScopes">
+                        <button class="menu-btn" ng-attr-title="{{toolbarCommand.title | translate}}">
+                            <i class="menu-ico" ng-class="toolbarCommand.icon"></i>
+                            {{ toolbarCommand.name | translate }}
+                        </button>
+                    </li>
+                </ul>
             </div>
         </header>
 

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/navigation/blade/bladeNavigation.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/navigation/blade/bladeNavigation.js
@@ -159,44 +159,93 @@ angular.module('platformWebApp')
                     });
                 };
 
-                scope.$watch('blade.toolbarCommands', function (toolbarCommands) {
-                    scope.resolvedToolbarCommands = toolbarService.resolve(toolbarCommands, scope.blade.controller);
+                scope.moreToolsOpen = false;
+                scope.overflowCommands = [];
 
+                scope.$watch('blade.toolbarCommands', function (toolbarCommands) {
+
+                    scope.resolvedToolbarCommands = toolbarService.resolve(toolbarCommands, scope.blade.controller);
+                    scope.moreToolsOpen = false;
                     setVisibleToolsLimit();
                 }, true);
 
-                var toolbar = currentBlade.find(".blade-toolbar .menu.__inline");
-
+                var pendingToolsTimeout = null;
                 function setVisibleToolsLimit() {
+                    scope.moreToolsOpen = false;
                     scope.toolsPerLineCount = scope.resolvedToolbarCommands ? scope.resolvedToolbarCommands.length : 1;
 
-                    $timeout(function () {
-                        if (toolbar.height() > 55 && scope.toolsPerLineCount > 1) {
-                            var maxToolbarWidth = toolbar.width() - 46; // the 'more' button is 46px wide
-                            //console.log(toolbar.width() + 'maxToolbarWidth: ' + maxToolbarWidth);
-                            var toolsWidth = 0;
-                            var lis = toolbar.find("li");
-                            var i = 0;
-                            while (maxToolbarWidth > toolsWidth && lis.length > i) {
-                                toolsWidth += lis[i].clientWidth;
-                                i++;
+                    // Cancel any pending timeout to avoid race conditions with repeated calls
+                    if (pendingToolsTimeout) {
+                        $timeout.cancel(pendingToolsTimeout);
+                    }
+
+                    pendingToolsTimeout = $timeout(function () {
+                        pendingToolsTimeout = null;
+                        // Look up toolbar element fresh each time to avoid stale references from ng-if
+                        var toolbar = currentBlade.find(".blade-toolbar .menu.__inline");
+                        var lis = toolbar.find("li");
+
+                        if (lis.length > 1) {
+                            var totalToolsWidth = 0;
+                            for (var j = 0; j < lis.length; j++) {
+                                totalToolsWidth += lis[j].clientWidth;
                             }
-                            scope.toolsPerLineCount = i - 1;
+                            var availableWidth = toolbar.width();
+
+                            if (totalToolsWidth > availableWidth) {
+                                var maxToolbarWidth = availableWidth - 46; // the 'more' button is 46px wide
+                                var toolsWidth = 0;
+                                var i = 0;
+                                while (i < lis.length && toolsWidth + lis[i].clientWidth <= maxToolbarWidth) {
+                                    toolsWidth += lis[i].clientWidth;
+                                    i++;
+                                }
+                                scope.toolsPerLineCount = Math.max(i, 1);
+
+                            }
                         }
+                        updateOverflowCommands();
                     }, 220);
                 }
 
+                function updateOverflowCommands() {
+                    if (scope.resolvedToolbarCommands && scope.toolsPerLineCount < scope.resolvedToolbarCommands.length) {
+                        scope.overflowCommands = scope.resolvedToolbarCommands.slice(scope.toolsPerLineCount);
+                    } else {
+                        scope.overflowCommands = [];
+                    }
+                }
+
                 function handleClickEvent() {
-                    setVisibleToolsLimit();
+                    scope.$apply(function () {
+                        scope.moreToolsOpen = false;
+                    });
                     $document.unbind('click', handleClickEvent);
                 }
 
+                scope.dropdownStyle = {};
                 scope.showMoreTools = function (event) {
-                    scope.toolsPerLineCount = scope.resolvedToolbarCommands.length;
-
+                    scope.moreToolsOpen = !scope.moreToolsOpen;
                     event.stopPropagation();
-                    $document.bind('click', handleClickEvent);
+                    if (scope.moreToolsOpen) {
+                        // Calculate fixed position for dropdown relative to the toolbar bottom
+                        var toolbar = currentBlade.find(".blade-toolbar")[0];
+                        if (toolbar) {
+                            var rect = toolbar.getBoundingClientRect();
+                            scope.dropdownStyle = {
+                                top: Math.round(rect.bottom) + 'px',
+                                right: Math.round(document.documentElement.clientWidth - rect.right) + 'px'
+                            };
+                        }
+                        $document.bind('click', handleClickEvent);
+                    } else {
+                        $document.unbind('click', handleClickEvent);
+                    }
                 };
+
+                scope.$on('$destroy', function () {
+                    $document.unbind('click', handleClickEvent);
+                });
 
                 scope.showErrorDetails = function () {
                     var dialog = {


### PR DESCRIPTION
## Description
feat: Adds More button in toolbar with overflow items.

<img width="586" height="347" alt="image" src="https://github.com/user-attachments/assets/53ceec83-d406-4e2e-ad62-dce031079bb8" />

<img width="543" height="486" alt="image" src="https://github.com/user-attachments/assets/ee1aacb7-e306-4f69-b5ea-3f809afaee41" />



## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4910
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates blade toolbar rendering and width-calculation logic to move overflowing commands into a new dropdown, which could affect command visibility/interaction across screen sizes and blade lifecycles.
> 
> **Overview**
> Adds a **"More" overflow dropdown** to the blade toolbar so commands that don’t fit in the available width are moved into a separate menu.
> 
> Updates `bladeNavigation.js` to compute how many commands can be shown inline based on measured `li` widths (with timeout debouncing/cancellation), maintain an `overflowCommands` list, and manage dropdown open/close behavior (fixed positioning plus document-click dismissal and cleanup on `$destroy`).
> 
> Extends toolbar styling in `_base-modules.sass` to prevent wrapping (`nowrap`) and to style/position the new `.toolbar-dropdown` menu.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2272d321d2f267831a53da9702042ee7f2daf522. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Image tag:
ghcr.io/VirtoCommerce/platform:3.1018.0-pr-3003-2272-vcst-4910-toolbar-2272d321