### PR TITLE
VCST-4492: Test new workflow versions

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -314,7 +314,7 @@ jobs:
     needs: ci
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-4492 #v3.800.35
     with:
       installModules: 'true'
       installCustomModule: 'false'
@@ -331,7 +331,7 @@ jobs:
   deploy-cloud:
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@VCST-4492 #v3.800.35    
     with:
       releaseSource: platform
       platformVer: ${{ needs.ci.outputs.version }}
@@ -356,7 +356,7 @@ jobs:
   trivy-scan:
     if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@VCST-4492 #v3.800.35
     with:
       assigneeAccountId: '621c47c0302c6b006af0a1cd'
       assigneeEmailAddress: 'andrew.kubyshkin@virtoworks.com'

--- a/.github/workflows/platform-release-hotfix.yml
+++ b/.github/workflows/platform-release-hotfix.yml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@VCST-4492 #v3.800.35    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@VCST-4492 #v3.800.35    
     with:
       uploadPackage: 'true'
       uploadDocker: 'true'
@@ -47,7 +47,7 @@ jobs:
   publish-docker:
     needs:
       [build, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@VCST-4492 #v3.800.35    
     with:
       fullKey: ${{ needs.build.outputs.dockerFullKey }}
       shortKey: '${{ needs.build.outputs.dockerShortKey }}-'
@@ -61,7 +61,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@VCST-4492 #v3.800.35    
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.35 
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@VCST-4492 #v3.800.35 
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.35 
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@VCST-4492 #v3.800.35 
     with:
       uploadDocker: 'true'
     secrets:

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -41,7 +41,7 @@ jobs:
   publish:
     needs:
       get-cache-key
-    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@VCST-4492 #v3.800.35
     with:
       fullKey: ${{ needs.get-cache-key.outputs.dockerFullKey }}
       shortKey: '${{ needs.get-cache-key.outputs.dockerShortKey }}-'
@@ -54,7 +54,7 @@ jobs:
   deploy-argoCD:
     needs:
       publish
-    uses: VirtoCommerce/.github/.github/workflows/deploy.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/deploy.yml@VCST-4492 #v3.800.35
     with:
       artifactUrl: ${{ needs.publish.outputs.imagePath }}
       matrix: '{"include":[{"envName": "qa", "confPath": "argoDeploy.json"}]}'
@@ -63,7 +63,7 @@ jobs:
   deploy-cloud:
     needs:
       [get-cache-key, publish]
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@VCST-4492 #v3.800.35
     with:
       releaseSource: platform
       platformVer: ${{ needs.get-cache-key.outputs.version }}

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@VCST-4492 #v3.800.35    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@VCST-4492 #v3.800.35    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.35
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@VCST-4492 #v3.800.35
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,6 @@ on:
 
 jobs:
   release:
-    uses: VirtoCommerce/.github/.github/workflows/release.yml@v3.800.35    
+    uses: VirtoCommerce/.github/.github/workflows/release.yml@VCST-4492 #v3.800.35    
     secrets:
       envPAT: ${{ secrets.REPO_TOKEN }}


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4492
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> CI/CD behavior depends on unreleased shared workflow code on a feature branch, which can affect builds, deploys, releases, and security scans until refs are reverted or promoted.
> 
> **Overview**
> **Reusable workflow pins** across platform CI/CD are switched from the tagged ref `@v3.800.35` to the branch `@VCST-4492` on `VirtoCommerce/.github`, with inline comments noting the prior tag (`#v3.800.35`).
> 
> Affected entry points include **platform CI** (pytest auto-tests, cloud deploy, Trivy), **PR CI/build**, **PR deploy** (publish Docker, ArgoCD, cloud), **release** and **release hotfix**, and **publish nugets**—covering shared workflows such as `test-and-sonar`, `build`, `publish-docker`, `publish-github`, `deploy`, and `deploy-cloud`.
> 
> No workflow inputs, secrets, or job logic change; only which revision of the shared workflows runs.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit b5e55a6dad77560154bb48648509b6149a7d91e2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Image tag:
ghcr.io/VirtoCommerce/platform:3.1035.0-pr-3052-b5e5-test-vcst-4492-b5e55a6d