### PR TITLE
fix(platform): guard null IconUrl in ModulesController.IconFileExists (VCST-5212)

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Controllers/Api/ModulesController.cs
+++ b/src/VirtoCommerce.Platform.Web/Controllers/Api/ModulesController.cs
@@ -540,6 +540,11 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
         private static bool IconFileExists(ManifestModuleInfo module)
         {
             var moduleIconUrl = module.IconUrl;
+            if (string.IsNullOrEmpty(moduleIconUrl))
+            {
+                return false;
+            }
+
             if (!moduleIconUrl.StartsWith('/'))
             {
                 moduleIconUrl = "/" + moduleIconUrl;

--- a/tests/VirtoCommerce.Platform.Web.Tests/Controllers/Api/ModulesControllerTests.cs
+++ b/tests/VirtoCommerce.Platform.Web.Tests/Controllers/Api/ModulesControllerTests.cs
@@ -1,0 +1,88 @@
+using System.Collections.Generic;
+using FluentAssertions;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Options;
+using Moq;
+using VirtoCommerce.Platform.Core;
+using VirtoCommerce.Platform.Core.Modularity;
+using VirtoCommerce.Platform.Core.PushNotifications;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.Platform.Web.Controllers.Api;
+using VirtoCommerce.Platform.Web.Modularity;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Web.Tests.Controllers.Api
+{
+    public class ModulesControllerTests
+    {
+        private readonly Mock<IModuleService> _moduleService = new();
+        private readonly Mock<IModuleManagementService> _moduleManagementService = new();
+        private readonly Mock<IPushNotificationManager> _pushNotifier = new();
+        private readonly Mock<IUserNameResolver> _userNameResolver = new();
+        private readonly Mock<ISettingsManager> _settingsManager = new();
+        private readonly Mock<IPlatformRestarter> _platformRestarter = new();
+        private readonly Mock<ILogger<ModulesController>> _logger = new();
+
+        private ModulesController CreateController() => new(
+            _moduleService.Object,
+            _moduleManagementService.Object,
+            _pushNotifier.Object,
+            _userNameResolver.Object,
+            _settingsManager.Object,
+            Options.Create(new PlatformOptions()),
+            Options.Create(new ExternalModuleCatalogOptions()),
+            Options.Create(new LocalStorageModuleCatalogOptions()),
+            _platformRestarter.Object,
+            _logger.Object);
+
+        private static ManifestModuleInfo CreateModule(string id, string iconUrl)
+        {
+            var module = new ManifestModuleInfo();
+            module.LoadFromManifest(new ModuleManifest
+            {
+                Id = id,
+                Version = "1.0.0",
+                PlatformVersion = "3.0.0",
+                IconUrl = iconUrl,
+            });
+            return module;
+        }
+
+        /// <summary>
+        /// VCST-5212: A module whose management descriptor has a non-empty IconUrl (so it passes
+        /// the GetModules() Where filter) but whose corresponding local module has a NULL IconUrl
+        /// must NOT crash IconFileExists with a NullReferenceException. The endpoint should return
+        /// 200 OK and the entry's IconUrl should be null (the caller's ": null" fallback).
+        /// </summary>
+        [Fact]
+        public void GetModules_LocalModuleHasNullIconUrl_ReturnsOkWithNullIconUrl()
+        {
+            // Arrange: management descriptor has an icon URL (passes the Where guard),
+            // local module for the same Id has a null IconUrl (triggers the NRE in IconFileExists).
+            const string moduleId = "VirtoCommerce.TestModule";
+
+            _moduleManagementService
+                .Setup(x => x.GetModules())
+                .Returns(new List<ManifestModuleInfo> { CreateModule(moduleId, "Content/logo.png") });
+
+            _moduleService
+                .Setup(x => x.GetModules())
+                .Returns(new List<ManifestModuleInfo> { CreateModule(moduleId, null) });
+
+            var controller = CreateController();
+
+            // Act
+            var result = controller.GetModules();
+
+            // Assert
+            var okResult = result.Result.Should().BeOfType<OkObjectResult>().Subject;
+            var modules = okResult.Value.Should().BeAssignableTo<IEnumerable<ModuleDescriptor>>().Subject;
+
+            var descriptor = Assert.Single(modules);
+            descriptor.Id.Should().Be(moduleId);
+            descriptor.IconUrl.Should().BeNull();
+        }
+    }
+}


### PR DESCRIPTION
## Summary
`GET /api/platform/modules` returned **500 NullReferenceException**. Fixes [VCST-5212](https://virtocommerce.atlassian.net/browse/VCST-5212).

## Root cause
`GetModules()` filters on the *management* descriptor's `IconUrl` (non-empty) but then calls `IconFileExists` on the *local* module, which is a different collection. A module can have a non-empty management `IconUrl` but a **null local `IconUrl`**, so `IconFileExists` dereferenced null at `moduleIconUrl.StartsWith('/')` and the whole endpoint 500'd.

## Fix
One-line null/empty guard at the top of `IconFileExists` returning `false`:
```csharp
if (string.IsNullOrEmpty(moduleIconUrl))
{
    return false;
}
```
A null/empty icon URL means "no resolvable icon" — exactly what the caller's `? localModule.IconUrl : null` fallback already expects. Behavior preserved (that entry's `IconUrl` becomes `null`, endpoint returns `200 OK`). No predicate/DTO/contract/manifest change, no refactor.

## Test (red → green)
- Added `ModulesControllerTests.GetModules_LocalModuleHasNullIconUrl_ReturnsOkWithNullIconUrl` in `VirtoCommerce.Platform.Web.Tests`: management descriptor has a non-empty `IconUrl`, local module has `IconUrl == null`.
- **Red** on current code: `System.NullReferenceException` at `ModulesController.IconFileExists` (`ModulesController.cs:543`).
- **Green** after the guard: returns `OkObjectResult`, entry's `IconUrl` is `null`.
- All **93** `VirtoCommerce.Platform.Web.Tests` pass (92 pre-existing untouched + 1 new), build clean with `TreatWarningsAsErrors=true`.

## ⚠ Needs deploy verification
Statically verified only (build + unit). Backend is static-only in CI — the live 500 symptom must be re-confirmed after this artifact deploys to QA (regression pipeline + `/qa-verify-fix VCST-5212`). Adding the **needs deploy verification** label.

---
**DO NOT MERGE until human review.** 🤖 Opened by the QA auto-fix pipeline — human review + deploy verification required before merge; do not auto-merge.


[VCST-5212]: https://virtocommerce.atlassian.net/browse/VCST-5212?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ
Image tag:
ghcr.io/VirtoCommerce/platform:3.1035.0-pr-3051-3e62-vcst-5212-3e62cd41