### PR TITLE
VCST-5178: Fix Truncate exceeding max length and cap Hangfire recurring-job user name

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Extensions/StringExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Extensions/StringExtensions.cs
@@ -168,8 +168,9 @@ namespace VirtoCommerce.Platform.Core.Common
             {
                 return value;
             }
+            suffix ??= string.Empty;
 
-            return value.Length <= maxLength ? value : value.Substring(0, maxLength) + suffix;
+            return value.Length <= maxLength ? value : string.Concat(value.AsSpan(0, maxLength - suffix.Length), suffix);
         }
 
         public static string EscapeSearchTerm(this string term)

--- a/src/VirtoCommerce.Platform.Core/Extensions/StringExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Extensions/StringExtensions.cs
@@ -170,7 +170,14 @@ namespace VirtoCommerce.Platform.Core.Common
             }
             suffix ??= string.Empty;
 
-            return value.Length <= maxLength ? value : string.Concat(value.AsSpan(0, maxLength - suffix.Length), suffix);
+            if (value.Length <= maxLength)
+            {
+                return value;
+            }
+
+            maxLength = Math.Max(0, maxLength - suffix.Length);
+
+            return string.Concat(value.AsSpan(0, maxLength), suffix);
         }
 
         public static string EscapeSearchTerm(this string term)

--- a/src/VirtoCommerce.Platform.Hangfire/Middleware/HangfireUserContextMiddleware.cs
+++ b/src/VirtoCommerce.Platform.Hangfire/Middleware/HangfireUserContextMiddleware.cs
@@ -1,5 +1,6 @@
 using Hangfire.Client;
 using Hangfire.Server;
+using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Security;
 using static VirtoCommerce.Platform.Core.Common.ThreadSlotNames;
 
@@ -11,6 +12,8 @@ namespace VirtoCommerce.Platform.Hangfire.Middleware
     /// </summary>
     public class HangfireUserContextMiddleware : IClientFilter, IServerFilter
     {
+        public const int UserNameLength = 64;
+
         private readonly IUserNameResolver _userNameResolver;
 
         public HangfireUserContextMiddleware(IUserNameResolver userNameResolver)
@@ -45,7 +48,7 @@ namespace VirtoCommerce.Platform.Hangfire.Middleware
 
             if (IsRecurringJob(filterContext, out var recurringJobId))
             {
-                userName = $"system:{recurringJobId}";
+                userName = $"system:{recurringJobId}".Truncate(UserNameLength);
             }
             else
             {

--- a/tests/VirtoCommerce.Platform.Core.Tests/Extensions/StringExtensionsTests.cs
+++ b/tests/VirtoCommerce.Platform.Core.Tests/Extensions/StringExtensionsTests.cs
@@ -118,6 +118,19 @@ namespace VirtoCommerce.Platform.Core.Tests.Extensions
             actual.Length.Should().Be(10);
         }
 
+        [Fact]
+        public void Truncate_MaxLengthSmallerThanSuffix_DoesNotThrow()
+        {
+            // Arrange
+            var value = "Hello";
+
+            // Act
+            var actual = value.Truncate(2);
+
+            // Assert
+            actual.Should().Be("...");
+        }
+
         #endregion Truncate
     }
 }

--- a/tests/VirtoCommerce.Platform.Core.Tests/Extensions/StringExtensionsTests.cs
+++ b/tests/VirtoCommerce.Platform.Core.Tests/Extensions/StringExtensionsTests.cs
@@ -1,0 +1,123 @@
+using FluentAssertions;
+using VirtoCommerce.Platform.Core.Common;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Core.Tests.Extensions
+{
+    public class StringExtensionsTests
+    {
+        #region Truncate
+
+        [Theory]
+        [InlineData(null)]
+        [InlineData("")]
+        public void Truncate_NullOrEmpty_ReturnsValueUnchanged(string value)
+        {
+            // Act
+            var actual = value.Truncate(10);
+
+            // Assert
+            actual.Should().Be(value);
+        }
+
+        [Fact]
+        public void Truncate_ShorterThanMaxLength_ReturnsValueUnchanged()
+        {
+            // Arrange
+            var value = "Short";
+
+            // Act
+            var actual = value.Truncate(10);
+
+            // Assert
+            actual.Should().Be(value);
+        }
+
+        [Fact]
+        public void Truncate_EqualToMaxLength_ReturnsValueUnchanged()
+        {
+            // Arrange
+            var value = "1234567890";
+
+            // Act
+            var actual = value.Truncate(value.Length);
+
+            // Assert
+            actual.Should().Be(value);
+        }
+
+        [Fact]
+        public void Truncate_LongerThanMaxLength_TruncatesAndAppendsSuffix()
+        {
+            // Arrange
+            var value = "The quick brown fox";
+
+            // Act
+            var actual = value.Truncate(10);
+
+            // Assert
+            actual.Should().Be("The qui...");
+        }
+
+        [Theory]
+        [InlineData(3)]
+        [InlineData(5)]
+        [InlineData(10)]
+        [InlineData(15)]
+        public void Truncate_LongerThanMaxLength_ResultDoesNotExceedMaxLength(int maxLength)
+        {
+            // Arrange
+            var value = "The quick brown fox jumps over the lazy dog";
+
+            // Act
+            var actual = value.Truncate(maxLength);
+
+            // Assert
+            actual.Length.Should().Be(maxLength);
+        }
+
+        [Fact]
+        public void Truncate_CustomSuffix_TruncatesAndAppendsSuffix()
+        {
+            // Arrange
+            var value = "The quick brown fox";
+
+            // Act
+            var actual = value.Truncate(10, "----");
+
+            // Assert
+            actual.Should().Be("The qu----");
+            actual.Length.Should().Be(10);
+        }
+
+        [Fact]
+        public void Truncate_EmptySuffix_TruncatesToExactMaxLength()
+        {
+            // Arrange
+            var value = "The quick brown fox";
+
+            // Act
+            var actual = value.Truncate(10, "");
+
+            // Assert
+            actual.Should().Be("The quick ");
+            actual.Length.Should().Be(10);
+        }
+
+        [Fact]
+        public void Truncate_NullSuffix_TreatedAsEmpty()
+        {
+            // Arrange
+            var value = "The quick brown fox";
+
+            // Act
+            var actual = value.Truncate(10, null);
+
+            // Assert
+            actual.Should().Be("The quick ");
+            actual.Length.Should().Be(10);
+        }
+
+        #endregion Truncate
+    }
+}


### PR DESCRIPTION
## Description
fix: The generated recurring-job user name to UserNameLength (64) via Truncate, so system:{recurringJobId} no longer exceeds the column limit.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5178
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Localized string helper and Hangfire user-name formatting fix with tests; no auth or data-model changes beyond preventing overlong names.
> 
> **Overview**
> **`StringExtensions.Truncate`** now reserves space for the suffix so the returned string never exceeds `maxLength` (including null/empty suffix and edge cases where `maxLength` is smaller than the suffix). Implementation uses `ReadOnlySpan`/`string.Concat` instead of substring-only truncation.
> 
> **Hangfire** recurring jobs set the background user name from `system:{recurringJobId}` and apply **`Truncate(64)`** via a new `UserNameLength` constant so long job IDs do not overflow stored user-name limits.
> 
> Adds **`StringExtensionsTests`** covering truncation behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e774931295b7803af0b29dca74f864e90fa42750. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1033.0-pr-3047-e774-vcst-5178-e7749312