### PR TITLE
VCST-4958: Use refactored autotests

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -310,6 +310,7 @@ jobs:
       run: |
         echo "Jira Upload Build Info response: ${{ steps.push_build_info_to_jira.outputs.response }}"
   auto-tests:
+    needs: ci
     # if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
     #     (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
     uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-4958

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -1,4 +1,5 @@
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Platform CI
 
 on:
@@ -311,92 +312,58 @@ jobs:
         echo "Jira Upload Build Info response: ${{ steps.push_build_info_to_jira.outputs.response }}"
   auto-tests:
     needs: ci
-    # if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
-    #     (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-4958
+    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
+        (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.30
     with:
       installModules: 'true'
       installCustomModule: 'false'
       platformDockerTag: ${{ needs.ci.outputs.tag }}
-      vctestingRepoBranch: 'test-VCST-4958' #'dev'
+      vctestingRepoBranch: 'dev'
       frontendZipUrl: 'latest'
       testSuites: 'graphql,restapi,e2e'
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}
-      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE_NEW }} #${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
+      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
 
-  # ui-auto-tests:
-  #   needs: 'ci'
-  #   if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
-  #       (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-  #   uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.29
-  #   with:
-  #     installModules: 'true'
-  #     installCustomModule: 'false'
-  #     platformDockerTag: ${{ needs.ci.outputs.tag }}
-  #     vctestingRepoBranch: 'dev'
-  #     frontendZipUrl: 'latest'
-  #   secrets:
-  #     envPAT: ${{ secrets.REPO_TOKEN }}
-  #     testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
-  #     sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
+  deploy-cloud:
+    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
+    needs: ci
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.30    
+    with:
+      releaseSource: platform
+      platformVer: ${{ needs.ci.outputs.version }}
+      platformTag: ${{ needs.ci.outputs.tag }}
+      jiraKeys: ${{ needs.ci.outputs.jira-keys }}
+      matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
+    secrets: inherit
 
-  # platform-katalon-tests:
-  #   needs: 'ci'
-  #   if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
-  #       (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-  #   uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.29
-  #   with:
-  #     katalonRepo: 'VirtoCommerce/vc-quality-gate-katalon'
-  #     katalonRepoBranch: 'dev'
-  #     testSuite: 'Test Suites/Modules/Platform_collection'
-  #     installModules: 'true'
-  #     installCustomModule: 'false'
-  #     platformDockerTag: ${{ needs.ci.outputs.tag }}
-  #     storefrontDockerTag: 'dev-linux-latest'
-  #   secrets:
-  #     envPAT: ${{ secrets.REPO_TOKEN }}
-  #     katalonApiKey: ${{ secrets.KATALON_API_KEY }}
+  owasp-scan:
+    if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
+    runs-on: ubuntu-latest
+    needs: 
+      - deploy-cloud
+    steps:
+      - name: OWASP ZAP Full Scan
+        uses: zaproxy/action-baseline@v0.14.0
+        with:
+          token: ${{ secrets.REPO_TOKEN }}
+          target: 'https://vcptcore-dev.govirto.com'
+          cmd_options: '-a -d'
 
-  # deploy-cloud:
-  #   if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
-  #   needs: ci
-  #   uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.29    
-  #   with:
-  #     releaseSource: platform
-  #     platformVer: ${{ needs.ci.outputs.version }}
-  #     platformTag: ${{ needs.ci.outputs.tag }}
-  #     jiraKeys: ${{ needs.ci.outputs.jira-keys }}
-  #     matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
-  #   secrets: inherit
-
-  # owasp-scan:
-  #   if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
-  #   runs-on: ubuntu-latest
-  #   needs: 
-  #     - deploy-cloud
-  #   steps:
-  #     - name: OWASP ZAP Full Scan
-  #       uses: zaproxy/action-baseline@v0.14.0
-  #       with:
-  #         token: ${{ secrets.REPO_TOKEN }}
-  #         target: 'https://vcptcore-dev.govirto.com'
-  #         cmd_options: '-a -d'
-  #         # allow_issue_writing: false
-
-  # trivy-scan:
-  #   if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
-  #   needs: 'ci'
-  #   uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.29
-  #   with:
-  #     assigneeAccountId: '621c47c0302c6b006af0a1cd'
-  #     assigneeEmailAddress: 'andrew.kubyshkin@virtoworks.com'
-  #     exitCodeOnFoundVulnerabilities: '0'
-  #     imageRef: "ghcr.io/virtocommerce/platform"
-  #     imageTag: ${{ needs.ci.outputs.tag }}
-  #     jiraProject: 'VCST'
-  #     vulnerabilitySkipList: ${{ needs.ci.outputs.vulnSkipList }}
-  #   secrets:
-  #     JIRA_USER: ${{ secrets.JIRA_USER }}
-  #     JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+  trivy-scan:
+    if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
+    needs: 'ci'
+    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.30
+    with:
+      assigneeAccountId: '621c47c0302c6b006af0a1cd'
+      assigneeEmailAddress: 'andrew.kubyshkin@virtoworks.com'
+      exitCodeOnFoundVulnerabilities: '0'
+      imageRef: "ghcr.io/virtocommerce/platform"
+      imageTag: ${{ needs.ci.outputs.tag }}
+      jiraProject: 'VCST'
+      vulnerabilitySkipList: ${{ needs.ci.outputs.vulnSkipList }}
+    secrets:
+      JIRA_USER: ${{ secrets.JIRA_USER }}
+      JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -320,7 +320,7 @@ jobs:
       platformDockerTag: ${{ needs.ci.outputs.tag }}
       vctestingRepoBranch: 'test-VCST-4958' #'dev'
       frontendZipUrl: 'latest'
