### PR TITLE
VCST-5113: Bump Azure.Core and Azure.Identity

### DIFF
--- a/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
+++ b/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
@@ -16,8 +16,13 @@
     <NoWarn>$(NoWarn);1701;1702;1705;1591</NoWarn>
   </PropertyGroup>
 
+  <!-- Added to bump to latest version sp other modules can consume them -->
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.53.0" />
+    <PackageReference Include="Azure.Core" Version="1.56.0" />
+    <PackageReference Include="Azure.Identity" Version="1.21.0" />
+  </ItemGroup>
+
+  <ItemGroup>
     <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.7" />
     <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.7" />


### PR DESCRIPTION
## Description
fix: Bump Azure.Core to 1.56 and Azure.Identity to 1.21

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5113
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Dependency-only change, but it updates `Azure.Core`/`Azure.Identity` which can affect token acquisition/credential behavior at runtime.
> 
> **Overview**
> Bumps Azure SDK dependencies in `VirtoCommerce.Platform.Web.csproj` by updating `Azure.Core` to `1.56.0` and adding/updating `Azure.Identity` to `1.21.0` so downstream modules can consume the newer versions.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a4032442af135b29bf8d09a654b5ba9bd28cab83. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Image tag:
ghcr.io/VirtoCommerce/platform:3.1028.0-pr-3035-a403-vcst-5113-a4032442