### PR TITLE
VCST-5041: Update workflow versions

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -1,4 +1,4 @@
-# v3.800.30
+# v3.800.31
 # https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Platform CI
 
@@ -314,7 +314,7 @@ jobs:
     needs: ci
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.31
     with:
       installModules: 'true'
       installCustomModule: 'false'
@@ -330,7 +330,7 @@ jobs:
   deploy-cloud:
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.30    
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.31    
     with:
       releaseSource: platform
       platformVer: ${{ needs.ci.outputs.version }}
@@ -355,7 +355,7 @@ jobs:
   trivy-scan:
     if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.31
     with:
       assigneeAccountId: '621c47c0302c6b006af0a1cd'
       assigneeEmailAddress: 'andrew.kubyshkin@virtoworks.com'

--- a/.github/workflows/platform-release-hotfix.yml
+++ b/.github/workflows/platform-release-hotfix.yml
@@ -1,4 +1,4 @@
-# v3.800.30
+# v3.800.31
 # https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Release hotfix
 
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.30    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.31    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.30    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.31    
     with:
       uploadPackage: 'true'
       uploadDocker: 'true'
@@ -47,7 +47,7 @@ jobs:
   publish-docker:
     needs:
       [build, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.30    
+    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.31    
     with:
       fullKey: ${{ needs.build.outputs.dockerFullKey }}
       shortKey: '${{ needs.build.outputs.dockerShortKey }}-'
@@ -61,7 +61,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.30    
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.31    
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.30 
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.31 
+# https://virtocommerce.atlassian.net/browse/VCST-5041
 name: Platform PR build
 
 on:
@@ -17,12 +17,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.30 
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.31 
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.30 
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.31 
     with:
       uploadDocker: 'true'
     secrets:

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -1,4 +1,4 @@
-# v3.800.30
+# v3.800.31
 # https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Publish nuget
 
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.30    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.31    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.30    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.31    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.30
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.31
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,4 +1,4 @@
-# v3.800.30
+# v3.800.31
 # https://virtocommerce.atlassian.net/browse/VCST-4958
 name: Release
 
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.30    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.31    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link: https://virtocommerce.atlassian.net/browse/VCST-5041
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk version bump of reusable GitHub workflow references; main impact is CI/release behavior changing only insofar as `VirtoCommerce/.github` v3.800.31 differs from v3.800.30.
> 
> **Overview**
> Updates GitHub Actions workflows to use `VirtoCommerce/.github` reusable workflows at **v3.800.31** (from **v3.800.30**) across CI, PR builds, releases, hotfix releases, NuGet publishing, and security scanning.
> 
> Also refreshes workflow header comments, including the Jira reference in `pr-ci.yml` to `VCST-5041`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 917edf3aef62d557a0f74498657e9bb97e2bb720. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Image tag:
ghcr.io/VirtoCommerce/platform:3.1027.0-pr-3026-917e-vcst-5041-917edf3a