### PR TITLE
feat: Enable UseSlidingInvisibilityTimeout by default for PostgreSQL storage

### DIFF
--- a/src/VirtoCommerce.Platform.Web/appsettings.json
+++ b/src/VirtoCommerce.Platform.Web/appsettings.json
@@ -92,6 +92,7 @@
       "PostgreSqlStorageOptions": {
         "InvisibilityTimeout": "00:05:00",
         "QueuePollInterval": "00:00:05",
+        "UseSlidingInvisibilityTimeout": true,
         "UseRecommendedIsolationLevel": true,
         "UsePageLocksOnDequeue": true,
         "DisableGlobalLocks": true


### PR DESCRIPTION
## Summary
- Aligns the default `PostgreSqlStorageOptions` with `SqlServerStorageOptions.SlidingInvisibilityTimeout`, so long-running jobs are not incorrectly re-enqueued on PostgreSQL.
- With sliding mode the `FetchedAt` timestamp is refreshed by a background heartbeat every `InvisibilityTimeout / 5`; the 5-minute `InvisibilityTimeout` becomes a dead-worker detection threshold rather than a hard job duration limit.

## Why
Without sliding mode, any job running longer than `InvisibilityTimeout` (5 min by default) is considered abandoned and picked up by another worker, resulting in duplicate execution while the original worker is still processing the job. Long-running jobs (e.g. large catalog imports that can run for hours or days) are impacted.

`Hangfire.PostgreSql 1.20.13` supports `UseSlidingInvisibilityTimeout` (default `false`) with identical semantics to SQL Server: heartbeat runs every `InvisibilityTimeout / 5` and stops on `Dispose` / `RemoveFromQueue` / `Requeue`. `InvisibilityTimeout` remains 5 min — now it is the dead-worker detection threshold.

## Test plan
- [ ] Start a long-running background job (> 5 min) and verify no duplicate execution occurs.
- [ ] Kill a Hangfire worker mid-job and verify the job is picked up by another worker within ~5 minutes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Single configuration default change affecting only Hangfire PostgreSQL dequeue/visibility behavior; main risk is a behavioral change in job retry/abandonment timing for existing PostgreSQL deployments.
> 
> **Overview**
> Enables Hangfire PostgreSQL sliding invisibility by default by adding `UseSlidingInvisibilityTimeout: true` under `VirtoCommerce:Hangfire:PostgreSqlStorageOptions` in `appsettings.json`, reducing duplicate execution of long-running jobs when they exceed the `InvisibilityTimeout`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 39880ba1f38c0459b8b3447ee575448db35db2d9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1022.0-pr-3010-3988-hangfire-pg-invisibility-39880ba1