-      testSuites: 'graphql, restapi'
+      testSuites: 'graphql,restapi,e2e'
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}
       testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE_NEW }} #${{ secrets.VC_TESTING_MODULE_ENV_FILE }}

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -309,78 +309,93 @@ jobs:
       if: success()
       run: |
         echo "Jira Upload Build Info response: ${{ steps.push_build_info_to_jira.outputs.response }}"
-
-  ui-auto-tests:
-    needs: 'ci'
-    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
-        (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.29
+  auto-tests:
+    # if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
+    #     (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-4958
     with:
       installModules: 'true'
       installCustomModule: 'false'
       platformDockerTag: ${{ needs.ci.outputs.tag }}
-      vctestingRepoBranch: 'dev'
+      vctestingRepoBranch: 'test-VCST-4958' #'dev'
       frontendZipUrl: 'latest'
+      testSuites: 'graphql, restapi'
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}
-      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
+      testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE_NEW }} #${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
 
-  platform-katalon-tests:
-    needs: 'ci'
-    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
-        (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.29
-    with:
-      katalonRepo: 'VirtoCommerce/vc-quality-gate-katalon'
-      katalonRepoBranch: 'dev'
-      testSuite: 'Test Suites/Modules/Platform_collection'
-      installModules: 'true'
-      installCustomModule: 'false'
-      platformDockerTag: ${{ needs.ci.outputs.tag }}
-      storefrontDockerTag: 'dev-linux-latest'
-    secrets:
-      envPAT: ${{ secrets.REPO_TOKEN }}
-      katalonApiKey: ${{ secrets.KATALON_API_KEY }}
+  # ui-auto-tests:
+  #   needs: 'ci'
+  #   if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
+  #       (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
+  #   uses: VirtoCommerce/.github/.github/workflows/ui-autotests.yml@v3.800.29
+  #   with:
+  #     installModules: 'true'
+  #     installCustomModule: 'false'
+  #     platformDockerTag: ${{ needs.ci.outputs.tag }}
+  #     vctestingRepoBranch: 'dev'
+  #     frontendZipUrl: 'latest'
+  #   secrets:
+  #     envPAT: ${{ secrets.REPO_TOKEN }}
+  #     testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
+  #     sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
 
-  deploy-cloud:
-    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
-    needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.29    
-    with:
-      releaseSource: platform
-      platformVer: ${{ needs.ci.outputs.version }}
-      platformTag: ${{ needs.ci.outputs.tag }}
-      jiraKeys: ${{ needs.ci.outputs.jira-keys }}
-      matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
-    secrets: inherit
+  # platform-katalon-tests:
+  #   needs: 'ci'
+  #   if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
+  #       (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
+  #   uses: VirtoCommerce/.github/.github/workflows/e2e.yml@v3.800.29
+  #   with:
+  #     katalonRepo: 'VirtoCommerce/vc-quality-gate-katalon'
+  #     katalonRepoBranch: 'dev'
+  #     testSuite: 'Test Suites/Modules/Platform_collection'
+  #     installModules: 'true'
+  #     installCustomModule: 'false'
+  #     platformDockerTag: ${{ needs.ci.outputs.tag }}
+  #     storefrontDockerTag: 'dev-linux-latest'
+  #   secrets:
+  #     envPAT: ${{ secrets.REPO_TOKEN }}
+  #     katalonApiKey: ${{ secrets.KATALON_API_KEY }}
 
-  owasp-scan:
-    if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
-    runs-on: ubuntu-latest
-    needs: 
-      - deploy-cloud
-    steps:
-      - name: OWASP ZAP Full Scan
-        uses: zaproxy/action-baseline@v0.14.0
-        with:
-          token: ${{ secrets.REPO_TOKEN }}
-          target: 'https://vcptcore-dev.govirto.com'
-          cmd_options: '-a -d'
-          # allow_issue_writing: false
+  # deploy-cloud:
+  #   if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
+  #   needs: ci
+  #   uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.29    
+  #   with:
+  #     releaseSource: platform
+  #     platformVer: ${{ needs.ci.outputs.version }}
+  #     platformTag: ${{ needs.ci.outputs.tag }}
+  #     jiraKeys: ${{ needs.ci.outputs.jira-keys }}
+  #     matrix: '{"include":${{ needs.ci.outputs.matrix }}}'
+  #   secrets: inherit
 
-  trivy-scan:
-    if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
-    needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.29
-    with:
-      assigneeAccountId: '621c47c0302c6b006af0a1cd'
-      assigneeEmailAddress: 'andrew.kubyshkin@virtoworks.com'
-      exitCodeOnFoundVulnerabilities: '0'
-      imageRef: "ghcr.io/virtocommerce/platform"
-      imageTag: ${{ needs.ci.outputs.tag }}
-      jiraProject: 'VCST'
-      vulnerabilitySkipList: ${{ needs.ci.outputs.vulnSkipList }}
-    secrets:
-      JIRA_USER: ${{ secrets.JIRA_USER }}
-      JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}
+  # owasp-scan:
+  #   if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
+  #   runs-on: ubuntu-latest
+  #   needs: 
+  #     - deploy-cloud
+  #   steps:
+  #     - name: OWASP ZAP Full Scan
+  #       uses: zaproxy/action-baseline@v0.14.0
+  #       with:
+  #         token: ${{ secrets.REPO_TOKEN }}
+  #         target: 'https://vcptcore-dev.govirto.com'
+  #         cmd_options: '-a -d'
+  #         # allow_issue_writing: false
+
+  # trivy-scan:
+  #   if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
+  #   needs: 'ci'
+  #   uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.29
+  #   with:
+  #     assigneeAccountId: '621c47c0302c6b006af0a1cd'
+  #     assigneeEmailAddress: 'andrew.kubyshkin@virtoworks.com'
+  #     exitCodeOnFoundVulnerabilities: '0'
+  #     imageRef: "ghcr.io/virtocommerce/platform"
+  #     imageTag: ${{ needs.ci.outputs.tag }}
+  #     jiraProject: 'VCST'
+  #     vulnerabilitySkipList: ${{ needs.ci.outputs.vulnSkipList }}
+  #   secrets:
+  #     JIRA_USER: ${{ secrets.JIRA_USER }}
+  #     JIRA_TOKEN: ${{ secrets.JIRA_TOKEN }}

