### PR TITLE
fix: don't cache null aggregates in GetOrLoadByIdsAsync

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Caching/MemoryCacheExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/MemoryCacheExtensions.cs
@@ -47,12 +47,15 @@ namespace VirtoCommerce.Platform.Core.Caching
                         {
                             var cacheKey = CacheKey.With(keyPrefix, id);
 
+                            // Do not cache "not found" — a transient empty read would otherwise poison
+                            // this instance's cache for the entry's TTL, manifesting as a per-id stuck
+                            // failure when no cross-instance invalidation backplane is in place.
                             result[id] = memoryCache.GetOrCreateExclusive(cacheKey, options =>
                             {
                                 var item = itemsByIds.GetValueSafe(id);
                                 configureCache(options, id, item);
                                 return item;
-                            });
+                            }, cacheNullValue: false);
                         }
                     }
                 }

--- a/tests/VirtoCommerce.Platform.Caching.Tests/MemoryCacheExtensionTests.cs
+++ b/tests/VirtoCommerce.Platform.Caching.Tests/MemoryCacheExtensionTests.cs
@@ -107,5 +107,65 @@ namespace VirtoCommerce.Platform.Caching.Tests
             });
             Assert.Equal(2, result);
         }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_DoesNotCacheMissingIds()
+        {
+            // arrange
+            var sut = GetPlatformMemoryCache();
+            var loadCallCount = 0;
+            var ids = new[] { "missing-id" };
+
+            Task<IList<TestEntity>> LoadItems(IList<string> missingIds)
+            {
+                loadCallCount++;
+                return Task.FromResult<IList<TestEntity>>(Array.Empty<TestEntity>());
+            }
+
+            // act — first call: miss, loadItems returns nothing, null must NOT be cached
+            var first = await sut.GetOrLoadByIdsAsync(nameof(GetOrLoadByIdsAsync_DoesNotCacheMissingIds), ids, LoadItems, ConfigureCache);
+
+            // act — second call with same id: must hit loadItems again, not a cached null
+            var second = await sut.GetOrLoadByIdsAsync(nameof(GetOrLoadByIdsAsync_DoesNotCacheMissingIds), ids, LoadItems, ConfigureCache);
+
+            // assert
+            Assert.Empty(first);
+            Assert.Empty(second);
+            Assert.Equal(2, loadCallCount);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_CachesPresentIds()
+        {
+            // arrange
+            var sut = GetPlatformMemoryCache();
+            var loadCallCount = 0;
+            var ids = new[] { "present-id" };
+
+            Task<IList<TestEntity>> LoadItems(IList<string> missingIds)
+            {
+                loadCallCount++;
+                return Task.FromResult<IList<TestEntity>>([new TestEntity { Id = "present-id" }]);
+            }
+
+            // act
+            var first = await sut.GetOrLoadByIdsAsync(nameof(GetOrLoadByIdsAsync_CachesPresentIds), ids, LoadItems, ConfigureCache);
+            var second = await sut.GetOrLoadByIdsAsync(nameof(GetOrLoadByIdsAsync_CachesPresentIds), ids, LoadItems, ConfigureCache);
+
+            // assert
+            Assert.Single(first);
+            Assert.Single(second);
+            Assert.Equal(1, loadCallCount);
+        }
+
+        private static void ConfigureCache(MemoryCacheEntryOptions options, string id, TestEntity item)
+        {
+            options.SlidingExpiration = TimeSpan.FromMinutes(1);
+        }
+
+        private sealed class TestEntity : IEntity
+        {
+            public string Id { get; set; }
+        }
     }
 }


### PR DESCRIPTION
## Description

`MemoryCacheExtensions.GetOrLoadByIdsAsync<T>` caches a null entry whenever `loadItems` returns no row for an id, because `GetOrCreateExclusive`'s `cacheNullValue` parameter defaults to `true`. On a multi-instance deployment without (or before) a working `RedisPlatformMemoryCache` backplane, a single transient empty DB read poisons that instance's local cache for up to the entry's TTL — every subsequent read for the same id returns the cached null until either every instance handles a write to it, the entry expires, or the backplane catches up. A cooperating defect in `vc-module-cart` then turns each cached null into a 500 on `availshippingrates` / `availpaymentmethods`. Full repro and analysis in #3027.

This change passes `cacheNullValue: false` at the call site so by-id lookups never cache "not found". By-id endpoints aren't at significant risk of high-volume probes for non-existent ids — the DB cost of a miss is bounded — and removing the cached null eliminates the stuck-failure pattern entirely, regardless of backplane health or write-path coverage.

The companion controller-layer fix is in VirtoCommerce/vc-module-cart#187.

### Tests

Added two tests in `MemoryCacheExtensionTests`:

- `GetOrLoadByIdsAsync_DoesNotCacheMissingIds` — would fail without this change; asserts `loadItems` is invoked again on a re-read of an id that resolved to nothing.
- `GetOrLoadByIdsAsync_CachesPresentIds` — regression guard for the present-id path; asserts a single `loadItems` invocation across reads.

## References
### QA-test:
### Jira-link: 
### Artifact URL:
