### PR TITLE
VCST-4843: Pin third-party actions to SHAs and automate updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,10 @@
+version: 2
+updates:
+  - package-ecosystem: github-actions
+    directory: /
+    schedule:
+      interval: weekly
+    groups:
+      actions:
+        patterns:
+          - "*"

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -1,0 +1,31 @@
+# Workflows
+
+GitHub Actions workflows for this repo. This document covers the supply-chain security setup; for what each workflow does, see the individual files.
+
+## Supply-chain security: pinned third-party actions
+
+Every third-party `uses:` reference in this repo (anything not under `VirtoCommerce/*`) is pinned to a full 40-character commit SHA with a trailing `# tag` comment, per the [GitHub Actions hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions). Tags are mutable; SHAs are not.
+
+```yaml
+# Correct
+uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+# Rejected by CI
+uses: actions/checkout@v6
+```
+
+### How updates happen
+
+- **Dependabot** ([`.github/dependabot.yml`](../dependabot.yml)) scans `.github/workflows/` weekly. When upstream cuts a new tag, it opens a grouped PR bumping the SHA + trailing comment.
+- **Pin-check CI** ([`pin-check.yml`](pin-check.yml)) runs `pinact run -check` on every PR that touches workflows. PRs with unpinned third-party `uses:` lines fail.
+- **Scope** is configured in [`.pinact.yaml`](../../.pinact.yaml) at the repo root — `VirtoCommerce/*` is intentionally ignored (internal, not third-party).
+
+### For contributors
+
+- When adding a new third-party action, write the SHA, not the tag. Quick lookup:
+
+  ```sh
+  gh api repos/OWNER/REPO/commits/TAG --jq '.sha'
+  ```
+
+- `VirtoCommerce/vc-github-actions/<dir>@master` and other `VirtoCommerce/*` refs remain version-/branch-pinned as before — only non-VirtoCommerce owners require SHA pinning.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -43,11 +43,11 @@ jobs:
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
     - name: Checkout repository
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
-      uses: github/codeql-action/init@v4
+      uses: github/codeql-action/init@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
       with:
         languages: ${{ matrix.language }}
         # If you wish to specify custom queries, you can do so here or in a config file.
@@ -66,7 +66,7 @@ jobs:
 
     - name: Autobuild javascript
       if: ${{ matrix.language == 'javascript' }}
-      uses: github/codeql-action/autobuild@v4
+      uses: github/codeql-action/autobuild@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4
 
 
     # ℹ️ Command-line programs to run using the OS shell.
@@ -80,4 +80,4 @@ jobs:
     #   ./location_of_script_within_repo/buildscript.sh
 
     - name: Perform CodeQL Analysis
-      uses: github/codeql-action/analyze@v4
+      uses: github/codeql-action/analyze@9e0d7b8d25671d64c341c19c0152d693099fb5ba # v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,7 +27,7 @@ jobs:
         envName: ${{ github.event.inputs.deployBranch }}
 
     - name: Start deployment
-      uses: bobheadxi/deployments@master
+      uses: bobheadxi/deployments@a3240c495b599dc16f99f6816a6f1ea8d10dc07b # master
       id: deployment
       with:
         step: start
@@ -69,7 +69,7 @@ jobs:
       run: echo "BUILD_STATE=failed"  >> $GITHUB_ENV
 
     - name: Update GitHub deployment status
-      uses: bobheadxi/deployments@master
+      uses: bobheadxi/deployments@a3240c495b599dc16f99f6816a6f1ea8d10dc07b # master
       if: always()
       with:
         step: finish