--- a/.github/workflows/platform-release-hotfix.yml
+++ b/.github/workflows/platform-release-hotfix.yml
@@ -1,5 +1,4 @@
 # v3.800.30
-# v3.800.30
 # https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Release hotfix
 

--- a/.github/workflows/platform-release-hotfix.yml
+++ b/.github/workflows/platform-release-hotfix.yml
@@ -1,5 +1,6 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Release hotfix
 
 on:
@@ -13,12 +14,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.29    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.30    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.29    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.30    
     with:
       uploadPackage: 'true'
       uploadDocker: 'true'
@@ -47,7 +48,7 @@ jobs:
   publish-docker:
     needs:
       [build, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.29    
+    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.30    
     with:
       fullKey: ${{ needs.build.outputs.dockerFullKey }}
       shortKey: '${{ needs.build.outputs.dockerShortKey }}-'
@@ -61,7 +62,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.29    
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.30    
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,4 +1,4 @@
-# v3.800.11 
+# v3.800.30 
 # https://virtocommerce.atlassian.net/browse/VCST-1109
 name: Platform PR build
 
@@ -17,12 +17,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.11 
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.30 
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.11 
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.30 
     with:
       uploadDocker: 'true'
     secrets:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,5 +1,5 @@
 # v3.800.30 
-# https://virtocommerce.atlassian.net/browse/VCST-1109
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Platform PR build
 
 on:

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -1,5 +1,4 @@
 # v3.800.30
-# v3.800.30
 # https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Publish nuget
 

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -1,5 +1,6 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Publish nuget
 
 on:
@@ -13,12 +14,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.29    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.30    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.29    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.30    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +30,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.29
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.30
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,4 @@
 # v3.800.30
-# v3.800.30
 # https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Release
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,6 @@
-# v3.800.29
-# https://virtocommerce.atlassian.net/browse/VCST-4770
+# v3.800.30
+# v3.800.30
+# https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Release
 
 on:
@@ -7,6 +8,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.29    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.30    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
## Description
Use new workflow running graphql, restapi and e2e autotests. 
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4958
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI behavior changes by replacing existing UI/Katalon E2E jobs with a new `pytest-tests` workflow and adjusting which suites run, which can affect test coverage and pipeline stability.
> 
> **Overview**
> Updates GitHub Actions workflows to **v3.800.30** reusable workflows across CI/release/hotfix/nuget pipelines.
> 
> In `platform-ci.yml`, replaces the previous UI/Katalon E2E jobs with a single `auto-tests` job that runs the refactored `pytest-tests` workflow and executes `graphql`, `restapi`, and `e2e` suites. Deployment and vulnerability-scan jobs are also bumped to the new workflow version.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f9829b39a332e4b82cf93f6ba6b62aef5b7c3f87. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Image tag:
ghcr.io/VirtoCommerce/platform:3.1026.0-pr-3015-f982-test-vcst-4958-f9829b39