### PR TITLE
VCST-4770: Update workflows to use Node 24

### DIFF
--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,7 +43,7 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
     - name: Checkout repository
-      uses: actions/checkout@v3
+      uses: actions/checkout@v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -1,5 +1,4 @@
-# v3.800.26
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# https://virtocommerce.atlassian.net/browse/VCST-4770
 name: Platform CI
 
 on:
@@ -67,13 +66,13 @@ jobs:
 
     steps:
 
-    - name: Set up Node 20
-      uses: actions/setup-node@v4
+    - name: Set up Node 24
+      uses: actions/setup-node@v6
       with:
-        node-version: '20'
+        node-version: '24'
 
     - name: Set up Java 17
-      uses: actions/setup-java@v4
+      uses: actions/setup-java@v5
       with:
         distribution: 'temurin'
         java-version: '17'
@@ -94,7 +93,7 @@ jobs:
       run: |
         echo "BUILD_DOCKER=true" >> $GITHUB_ENV
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -289,7 +288,7 @@ jobs:
     - name: Push Build Info to Jira
       if: ${{ env.CLOUD_INSTANCE_BASE_URL != 0 && env.CLIENT_ID != 0 && env.CLIENT_SECRET != 0 && steps.jira_keys.outputs.jira-keys != '' && always() }}
       id: push_build_info_to_jira
-      uses: VirtoCommerce/jira-upload-build-info@master
+      uses: VirtoCommerce/jira-upload-build-info@VCST-4770
       with:
         cloud-instance-base-url: '${{ secrets.CLOUD_INSTANCE_BASE_URL }}'
         client-id: '${{ secrets.CLIENT_ID }}'
@@ -315,7 +314,7 @@ jobs:
     needs: 'ci'
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.26  
+    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@VCST-4770
     with:
       installModules: 'true'
       installCustomModule: 'false'
@@ -331,7 +330,7 @@ jobs:
     needs: 'ci'
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.26
+    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@VCST-4770
     with:
       katalonRepo: 'VirtoCommerce/vc-quality-gate-katalon'
       katalonRepoBranch: 'dev'
@@ -344,17 +343,17 @@ jobs:
       envPAT: ${{ secrets.REPO_TOKEN }}
       katalonApiKey: ${{ secrets.KATALON_API_KEY }}
 
-  deploy-cloud:
-    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
-    needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.26    
-    with:
-      releaseSource: platform
-      platformVer: ${{ needs.ci.outputs.version }}
-      platformTag: ${{ needs.ci.outputs.tag }}
-      jiraKeys: ${{ needs.ci.outputs.jira-keys }}
-      matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
-    secrets: inherit
+  # deploy-cloud:
+  #   if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
+  #   needs: ci
+  #   uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.26    
+  #   with:
+  #     releaseSource: platform
+  #     platformVer: ${{ needs.ci.outputs.version }}
+  #     platformTag: ${{ needs.ci.outputs.tag }}
+  #     jiraKeys: ${{ needs.ci.outputs.jira-keys }}
+  #     matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
+  #   secrets: inherit
 
   owasp-scan:
     if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
@@ -373,7 +372,7 @@ jobs:
   trivy-scan:
     if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.26  
+    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@VCST-4770
     with:
       assigneeAccountId: '621c47c0302c6b006af0a1cd'
       assigneeEmailAddress: 'andrew.kubyshkin@virtoworks.com'

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -288,7 +288,7 @@ jobs:
     - name: Push Build Info to Jira
       if: ${{ env.CLOUD_INSTANCE_BASE_URL != 0 && env.CLIENT_ID != 0 && env.CLIENT_SECRET != 0 && steps.jira_keys.outputs.jira-keys != '' && always() }}
       id: push_build_info_to_jira
-      uses: VirtoCommerce/jira-upload-build-info@VCST-4770
+      uses: VirtoCommerce/jira-upload-build-info@master
       with:
         cloud-instance-base-url: '${{ secrets.CLOUD_INSTANCE_BASE_URL }}'
         client-id: '${{ secrets.CLIENT_ID }}'
@@ -314,7 +314,7 @@ jobs:
     needs: 'ci'
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@VCST-4770
+    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.29
     with:
       installModules: 'true'
       installCustomModule: 'false'
@@ -330,7 +330,7 @@ jobs:
     needs: 'ci'
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@VCST-4770
+    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.29
     with:
       katalonRepo: 'VirtoCommerce/vc-quality-gate-katalon'
       katalonRepoBranch: 'dev'
