### PR TITLE
VCST-4899: Hide forgot your password link on login via config

### DIFF
--- a/src/VirtoCommerce.Platform.Core/LoginPageUIOptions.cs
+++ b/src/VirtoCommerce.Platform.Core/LoginPageUIOptions.cs
@@ -10,6 +10,8 @@ namespace VirtoCommerce.Platform.Core
 
         public string Preset { get; set; }
 
+        public bool ShowForgotPasswordLink { get; set; } = true;
+
         public List<LoginPageUIOptionPreset> Presets { get; set; } = new List<LoginPageUIOptionPreset>();
 
         public class LoginPageUIOptionPreset

--- a/src/VirtoCommerce.Platform.Web/Controllers/Api/CommonController.cs
+++ b/src/VirtoCommerce.Platform.Web/Controllers/Api/CommonController.cs
@@ -62,7 +62,12 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
                 patternUrl = preset?.PatternUrl;
             }
 
-            return Ok(new { BackgroundUrl = backgroundUrl, PatternUrl = patternUrl });
+            return Ok(new
+            {
+                BackgroundUrl = backgroundUrl,
+                PatternUrl = patternUrl,
+                ShowForgotPasswordLink = _loginPageOptions.ShowForgotPasswordLink,
+            });
         }
     }
 }

--- a/src/VirtoCommerce.Platform.Web/appsettings.json
+++ b/src/VirtoCommerce.Platform.Web/appsettings.json
@@ -328,6 +328,7 @@
     "BackgroundUrl": "",
     "PatternUrl": "",
     "Preset": "",
+    "ShowForgotPasswordLink": true,
     "Presets": [
       {
         "Name": "demo",

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/app.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/app.js
@@ -189,6 +189,9 @@ angular.module('platformWebApp', AppDependencies).controller('platformWebApp.app
                         url: loginPageUIOptions.patternUrl
                     };
                 }
+                // Default to true when the flag is missing (older backends).
+                $rootScope.uiCustomization.showForgotPasswordLink =
+                    loginPageUIOptions.showForgotPasswordLink !== false;
             })
         });
 

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/security/login/login.tpl.html
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/security/login/login.tpl.html
@@ -29,7 +29,7 @@
                             <input type="checkbox" class="vc-checkbox__input" name="c1" checked="" ng-model="user.remember">
                             <span class="vc-checkbox__label">{{ 'platform.blades.login.labels.remember-me' | translate }}</span>
                         </label>
-                        <a class="vc-link" ui-sref="forgotpasswordDialog">{{ 'platform.blades.login.labels.forgot-password' | translate }}</a>
+                        <a class="vc-link" ng-if="uiCustomization.showForgotPasswordLink" ui-sref="forgotpasswordDialog">{{ 'platform.blades.login.labels.forgot-password' | translate }}</a>
                     </div>
                 </div>
                 <div class="login-form__alerts" ng-if="authError">


### PR DESCRIPTION
## Description
feat: Hide forgot your password link on login via config

<img width="871" height="682" alt="image" src="https://github.com/user-attachments/assets/a94db6b8-e7fd-4e0c-a672-87509677c2c4" />


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4899
### Artifact URL:


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small, additive configuration and UI conditional rendering change with a safe default (`true`) and backward-compatible frontend behavior.
> 
> **Overview**
> Adds a new `LoginPageUI.ShowForgotPasswordLink` configuration option (default `true`) and exposes it via `GET api/platform/common/ui/loginPageOptions`.
> 
> Updates the Angular UI customization bootstrap and `login.tpl.html` to conditionally render the “Forgot password” link based on this flag, with a backwards-compatible default to show the link when older backends don’t return the field.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 5028367245802c7e7139a62cd9d8672c94e65efe. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1022.0-pr-3009-5028-vcst-4899-50283672