### PR TITLE
VCST-5063: Pass Application Insights instrumentation key to callable workflow

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -326,6 +326,8 @@ jobs:
       envPAT: ${{ secrets.REPO_TOKEN }}
       testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
+      appInsightsInstrumentationKey: ${{ secrets.appInsightsInstrumentationKey }}
+      appInsightsResourceId: ${{ secrets.appInsightsResourceId }}
 
   deploy-cloud:
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -314,7 +314,7 @@ jobs:
     needs: ci
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.34
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.35
     with:
       installModules: 'true'
       installCustomModule: 'false'
@@ -331,7 +331,7 @@ jobs:
   deploy-cloud:
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.34    
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.35    
     with:
       releaseSource: platform
       platformVer: ${{ needs.ci.outputs.version }}
@@ -356,7 +356,7 @@ jobs:
   trivy-scan:
     if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.34
+    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.35
     with:
       assigneeAccountId: '621c47c0302c6b006af0a1cd'
       assigneeEmailAddress: 'andrew.kubyshkin@virtoworks.com'

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -326,8 +326,7 @@ jobs:
       envPAT: ${{ secrets.REPO_TOKEN }}
       testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
-      appInsightsInstrumentationKey: ${{ secrets.appInsightsInstrumentationKey }}
-      appInsightsResourceId: ${{ secrets.appInsightsResourceId }}
+      appInsightsInstrumentationKey: ${{ secrets.E2E_APPINSIGHTSINSTRUMENTATIONKEY }}
 
   deploy-cloud:
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -314,7 +314,7 @@ jobs:
     needs: ci
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-5063 #v3.800.31
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.34
     with:
       installModules: 'true'
       installCustomModule: 'false'
@@ -331,7 +331,7 @@ jobs:
   deploy-cloud:
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.31    
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.34    
     with:
       releaseSource: platform
       platformVer: ${{ needs.ci.outputs.version }}
@@ -356,7 +356,7 @@ jobs:
   trivy-scan:
     if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.31
+    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.34
     with:
       assigneeAccountId: '621c47c0302c6b006af0a1cd'
       assigneeEmailAddress: 'andrew.kubyshkin@virtoworks.com'

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -1,5 +1,5 @@
-# v3.800.31
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.35
+# https://virtocommerce.atlassian.net/browse/VCST-5063
 name: Platform CI
 
 on:

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -314,7 +314,7 @@ jobs:
     needs: ci
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.31
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-5063 #v3.800.31
     with:
       installModules: 'true'
       installCustomModule: 'false'

--- a/.github/workflows/platform-release-hotfix.yml
+++ b/.github/workflows/platform-release-hotfix.yml
@@ -1,5 +1,5 @@
-# v3.800.31
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.35
+# https://virtocommerce.atlassian.net/browse/VCST-5063
 name: Release hotfix
 
 on:

--- a/.github/workflows/platform-release-hotfix.yml
+++ b/.github/workflows/platform-release-hotfix.yml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.34    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.35    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.34    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.35    
     with:
       uploadPackage: 'true'
       uploadDocker: 'true'
@@ -47,7 +47,7 @@ jobs:
   publish-docker:
     needs:
       [build, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.34    
+    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.35    
     with:
       fullKey: ${{ needs.build.outputs.dockerFullKey }}
       shortKey: '${{ needs.build.outputs.dockerShortKey }}-'
@@ -61,7 +61,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.34    
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.35    
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/.github/workflows/platform-release-hotfix.yml
+++ b/.github/workflows/platform-release-hotfix.yml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.31    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.34    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.31    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.34    
     with:
       uploadPackage: 'true'
       uploadDocker: 'true'
@@ -47,7 +47,7 @@ jobs:
   publish-docker:
     needs:
       [build, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.31    
+    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.34    
     with:
       fullKey: ${{ needs.build.outputs.dockerFullKey }}
       shortKey: '${{ needs.build.outputs.dockerShortKey }}-'
@@ -61,7 +61,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.31    
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.34    
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.31 
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.34 
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.31 
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.34 
     with:
       uploadDocker: 'true'
     secrets:

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.34 
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.35 
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.34 
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.35 
     with:
       uploadDocker: 'true'
     secrets:

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.31    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.34    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.31    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.34    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.31
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.34
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -1,5 +1,5 @@
-# v3.800.31
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.35
+# https://virtocommerce.atlassian.net/browse/VCST-5063
 name: Publish nuget
 
 on:

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.34    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.35    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.34    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.35    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.34
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.35
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.31    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.34    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,5 +1,5 @@
-# v3.800.31
-# https://virtocommerce.atlassian.net/browse/VCST-4958
+# v3.800.35
+# https://virtocommerce.atlassian.net/browse/VCST-5063
 name: Release
 
 on:

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.34    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.35    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5063
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> CI-only changes: version pins and forwarding an existing E2E secret to the test workflow; no platform runtime code changes.
> 
> **Overview**
> Bumps **Platform CI** and related workflows to reusable **`VirtoCommerce/.github`** refs **`v3.800.35`** (from **`v3.800.33`**) and updates workflow header comments to **VCST-5063**.
> 
> The meaningful behavior change is in **`platform-ci.yml`**: the **`auto-tests`** job now passes **`appInsightsInstrumentationKey`** from **`secrets.E2E_APPINSIGHTSINSTRUMENTATIONKEY`** into **`pytest-tests.yml`**, so E2E/pytest runs can use Application Insights telemetry via the shared workflow contract.
> 
> Other workflows (**`pr-ci`**, **`release`**, **`publish-nugets`**, **`platform-release-hotfix`**) only pick up the same reusable-workflow version bump.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ae8af4fcc4750e9124f4668b93d9fb29b5511dba. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Image tag:
ghcr.io/VirtoCommerce/platform:3.1031.0-pr-3040-ae8a-test-vcst-5063-ae8af4fc