### PR TITLE
Test-VCST-5054: Use test branch for workflows

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,4 +28,4 @@ uses: actions/checkout@v6
   gh api repos/OWNER/REPO/commits/TAG --jq '.sha'
   ```
 
-- `VirtoCommerce/vc-github-actions/<dir>@master` and other `VirtoCommerce/*` refs remain version-/branch-pinned as before — only non-VirtoCommerce owners require SHA pinning.
+- `VirtoCommerce/vc-github-actions/<dir>@VCST-5054 #master` and other `VirtoCommerce/*` refs remain version-/branch-pinned as before — only non-VirtoCommerce owners require SHA pinning.

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -40,7 +40,7 @@ jobs:
     steps:
     # Initializes vc-build  for solution build.
     - name: Install VirtoCommerce.GlobalTool
-      uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
+      uses: VirtoCommerce/vc-github-actions/setup-vcbuild@VCST-5054 #master
 
     - name: Checkout repository
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -21,7 +21,7 @@ jobs:
     steps: 
 
     - name: Read deployment config
-      uses: VirtoCommerce/vc-github-actions/get-deploy-param@master
+      uses: VirtoCommerce/vc-github-actions/get-deploy-param@VCST-5054 #master
       id: deployConfig
       with:
         envName: ${{ github.event.inputs.deployBranch }}
@@ -36,7 +36,7 @@ jobs:
         no_override: false
 
     - name: Update deployment-cm
-      uses: VirtoCommerce/vc-github-actions/create-deploy-pr@master
+      uses: VirtoCommerce/vc-github-actions/create-deploy-pr@VCST-5054 #master
       with:
         deployRepo: ${{ steps.deployConfig.outputs.deployRepo }}
         deployBranch: ${{ steps.deployConfig.outputs.deployBranch }}

--- a/.github/workflows/msteams.yml
+++ b/.github/workflows/msteams.yml
@@ -11,7 +11,7 @@ jobs:
     steps:
 
     - name: Send a message to Microsoft Teams
-      uses: VirtoCommerce/vc-github-actions/msteams-send-message@master
+      uses: VirtoCommerce/vc-github-actions/msteams-send-message@VCST-5054 #master
       with:
         body: '{
     "@type": "MessageCard",

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -99,18 +99,18 @@ jobs:
         fetch-depth: 0
 
     - name: Install VirtoCommerce.GlobalTool
-      uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
+      uses: VirtoCommerce/vc-github-actions/setup-vcbuild@VCST-5054 #master
 
     - name: Install dotnet-sonarscanner
       run: dotnet tool install --global dotnet-sonarscanner
 
     - name: Get Image Version
-      uses: VirtoCommerce/vc-github-actions/get-image-version@master
+      uses: VirtoCommerce/vc-github-actions/get-image-version@VCST-5054 #master
       id: image
 
     - name: Get changelog
       id: changelog
-      uses: VirtoCommerce/vc-github-actions/changelog-generator@master
+      uses: VirtoCommerce/vc-github-actions/changelog-generator@VCST-5054 #master
 
     - name: Set VERSION_SUFFIX variable
       run: |
@@ -149,12 +149,12 @@ jobs:
         }
     - name: Add version suffix
       if: ${{ github.ref != 'refs/heads/master' || github.ref != 'refs/heads/main' }}
-      uses: VirtoCommerce/vc-github-actions/add-version-suffix@master
+      uses: VirtoCommerce/vc-github-actions/add-version-suffix@VCST-5054 #master
       with:
         versionSuffix: ${{ env.VERSION_SUFFIX }}
 
     - name: SonarCloud Begin
-      uses: VirtoCommerce/vc-github-actions/sonar-scanner-begin@master
+      uses: VirtoCommerce/vc-github-actions/sonar-scanner-begin@VCST-5054 #master
 
     - name: Build
       run: vc-build Compile
@@ -167,10 +167,10 @@ jobs:
       run: echo "BUILD_STATE=successful" >> $GITHUB_ENV
 
     - name: SonarCloud End
-      uses: VirtoCommerce/vc-github-actions/sonar-scanner-end@master
+      uses: VirtoCommerce/vc-github-actions/sonar-scanner-end@VCST-5054 #master
 
     - name: Quality Gate
-      uses: VirtoCommerce/vc-github-actions/sonar-quality-gate@master
+      uses: VirtoCommerce/vc-github-actions/sonar-quality-gate@VCST-5054 #master
       with:
         login: ${{secrets.SONAR_TOKEN}}
 
@@ -180,7 +180,7 @@ jobs:
     - name: Build Docker Image
       if: ${{ env.BUILD_DOCKER == 'true' }}
       id: dockerBuild
-      uses: VirtoCommerce/vc-github-actions/build-docker-image@master
+      uses: VirtoCommerce/vc-github-actions/build-docker-image@VCST-5054 #master
       with:
         tag: ${{ env.DOCKER_TAG }}
         imageName: 'platform'
@@ -195,7 +195,7 @@ jobs:
         password: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Swagger validation
-      uses: VirtoCommerce/vc-github-actions/docker-env@master
+      uses: VirtoCommerce/vc-github-actions/docker-env@VCST-5054 #master
       if: ${{ github.ref == 'refs/heads/dev' }}
       with:
         githubUser: ${{ env.GITHUB_ACTOR }}
@@ -206,12 +206,12 @@ jobs:
 
     - name: Publish Nuget
       if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
-      uses: VirtoCommerce/vc-github-actions/publish-nuget@master
+      uses: VirtoCommerce/vc-github-actions/publish-nuget@VCST-5054 #master
 
     - name: Publish to Blob
       if: ${{ github.ref == 'refs/heads/dev' || github.event_name == 'pull_request' || (github.event_name == 'workflow_dispatch' && (github.ref != 'refs/heads/master' || github.ref != 'refs/heads/main')) }}
       id: blobRelease
-      uses: VirtoCommerce/vc-github-actions/publish-blob-release@master
+      uses: VirtoCommerce/vc-github-actions/publish-blob-release@VCST-5054 #master
       with:
         blobSAS: ${{ secrets.BLOB_TOKEN }}
         blobUrl: ${{ vars.BLOB_URL }}
@@ -224,7 +224,7 @@ jobs:
 
     - name: Add Jira link
       if: ${{ github.event_name == 'pull_request' }}
-      uses: VirtoCommerce/vc-github-actions/publish-jira-link@master
+      uses: VirtoCommerce/vc-github-actions/publish-jira-link@VCST-5054 #master
       with:
         branchName: ${{ github.head_ref }}
         repoOrg: ${{ github.repository_owner }}
@@ -233,7 +233,7 @@ jobs:
 
     - name: Add link to PR
       if: ${{ github.event_name == 'pull_request' }}
-      uses: VirtoCommerce/vc-github-actions/publish-artifact-link@master
+      uses: VirtoCommerce/vc-github-actions/publish-artifact-link@VCST-5054 #master
       with:
         artifactUrl: ${{ steps.artifactUrl.outputs.DOCKER_URL }}
         repoOrg: ${{ github.repository_owner }}
@@ -244,11 +244,11 @@ jobs:
       with:
         changelog: ${{ steps.changelog.outputs.changelog }}
         organization: ${{ github.repository_owner }}
-      uses: VirtoCommerce/vc-github-actions/publish-github-release@master
+      uses: VirtoCommerce/vc-github-actions/publish-github-release@VCST-5054 #master
 
     - name: Create deployment matrix
       if: ${{ github.ref == 'refs/heads/dev' || github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
-      uses: VirtoCommerce/vc-github-actions/cloud-create-deploy-matrix@master
+      uses: VirtoCommerce/vc-github-actions/cloud-create-deploy-matrix@VCST-5054 #master
       id: deployment-matrix
       with:
         deployConfigPath: 'cloudDeploy.json'
@@ -268,7 +268,7 @@ jobs:
 
     - name: Publish Docker Image
       if: ${{ env.BUILD_DOCKER == 'true' }}
-      uses: VirtoCommerce/vc-github-actions/publish-docker-image@master
+      uses: VirtoCommerce/vc-github-actions/publish-docker-image@VCST-5054 #master
       with:
           image: ${{ steps.dockerBuild.outputs.imageName }}
           tag: ${{ env.DOCKER_TAG }}
@@ -278,7 +278,7 @@ jobs:
           update_latest: ${{ env.UPDATE_LATEST_TAG }}
 
     - name: Parse Jira Keys from All Commits
-      uses: VirtoCommerce/vc-github-actions/get-jira-keys@master
+      uses: VirtoCommerce/vc-github-actions/get-jira-keys@VCST-5054 #master
       if: always()
       id: jira_keys
       with:
@@ -314,7 +314,7 @@ jobs:
     needs: ci
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-5054 #v3.800.35
     with:
       installModules: 'true'
       installCustomModule: 'false'
@@ -331,7 +331,7 @@ jobs:
   deploy-cloud:
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@VCST-5054 #v3.800.35    
     with:
       releaseSource: platform
       platformVer: ${{ needs.ci.outputs.version }}
@@ -356,7 +356,7 @@ jobs:
   trivy-scan:
     if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@VCST-5054 #v3.800.35
     with:
       assigneeAccountId: '621c47c0302c6b006af0a1cd'
       assigneeEmailAddress: 'andrew.kubyshkin@virtoworks.com'

--- a/.github/workflows/platform-release-hotfix.yml
+++ b/.github/workflows/platform-release-hotfix.yml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@VCST-5054 #v3.800.35    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@VCST-5054 #v3.800.35    
     with:
       uploadPackage: 'true'
       uploadDocker: 'true'
@@ -42,12 +42,12 @@ jobs:
 
     - name: Get Changelog
       id: changelog
-      uses: VirtoCommerce/vc-github-actions/changelog-generator@master
+      uses: VirtoCommerce/vc-github-actions/changelog-generator@VCST-5054 #master
 
   publish-docker:
     needs:
       [build, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@VCST-5054 #v3.800.35    
     with:
       fullKey: ${{ needs.build.outputs.dockerFullKey }}
       shortKey: '${{ needs.build.outputs.dockerShortKey }}-'
@@ -61,7 +61,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@VCST-5054 #v3.800.35    
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'
@@ -81,10 +81,10 @@ jobs:
       uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Install VirtoCommerce.GlobalTool
-      uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
+      uses: VirtoCommerce/vc-github-actions/setup-vcbuild@VCST-5054 #master
 
     - name: Setup Git Credentials
-      uses: VirtoCommerce/vc-github-actions/setup-git-credentials-github@master
+      uses: VirtoCommerce/vc-github-actions/setup-git-credentials-github@VCST-5054 #master
       with:
         githubToken: ${{ secrets.REPO_TOKEN }}
 

--- a/.github/workflows/platfotm-owasp.yml
+++ b/.github/workflows/platfotm-owasp.yml
@@ -19,7 +19,7 @@ jobs:
     steps:
 
       - name: Install VirtoCommerce.GlobalTool
-        uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
+        uses: VirtoCommerce/vc-github-actions/setup-vcbuild@VCST-5054 #master
 
       - name: Docker Login
         uses: docker/login-action@650006c6eb7dba73a995cc03b0b2d7f5ca915bee # v4
@@ -29,7 +29,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Docker Env
-        uses: VirtoCommerce/vc-github-actions/docker-env@master
+        uses: VirtoCommerce/vc-github-actions/docker-env@VCST-5054 #master
         with:
           githubUser: ${{ env.GITHUB_ACTOR }}
           githubToken: ${{ env.GITHUB_TOKEN }}

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.35 
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@VCST-5054 #v3.800.35 
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.35 
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@VCST-5054 #v3.800.35 
     with:
       uploadDocker: 'true'
     secrets:
@@ -36,7 +36,7 @@ jobs:
     steps:
     - name: publish-tag  
       if: ${{ github.event_name == 'pull_request' }}
-      uses: VirtoCommerce/vc-github-actions/publish-artifact-link@master
+      uses: VirtoCommerce/vc-github-actions/publish-artifact-link@VCST-5054 #master
       with:
         artifactUrl: ${{ needs.build.outputs.imageTag}}
         repoOrg: ${{ github.repository_owner }}

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -28,11 +28,11 @@ jobs:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
     - name: Get Artifact Version
-      uses: VirtoCommerce/vc-github-actions/get-image-version@master
+      uses: VirtoCommerce/vc-github-actions/get-image-version@VCST-5054 #master
       id: artifactVer
 
     - name: Get cache key
-      uses: VirtoCommerce/vc-github-actions/cache-get-key@master
+      uses: VirtoCommerce/vc-github-actions/cache-get-key@VCST-5054 #master
       id: cache-key
       with:
         runnerOs: ${{ runner.os  }}
@@ -41,7 +41,7 @@ jobs:
   publish:
     needs:
       get-cache-key
-    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@VCST-5054 #v3.800.35
     with:
       fullKey: ${{ needs.get-cache-key.outputs.dockerFullKey }}
       shortKey: '${{ needs.get-cache-key.outputs.dockerShortKey }}-'
@@ -54,7 +54,7 @@ jobs:
   deploy-argoCD:
     needs:
       publish
-    uses: VirtoCommerce/.github/.github/workflows/deploy.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/deploy.yml@VCST-5054 #v3.800.35
     with:
       artifactUrl: ${{ needs.publish.outputs.imagePath }}
       matrix: '{"include":[{"envName": "qa", "confPath": "argoDeploy.json"}]}'
@@ -63,7 +63,7 @@ jobs:
   deploy-cloud:
     needs:
       [get-cache-key, publish]
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@VCST-5054 #v3.800.35
     with:
       releaseSource: platform
       platformVer: ${{ needs.get-cache-key.outputs.version }}

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@VCST-5054 #v3.800.35    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@VCST-5054 #v3.800.35    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@VCST-5054 #v3.800.35
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@VCST-5054 #v3.800.35    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5054
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI, release, deploy, and security-scan paths all depend on a non-production branch; a mistaken merge would leave production pipelines on test refs until reverted.
> 
> **Overview**
> This PR retargets **all** internal GitHub Actions and reusable workflows from their normal refs (`master` on `vc-github-actions`, `v3.800.35` on `VirtoCommerce/.github`) to the **`VCST-5054`** branch, with the previous ref kept in trailing comments (e.g. `#master`, `#v3.800.35`).
> 
> Touched workflows span the full platform pipeline: **platform-ci**, **pr-ci**, **pr-deploy**, **deploy**, **release**, **publish-nugets**, **platform-release-hotfix**, **CodeQL**, **OWASP**, **Teams** notifications, and related jobs (build, Sonar, Docker publish, blob/NuGet, cloud deploy, pytest, Trivy). **`.github/workflows/README.md`** is updated to document the temporary `vc-github-actions` pin example.
> 
> There is **no application or platform code** change—only CI/CD wiring so runs exercise workflow/action changes on the VCST-5054 branch.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit ab59a16cbba49afce3e00179326b06ba34ad473d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Image tag:
ghcr.io/VirtoCommerce/platform:3.1032.0-pr-3044-ab59-test-vcst-5054-ab59a16c