### PR TITLE
VCST-4934: Allow override protected user fields

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Security/AuthorizationOptions.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/AuthorizationOptions.cs
@@ -26,5 +26,16 @@ namespace VirtoCommerce.Platform.Core.Security
         /// Allows customers to access the API endpoints and perform authorized actions. By default, false.
         /// </summary>
         public bool AllowApiAccessForCustomers { get; set; }
+
+        /// <summary>
+        /// Legacy storefront scenario only. When true, the PUT users endpoint accepts
+        /// caller-provided values for the protected user fields (PasswordExpired,
+        /// LockoutEnabled, LockoutEnd, LastLoginDate, LastPasswordChangedDate,
+        /// LastPasswordChangeRequestDate) instead of restoring them from the database.
+        /// Provided for backward compatibility with integrations (e.g. vc-storefront)
+        /// that manage their own ASP.NET Core Identity lockout and push state back via
+        /// this endpoint. By default, false.
+        /// </summary>
+        public bool AllowOverrideProtectedUserFields { get; set; }
     }
 }

--- a/src/VirtoCommerce.Platform.Web/Controllers/Api/SecurityController.cs
+++ b/src/VirtoCommerce.Platform.Web/Controllers/Api/SecurityController.cs
@@ -827,13 +827,21 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
                 user.SecurityStamp = applicationUser.SecurityStamp;
             }
 
-            user.PasswordExpired = applicationUser.PasswordExpired;
-            user.LockoutEnabled = applicationUser.LockoutEnabled;
+            // Legacy storefront scenario: when AllowOverrideProtectedUserFields is enabled,
+            // integrations (e.g. vc-storefront) that manage their own ASP.NET Core Identity
+            // lockout may push updated lockout/audit state via PUT /users. By default the
+            // protected fields are restored from the database so the API cannot tamper with
+            // them as a side effect of profile updates.
+            if (!_securityOptions.AllowOverrideProtectedUserFields)
+            {
+                user.PasswordExpired = applicationUser.PasswordExpired;
+                user.LockoutEnabled = applicationUser.LockoutEnabled;
 
-            user.LockoutEnd = applicationUser.LockoutEnd;
-            user.LastLoginDate = applicationUser.LastLoginDate;
-            user.LastPasswordChangedDate = applicationUser.LastPasswordChangedDate;
-            user.LastPasswordChangeRequestDate = applicationUser.LastPasswordChangeRequestDate;
+                user.LockoutEnd = applicationUser.LockoutEnd;
+                user.LastLoginDate = applicationUser.LastLoginDate;
+                user.LastPasswordChangedDate = applicationUser.LastPasswordChangedDate;
+                user.LastPasswordChangeRequestDate = applicationUser.LastPasswordChangeRequestDate;
+            }
 
             var result = await UserManager.UpdateAsync(user);
 


### PR DESCRIPTION
## Description
feat:  Adds a new AuthorizationOptions.AllowUpdateProtectedUserFields flag (default false) to support legacy storefront integrations that manage ASP.NET Core Identity lockout state externally.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4934
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches user update logic in a security-sensitive area; when the new flag is enabled it allows clients to modify lockout/audit fields, which could be abused if misconfigured.
> 
> **Overview**
> Adds a new `AuthorizationOptions.AllowUpdateProtectedUserFields` flag (default `false`) to support legacy storefront integrations that manage ASP.NET Core Identity lockout state externally.
> 
> Updates `SecurityController.Update` (PUT `api/platform/security/users`) to **stop restoring** lockout/audit-related fields (`PasswordExpired`, `LockoutEnabled`, `LockoutEnd`, `LastLoginDate`, `LastPasswordChangedDate`, `LastPasswordChangeRequestDate`) from the database when the flag is enabled, allowing caller-provided values to be persisted instead.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8527c42dbeef2c0cbccc66b2bb09694be047c91a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Image tag:
ghcr.io/VirtoCommerce/platform:3.1020.0-pr-3008-8527-vcst-4934-8527c42d