### PR TITLE
fix: Stop excluding Azure.Identity.dll from module bin/

### DIFF
--- a/module.ignore
+++ b/module.ignore
@@ -1,5 +1,4 @@
 Azure.Core.dll
-Azure.Identity.dll
 Dapper.dll
 EntityFrameworkCore.Triggers.dll
 FluentValidation.dll


### PR DESCRIPTION
## Summary

`module.ignore` still excludes `Azure.Identity.dll` from being packed into module zips, but the platform no longer ships this assembly. As a result, any module that depends on `Azure.Identity` (e.g. `VirtoCommerce.NotificationsModule.MicrosoftGraph`) throws `FileNotFoundException` at runtime.

This PR removes the single line `Azure.Identity.dll` from `module.ignore`. `Azure.Core.dll` stays — `Platform.Web` still references it explicitly.

## Root cause

`module.ignore` is a build-time contract: it lists DLLs that modules must **not** include in their `bin/` because the platform already provides them. The contract relies on the platform actually shipping those assemblies.

In #2989 (`VCST-4696: clean modularity`, commit 3d007cb), `Microsoft.Azure.AppConfiguration.AspNetCore` was removed from `Platform.Web.csproj` and moved into the dedicated `vc-module-azure-app-configuration` module. That package was the **transitive source** of `Azure.Identity.dll` in the platform bin (via `Azure.Data.AppConfiguration` → `Azure.Identity`).

The same commit cleaned up many AppConfiguration-related entries from `module.ignore` (`Azure.Data.AppConfiguration.dll`, `Microsoft.Azure.AppConfiguration.AspNetCore.dll`, `Azure.Messaging.EventGrid.dll`, etc.) but missed `Azure.Identity.dll` and left it asserting a guarantee the platform no longer satisfies.

## Evidence

Diff of relevant `Platform.Web.csproj` references across versions:

| Version | `Microsoft.Azure.AppConfiguration.AspNetCore` | `Azure.Identity` (transitive) |
| --- | --- | --- |
| `3.1011.0` | `8.4.0` | provided |
| `3.1012.0`–`3.1028.0` | removed | **missing** |

`module.ignore` on `dev` still contains `Azure.Identity.dll` at line 2.

Inspecting the published module zips that depend on `Azure.Identity`:

- `VirtoCommerce.Notifications` 3.1004.0 / 3.1005.0 / 3.1006.0-alpha.459 — `bin/` contains 91 DLLs incl. `Microsoft.Graph.dll`, `Microsoft.Kiota.Authentication.Azure.dll`, but **no** `Azure.Identity.dll`.
- `VirtoCommerce.AzureAppConfiguration` 3.1000.0 — `bin/` contains `Azure.Data.AppConfiguration.dll`, `Microsoft.Azure.AppConfiguration.AspNetCore.dll`, but **no** `Azure.Identity.dll`.

Stack trace observed in production on platform 3.1017.0 + Notifications 3.1005.0:

```
System.IO.FileNotFoundException: Could not load file or assembly
'Azure.Identity, Version=1.17.1.0, Culture=neutral, PublicKeyToken=92742159e12e44c8'.
   at VirtoCommerce.NotificationsModule.MicrosoftGraph
        .MicrosoftGraphEmailNotificationMessageSender.SendNotificationAsync(NotificationMessage message)
```

`VirtoCommerce.NotificationsModule.MicrosoftGraph` 3.1005.0 nuspec declares `Azure.Identity 1.17.1` as a dependency, but `module.ignore` prevented this assembly from ever being packed into the module zip.

## Why fix this in `module.ignore` and not in `Platform.Web`

Adding `<PackageReference Include="Azure.Identity" />` back to `Platform.Web.csproj` would undo the intent of `VCST-4696`, which moved Azure-specific dependencies out of the platform host into a dedicated module. The correct outcome is for modules that need `Azure.Identity` to pack it themselves — exactly what unblocking it in `module.ignore` enables.

## Consequences

- Affects **all modules** that depend on `Azure.Identity` under platform `>= 3.1012.0`, not just `NotificationsModule.MicrosoftGraph`.
- Already-published module zips (`VirtoCommerce.Notifications 3.1005.0`, `VirtoCommerce.AzureAppConfiguration 3.1000.0`, etc.) **will need to be rebuilt and republished** after this platform fix so that their `bin/` actually includes `Azure.Identity.dll`. Until then, those zips remain broken on platform 3.1012.0+.
- New module builds will pick this up automatically — no module-side csproj changes required because `Azure.Identity` is already declared as a NuGet dependency on the affected submodules.

## Test plan

- [ ] Build the platform — no change expected, since the file is consumed only at module-packaging time.
- [ ] Rebuild `vc-module-notification` against this platform — verify `Azure.Identity.dll` appears in the resulting `VirtoCommerce.Notifications_*.zip` under `bin/`.
- [ ] Deploy the rebuilt module on a stand running platform `>= 3.1017.0` and trigger an email via Microsoft Graph — `FileNotFoundException` should no longer occur.
- [ ] Same verification for `vc-module-azure-app-configuration` if it is exercised.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: a single-line change to the module packaging ignore list that only affects which dependencies are bundled into built module artifacts.
> 
> **Overview**
> Stops excluding `Azure.Identity.dll` from module packaging by removing it from `module.ignore`, allowing modules that depend on `Azure.Identity` to include the assembly in their `bin/` and avoid runtime `FileNotFoundException` when the platform no longer ships it.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0329a37ff56486d6f3b5d3a0d1d667b3f8bdbf43. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Image tag:
ghcr.io/VirtoCommerce/platform:3.1028.0-pr-3034-0329-remove-azure-identity-from-module-ignore-0329a37f