### PR TITLE
VCST-4991: Bump ASP.NET packages to 10.0.7

### DIFF
--- a/src/VirtoCommerce.Platform.Caching/VirtoCommerce.Platform.Caching.csproj
+++ b/src/VirtoCommerce.Platform.Caching/VirtoCommerce.Platform.Caching.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
     <PackageReference Include="Polly" Version="8.6.6" />
     <PackageReference Include="StackExchange.Redis" Version="2.12.14" />
   </ItemGroup>

--- a/src/VirtoCommerce.Platform.Data.MySql/Readme.md
+++ b/src/VirtoCommerce.Platform.Data.MySql/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.5
+dotnet tool install --global dotnet-ef --version 10.0.7
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.5
+dotnet tool update --global dotnet-ef --version 10.0.7
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.Platform.Data.MySql/VirtoCommerce.Platform.Data.MySql.csproj
+++ b/src/VirtoCommerce.Platform.Data.MySql/VirtoCommerce.Platform.Data.MySql.csproj
@@ -8,13 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.6" />
-    <PackageReference Include="Microting.EntityFrameworkCore.MySql" Version="10.0.5" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+    <PackageReference Include="Microting.EntityFrameworkCore.MySql" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.Platform.Data.MySql/VirtoCommerce.Platform.Data.MySql.csproj
+++ b/src/VirtoCommerce.Platform.Data.MySql/VirtoCommerce.Platform.Data.MySql.csproj
@@ -1,4 +1,4 @@
-<Project Sdk="Microsoft.NET.Sdk">
+﻿<Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
     <TargetFramework>net10.0</TargetFramework>
@@ -14,7 +14,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
     <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-    <PackageReference Include="Microting.EntityFrameworkCore.MySql" Version="10.0.7" />
+    <PackageReference Include="Microting.EntityFrameworkCore.MySql" Version="10.0.5" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.Platform.Data.PostgreSql/Readme.md
+++ b/src/VirtoCommerce.Platform.Data.PostgreSql/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.5
+dotnet tool install --global dotnet-ef --version 10.0.7
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.5
+dotnet tool update --global dotnet-ef --version 10.0.7
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.Platform.Data.PostgreSql/VirtoCommerce.Platform.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.Platform.Data.PostgreSql/VirtoCommerce.Platform.Data.PostgreSql.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/VirtoCommerce.Platform.Data.SqlServer/Readme.md
+++ b/src/VirtoCommerce.Platform.Data.SqlServer/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.5
+dotnet tool install --global dotnet-ef --version 10.0.7
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.5
+dotnet tool update --global dotnet-ef --version 10.0.7
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.Platform.Data.SqlServer/VirtoCommerce.Platform.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.Platform.Data.SqlServer/VirtoCommerce.Platform.Data.SqlServer.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.6">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.Platform.Data/VirtoCommerce.Platform.Data.csproj
+++ b/src/VirtoCommerce.Platform.Data/VirtoCommerce.Platform.Data.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="EntityFrameworkCore.Triggers" Version="1.2.3" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="Humanizer.Core" Version="3.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.6" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.6" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
     <PackageReference Include="Nager.Country" Version="4.4.0" />
     <PackageReference Include="Serialize.Linq" Version="4.0.167" />
   </ItemGroup>

--- a/src/VirtoCommerce.Platform.Hangfire/VirtoCommerce.Platform.Hangfire.csproj
+++ b/src/VirtoCommerce.Platform.Hangfire/VirtoCommerce.Platform.Hangfire.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Hangfire.MySqlStorage" Version="2.0.3" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.21.1" />
     <PackageReference Include="HangFire.SqlServer" Version="1.8.23" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.Platform.Modules/VirtoCommerce.Platform.Modules.csproj
+++ b/src/VirtoCommerce.Platform.Modules/VirtoCommerce.Platform.Modules.csproj
@@ -22,9 +22,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.Platform.Security/VirtoCommerce.Platform.Security.csproj
+++ b/src/VirtoCommerce.Platform.Security/VirtoCommerce.Platform.Security.csproj
@@ -18,10 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="10.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.6" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.7" />
     <PackageReference Include="Microsoft.IdentityModel.Validators" Version="8.17.0" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.2.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
