### PR TITLE
VCST-5251: Added IHasModuleService and IHasLogger

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Modularity/IHasLogger.cs
+++ b/src/VirtoCommerce.Platform.Core/Modularity/IHasLogger.cs
@@ -1,0 +1,14 @@
+using Microsoft.Extensions.Logging;
+
+namespace VirtoCommerce.Platform.Core.Modularity
+{
+    /// <summary>
+    /// Used to set an <see cref="ILogger"/> for modules and platform startups during initialization.
+    /// In order to log messages from a module or an <see cref="IPlatformStartup"/> you have to implement this
+    /// interface for your class - the platform assigns a logger scoped to the implementing type.
+    /// </summary>
+    public interface IHasLogger
+    {
+        ILogger Logger { get; set; }
+    }
+}

--- a/src/VirtoCommerce.Platform.Core/Modularity/IHasModuleCatalog.cs
+++ b/src/VirtoCommerce.Platform.Core/Modularity/IHasModuleCatalog.cs
@@ -2,7 +2,7 @@ using System;
 
 namespace VirtoCommerce.Platform.Core.Modularity
 {
-    [Obsolete("Use ModuleBootstrapper for read-only module queries.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
+    [Obsolete("Use IHasModuleService.", DiagnosticId = "VC0014", UrlFormat = "https://docs.virtocommerce.org/products/products-virto3-versions")]
     public interface IHasModuleCatalog
     {
         IModuleCatalog ModuleCatalog { get; set; }

--- a/src/VirtoCommerce.Platform.Core/Modularity/IHasModuleService.cs
+++ b/src/VirtoCommerce.Platform.Core/Modularity/IHasModuleService.cs
@@ -1,0 +1,12 @@
+namespace VirtoCommerce.Platform.Core.Modularity
+{
+    /// <summary>
+    /// Used to provide <see cref="IModuleService"/> access for modules during initialization.
+    /// In order to query loaded modules (installed/failed modules, version checks) from a module during
+    /// Initialize/PostInitialize you have to implement this interface for your IModule class.
+    /// </summary>
+    public interface IHasModuleService
+    {
+        IModuleService ModuleService { get; set; }
+    }
+}

--- a/src/VirtoCommerce.Platform.Modules/ModuleBootstrapper.cs
+++ b/src/VirtoCommerce.Platform.Modules/ModuleBootstrapper.cs
@@ -509,6 +509,16 @@ public class ModuleBootstrapper : IModuleService
                     hasHost.HostEnvironment = hostEnvironment;
                 }
 
+                if (instance is IHasLogger hasLogger)
+                {
+                    hasLogger.Logger = _loggerFactory.CreateLogger(instance.GetType());
+                }
+
+                if (instance is IHasModuleService hasModuleService)
+                {
+                    hasModuleService.ModuleService = this;
+                }
+
 #pragma warning disable VC0014
                 if (instance is IHasModuleCatalog hasModuleCatalog && moduleCatalog != null)
                 {
@@ -1218,6 +1228,11 @@ public class ModuleBootstrapper : IModuleService
 
                 if (Activator.CreateInstance(startupType) is IPlatformStartup instance)
                 {
+                    if (instance is IHasLogger hasLogger)
+                    {
+                        hasLogger.Logger = _loggerFactory.CreateLogger(startupType);
+                    }
+
                     startups.Add(instance);
                     logger.LogInformation("Discovered {StartupTypeName} from {ModuleId}", startupType.Name, module.Id);
                 }


### PR DESCRIPTION
## Description
feat: Added IHasModuleService - used to provide IModuleService access for modules during initialization. If you have to implement this interface for your class - the platform assigns a IModuleService.
feat: Added IHasLogger - used to provide ILogger access from platform startup or module initialization If you have to implement this interface for your class - the platform assigns a logger scoped to the implementing type.


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5251
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive opt-in interfaces and wiring in the module pipeline; existing modules are unchanged unless they implement the new interfaces.
> 
> **Overview**
> Adds **opt-in modularity hooks** so modules and `IPlatformStartup` types can receive platform-provided dependencies during initialization.
> 
> **`IHasLogger`** lets an `IModule` or `IPlatformStartup` get an `ILogger` scoped to its type. `ModuleBootstrapper` assigns it in `InitializeModules` and when discovering startup types.
> 
> **`IHasModuleService`** lets an `IModule` get `IModuleService` (the bootstrapper) before `Initialize`, for queries like installed/failed modules and version checks. The obsolete `IHasModuleCatalog` message now directs authors to **`IHasModuleService`** instead of `ModuleBootstrapper`.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 75449fcc8b65523baf0f5d3927f08880536f2daf. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Image tag:
ghcr.io/VirtoCommerce/platform:3.1038.0-pr-3057-7544-vcst-5251-75449fcc