### PR TITLE
VCST-4863: Update workflows version

### DIFF
--- a/.github/workflows/platform-release-hotfix.yml
+++ b/.github/workflows/platform-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.26
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.29
+# https://virtocommerce.atlassian.net/browse/VCST-4770
 name: Release hotfix
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.26    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.29    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.26    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.29    
     with:
       uploadPackage: 'true'
       uploadDocker: 'true'
@@ -47,7 +47,7 @@ jobs:
   publish-docker:
     needs:
       [build, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.26    
+    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.29    
     with:
       fullKey: ${{ needs.build.outputs.dockerFullKey }}
       shortKey: '${{ needs.build.outputs.dockerShortKey }}-'
@@ -61,7 +61,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.26    
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.29    
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.26
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.29
+# https://virtocommerce.atlassian.net/browse/VCST-4770
 name: Publish nuget
 
 on:
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.26    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.29    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.26    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.29    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.26
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.29
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# v3.800.26
-# https://virtocommerce.atlassian.net/browse/VCST-4746
+# v3.800.29
+# https://virtocommerce.atlassian.net/browse/VCST-4770
 name: Release
 
 on:
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.26    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.29    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
## Description
Update workflows version to fix Node deprecation and use default Net10 for Docker images
## References
### QA-test:
### Jira-link: 
https://virtocommerce.atlassian.net/browse/VCST-4863
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Only changes pinned versions of reusable CI workflows; behavior changes are limited to whatever upstream `v3.800.29` introduces.
> 
> **Overview**
> Updates the `platform-release-hotfix`, `publish-nugets`, and `release` GitHub Actions workflows to use VirtoCommerce reusable workflows `v3.800.29` instead of `v3.800.26`, including updated header references/Jira link comments.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a67a26957de52e3ca00d5c646a6c2d0b4006a318. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Image tag:
ghcr.io/VirtoCommerce/platform:3.1022.0-pr-3011-a67a-vcst-4863-a67a2695