+++ b/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
@@ -18,21 +18,21 @@
 
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.53.0" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client.Core" Version="10.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.6" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.6" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client.Core" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.7" />
     <PackageReference Include="Microsoft.Azure.SignalR" Version="1.33.0" />
-    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="10.0.7" />
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.32" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="10.0.7" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.83.3" />
     <PackageReference Include="Microsoft.OpenApi" Version="2.3.0" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="10.0.6" />
+    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="10.0.7" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="1.3.1" />
     <PackageReference Include="OpenIddict.AspNetCore" Version="7.2.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
@@ -44,13 +44,13 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.1.0" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.0" />
-    <PackageReference Include="System.CodeDom" Version="10.0.6" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.6" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.6" />
-    <PackageReference Include="System.Management" Version="10.0.6" />
-    <PackageReference Include="System.Runtime.Caching" Version="10.0.6" />
-    <PackageReference Include="System.Security.Permissions" Version="10.0.6" />
-    <PackageReference Include="System.Windows.Extensions" Version="10.0.6" />
+    <PackageReference Include="System.CodeDom" Version="10.0.7" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.7" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.7" />
+    <PackageReference Include="System.Management" Version="10.0.7" />
+    <PackageReference Include="System.Runtime.Caching" Version="10.0.7" />
+    <PackageReference Include="System.Security.Permissions" Version="10.0.7" />
+    <PackageReference Include="System.Windows.Extensions" Version="10.0.7" />
     <PackageReference Include="VirtoCommerce.BuildWebpack" Version="1.0.0" />
   </ItemGroup>
 

--- a/tests/VirtoCommerce.Platform.Caching.Tests/VirtoCommerce.Platform.Caching.Tests.csproj
+++ b/tests/VirtoCommerce.Platform.Caching.Tests/VirtoCommerce.Platform.Caching.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/VirtoCommerce.Platform.Core.Tests/VirtoCommerce.Platform.Core.Tests.csproj
+++ b/tests/VirtoCommerce.Platform.Core.Tests/VirtoCommerce.Platform.Core.Tests.csproj
@@ -6,7 +6,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/VirtoCommerce.Platform.Tests/VirtoCommerce.Platform.Tests.csproj
+++ b/tests/VirtoCommerce.Platform.Tests/VirtoCommerce.Platform.Tests.csproj
@@ -10,7 +10,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/VirtoCommerce.Platform.Web.Tests/VirtoCommerce.Platform.Web.Tests.csproj
+++ b/tests/VirtoCommerce.Platform.Web.Tests/VirtoCommerce.Platform.Web.Tests.csproj
@@ -9,7 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>

--- a/tests/VirtoCommerce.Testing/VirtoCommerce.Testing.csproj
+++ b/tests/VirtoCommerce.Testing/VirtoCommerce.Testing.csproj
@@ -12,7 +12,7 @@
 
   <ItemGroup>
     <PackageReference Include="AutoFixture" Version="4.18.1" />
-    <PackageReference Include="coverlet.collector" Version="8.0.1">
+    <PackageReference Include="coverlet.collector" Version="10.0.0">
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>


### PR DESCRIPTION
## Description
fix: Bump ASP.NET packages to 10.0.7

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4991
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Primarily dependency bumps, but they touch web hosting, authentication, and EF Core runtime packages where patch changes can introduce subtle behavior/regression differences across builds and environments.
> 
> **Overview**
> Updates platform projects to consume Microsoft `10.0.7` packages, including ASP.NET Core auth/SignalR/data-protection dependencies in `VirtoCommerce.Platform.Web`, security/auth dependencies in `VirtoCommerce.Platform.Security`, caching memory provider, and EF Core packages across `VirtoCommerce.Platform.Data` and provider-specific projects.
> 
> Also refreshes migration docs to use `dotnet-ef` `10.0.7` and upgrades test coverage tooling by bumping `coverlet.collector` from `8.0.1` to `10.0.0` in all test projects.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 4fd223910e9942d1b36ff2564048a82051c8fc2a. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1023.0-pr-3014-4fd2-vcst-4991-4fd22391