--- a/.github/workflows/pin-check.yml
+++ b/.github/workflows/pin-check.yml
@@ -1,0 +1,39 @@
+name: Verify action pinning
+
+on:
+  pull_request:
+    paths:
+      - '.github/workflows/**'
+      - '**/action.yml'
+      - '**/action.yaml'
+      - '.pinact.yaml'
+
+permissions:
+  contents: read
+
+jobs:
+  pinact:
+    runs-on: ubuntu-latest
+    env:
+      PINACT_VERSION: v3.10.1
+      # Used by `gh release download` and by pinact when calling the GitHub
+      # REST API to resolve latest tag SHAs. Without this, pinact falls back
+      # to unauthenticated requests (60/hour) and the update will likely
+      # rate-limit. GH_TOKEN is the alias gh CLI prefers; pinact reads
+      # GITHUB_TOKEN.
+      GH_TOKEN: ${{ github.token }}
+      GITHUB_TOKEN: ${{ github.token }}
+    steps:
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
+
+      - name: Install pinact
+        run: |
+          cd "$RUNNER_TEMP"
+          gh release download "$PINACT_VERSION" \
+            --repo suzuki-shunsuke/pinact \
+            --pattern 'pinact_linux_amd64.tar.gz'
+          tar -xzf pinact_linux_amd64.tar.gz
+          sudo install pinact /usr/local/bin/
+
+      - name: Verify all third-party actions are pinned to SHAs
+        run: pinact run -check

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -68,12 +68,12 @@ jobs:
     steps:
 
     - name: Set up Node 24
-      uses: actions/setup-node@v6
+      uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6
       with:
         node-version: '24'
 
     - name: Set up Java 17
-      uses: actions/setup-java@v5
+      uses: actions/setup-java@be666c2fcd27ec809703dec50e508c2fdc7f6654 # v5
       with:
         distribution: 'temurin'
         java-version: '17'
@@ -94,7 +94,7 @@ jobs:
       run: |
         echo "BUILD_DOCKER=true" >> $GITHUB_ENV
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 0
 
@@ -188,7 +188,7 @@ jobs:
 
     - name: Docker Login
       if: ${{ env.BUILD_DOCKER == 'true' }}
-      uses: docker/login-action@v4
+      uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
       with:
         registry: ${{ env.PACKAGE_SERVER }}
         username: $GITHUB_ACTOR
@@ -346,7 +346,7 @@ jobs:
       - deploy-cloud
     steps:
       - name: OWASP ZAP Full Scan
-        uses: zaproxy/action-baseline@v0.14.0
+        uses: zaproxy/action-baseline@7c4deb10e6261301961c86d65d54a516394f9aed # v0.14.0
         with:
           token: ${{ secrets.REPO_TOKEN }}
           target: 'https://vcptcore-dev.govirto.com'

--- a/.github/workflows/platform-release-hotfix.yml
+++ b/.github/workflows/platform-release-hotfix.yml
@@ -36,7 +36,7 @@ jobs:
       changelog: ${{ steps.changelog.outputs.changelog }}
     steps:
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 0
 
@@ -78,7 +78,7 @@ jobs:
     runs-on: ubuntu-24.04
     steps:
     - name: Checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Install VirtoCommerce.GlobalTool
       uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master

--- a/.github/workflows/platfotm-owasp.yml
+++ b/.github/workflows/platfotm-owasp.yml
@@ -22,7 +22,7 @@ jobs:
         uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
       - name: Docker Login
-        uses: docker/login-action@v4
+        uses: docker/login-action@4907a6ddec9925e35a0a9e82d7399ccc52663121 # v4
         with:
           registry: ghcr.io
           username: $GITHUB_ACTOR
@@ -38,7 +38,7 @@ jobs:
           validateSwagger: 'false'
 
       - name: OWASP ZAP Full Scan
-        uses: zaproxy/action-baseline@v0.12.0
+        uses: zaproxy/action-baseline@66042c8e7e24680119199a017e5b0e8603bf4dae # v0.12.0
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
           target: 'http://localhost:8090'

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -25,7 +25,7 @@ jobs:
       version: ${{ steps.artifactVer.outputs.shortVersion }}
     steps:
 
-    - uses: actions/checkout@v6
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Get Artifact Version
       uses: VirtoCommerce/vc-github-actions/get-image-version@master
@@ -94,7 +94,7 @@ jobs:
       run: |
         echo "MESSAGE_BODY=:heavy_check_mark: Docker image ${{ needs.publish.outputs.imagePath }} published" >> $GITHUB_ENV
 