@@ -372,7 +372,7 @@ jobs:
   trivy-scan:
     if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@VCST-4770
+    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.29
     with:
       assigneeAccountId: '621c47c0302c6b006af0a1cd'
       assigneeEmailAddress: 'andrew.kubyshkin@virtoworks.com'

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -346,7 +346,7 @@ jobs:
   deploy-cloud:
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.26    
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.29    
     with:
       releaseSource: platform
       platformVer: ${{ needs.ci.outputs.version }}

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -343,17 +343,17 @@ jobs:
       envPAT: ${{ secrets.REPO_TOKEN }}
       katalonApiKey: ${{ secrets.KATALON_API_KEY }}
 
-  # deploy-cloud:
-  #   if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
-  #   needs: ci
-  #   uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.26    
-  #   with:
-  #     releaseSource: platform
-  #     platformVer: ${{ needs.ci.outputs.version }}
-  #     platformTag: ${{ needs.ci.outputs.tag }}
-  #     jiraKeys: ${{ needs.ci.outputs.jira-keys }}
-  #     matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
-  #   secrets: inherit
+  deploy-cloud:
+    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
+    needs: ci
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.26    
+    with:
+      releaseSource: platform
+      platformVer: ${{ needs.ci.outputs.version }}
+      platformTag: ${{ needs.ci.outputs.tag }}
+      jiraKeys: ${{ needs.ci.outputs.jira-keys }}
+      matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
+    secrets: inherit
 
   owasp-scan:
     if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -187,7 +187,7 @@ jobs:
 
     - name: Docker Login
       if: ${{ env.BUILD_DOCKER == 'true' }}
-      uses: docker/login-action@v3
+      uses: docker/login-action@v4
       with:
         registry: ${{ env.PACKAGE_SERVER }}
         username: $GITHUB_ACTOR

--- a/.github/workflows/platform-release-hotfix.yml
+++ b/.github/workflows/platform-release-hotfix.yml
@@ -36,7 +36,7 @@ jobs:
       changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
 
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@v6
       with:
         fetch-depth: 0
 
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v6
 
     - name: Install VirtoCommerce.GlobalTool
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master

--- a/.github/workflows/platfotm-owasp.yml
+++ b/.github/workflows/platfotm-owasp.yml
@@ -22,7 +22,7 @@ jobs:
         uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
       - name: Docker Login
-        uses: docker/login-action@v3
+        uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: $GITHUB_ACTOR

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -25,7 +25,7 @@ jobs:
       version: ${{ steps.artifactVer.outputs.shortVersion }}
     steps:
 
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v6
 
     - name: Get Artifact Version
       uses: VirtoCommerce/vc-github-actions/get-image-version@master

--- a/.github/workflows/regression-pr.yml
+++ b/.github/workflows/regression-pr.yml
@@ -49,6 +49,8 @@ jobs:
 
     - name: checkout
       uses: actions/checkout@v6
+      with:
+        fetch-depth: 0
 
     - uses: VirtoCommerce/vc-github-actions/setup-git-credentials-github@master
       with:

--- a/.github/workflows/regression-pr.yml
+++ b/.github/workflows/regression-pr.yml
@@ -48,7 +48,7 @@ jobs:
         echo "PR_BODY=Automated cherry-pick update from PR ${{ needs.check-label.outputs.pullUrl}}" >> $GITHUB_ENV
 
     - name: checkout
-      uses: actions/checkout@v1
+      uses: actions/checkout@v6
 
     - uses: VirtoCommerce/vc-github-actions/setup-git-credentials-github@master
       with:


### PR DESCRIPTION
## Description
Update workflows and used for build Node version 24
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4770
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Workflow runtime/tooling changes (Node 24 and major action version bumps) can break CI/release pipelines if any steps or dependencies are incompatible, but no product code or runtime logic is touched.
> 
> **Overview**
> Updates GitHub Actions workflows to run builds on **Node.js 24** (via `actions/setup-node@v6`) and bumps several key actions to newer major versions, including `actions/checkout@v6`, `actions/setup-java@v5`, and `docker/login-action@v4`.
> 
> Refreshes reusable workflow references in `platform-ci.yml` to `VirtoCommerce/.github@v3.800.29`, and adjusts the regression cherry-pick workflow checkout to use `checkout@v6` with full history (`fetch-depth: 0`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c7afa73a17baae98b993c9a9dd5c77c00195ac2e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1019.0-pr-3005-c7af-vcst-4770-c7afa73a