-    - uses: actions/github-script@v5
+    - uses: actions/github-script@211cb3fefb35a799baa5156f9321bb774fe56294 # v5
       if: ${{ !(contains('skipped, cancelled', needs.publish.result ))  }}
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
@@ -121,7 +121,7 @@ jobs:
       run: |
         echo "MESSAGE_BODY=:heavy_check_mark: Docker image ${{ needs.publish.outputs.imagePath }} deployed to QA argoCD" >> $GITHUB_ENV
 
-    - uses: actions/github-script@v5
+    - uses: actions/github-script@211cb3fefb35a799baa5156f9321bb774fe56294 # v5
       if: ${{ !(contains('skipped, cancelled', needs.deploy-argoCD.result )) }}
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}
@@ -148,7 +148,7 @@ jobs:
       run: |
         echo "MESSAGE_BODY=:heavy_check_mark: Docker image ${{ needs.publish.outputs.imagePath }} deployed to QA cloud" >> $GITHUB_ENV
 
-    - uses: actions/github-script@v5
+    - uses: actions/github-script@211cb3fefb35a799baa5156f9321bb774fe56294 # v5
       if: ${{ !(contains('skipped, cancelled', needs.deploy-cloud.result )) }}
       with:
         github-token: ${{secrets.GITHUB_TOKEN}}

--- a/.github/workflows/regression-pr.yml
+++ b/.github/workflows/regression-pr.yml
@@ -48,7 +48,7 @@ jobs:
         echo "PR_BODY=Automated cherry-pick update from PR ${{ needs.check-label.outputs.pullUrl}}" >> $GITHUB_ENV
 
     - name: checkout
-      uses: actions/checkout@v6
+      uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       with:
         fetch-depth: 0
 

--- a/.pinact.yaml
+++ b/.pinact.yaml
@@ -1,0 +1,10 @@
+# yaml-language-server: $schema=https://raw.githubusercontent.com/suzuki-shunsuke/pinact/refs/heads/main/json-schema/pinact.json
+version: 3
+
+files:
+  - pattern: ^\.github/workflows/.*\.ya?ml$
+  - pattern: ^(.*/)?action\.ya?ml$
+
+ignore_actions:
+  - name: VirtoCommerce/.*
+    ref: .*


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4843
### Artifact URL:
Pins every third-party uses: reference (non-VirtoCommerce/* owners) in .github/workflows/ and workflow-templates/ to a 40-character commit SHA with a trailing # tag comment, per [GitHub's supply-chain hardening guide](https://docs.github.com/en/actions/security-for-github-actions/security-guides/security-hardening-for-github-actions#using-third-party-actions). Tags are mutable; SHAs are not.

New pinact.yaml declaring scan paths and VirtoCommerce/* ignore.
New .github/workflows/pin-check.yml — runs pinact run -check on every PR that touches workflows or templates; fails on unpinned uses: lines.
Internal VirtoCommerce/* refs (vc-github-actions, jira-upload-*, reusable workflows) are intentionally left as version-/branch-pinned — they're not third-party.

Layers automated maintenance onto the SHA pinning from #.

.github/dependabot.yml — weekly grouped github-actions updates. Dependabot reads the # tag comment, bumps SHA + comment together when upstream cuts new tags.

README file added under .github/workflows/.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Low risk: changes are limited to CI/workflow configuration, primarily replacing tag/branch refs with immutable SHAs and adding validation automation.
> 
> **Overview**
> Hardens GitHub Actions supply-chain security by **pinning all third-party `uses:` references** in workflows to full commit SHAs (with trailing `# tag` comments), replacing tag/branch-based references.
> 
> Adds automated enforcement and maintenance: a new `pin-check.yml` workflow runs `pinact run -check` on PRs that touch workflows/actions, a new root `.pinact.yaml` defines scan scope while ignoring `VirtoCommerce/*`, and Dependabot is configured to open weekly grouped `github-actions` update PRs. Includes a short `.github/workflows/README.md` documenting the pinning policy and update flow.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 013149b5387d13f5071c9ff39c8a8cd0d1caa652. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Image tag:
ghcr.io/VirtoCommerce/platform:3.1029.0-pr-3036-0131-vcst-4843-013149b5