### PR TITLE
VCST-5261: Bump 3rd party dependency to latest release

### DIFF
--- a/src/VirtoCommerce.Platform.Caching/VirtoCommerce.Platform.Caching.csproj
+++ b/src/VirtoCommerce.Platform.Caching/VirtoCommerce.Platform.Caching.csproj
@@ -17,9 +17,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.7" />
-    <PackageReference Include="Polly" Version="8.6.6" />
-    <PackageReference Include="StackExchange.Redis" Version="2.12.14" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageReference Include="Polly" Version="8.7.0" />
+    <PackageReference Include="StackExchange.Redis" Version="3.0.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.Platform.Data.MySql/Readme.md
+++ b/src/VirtoCommerce.Platform.Data.MySql/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.7
+dotnet tool install --global dotnet-ef --version 10.0.9
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.7
+dotnet tool update --global dotnet-ef --version 10.0.9
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.Platform.Data.MySql/VirtoCommerce.Platform.Data.MySql.csproj
+++ b/src/VirtoCommerce.Platform.Data.MySql/VirtoCommerce.Platform.Data.MySql.csproj
@@ -8,12 +8,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <!-- Breaking Change: After 10.0.5 Microting changed assembly name and C# namespaces from Pomelo.EntityFrameworkCore.MySql to Microting.EntityFrameworkCore.MySql. -->
     <PackageReference Include="Microting.EntityFrameworkCore.MySql" Version="10.0.5" />
   </ItemGroup>
 

--- a/src/VirtoCommerce.Platform.Data.PostgreSql/Readme.md
+++ b/src/VirtoCommerce.Platform.Data.PostgreSql/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.7
+dotnet tool install --global dotnet-ef --version 10.0.9
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.7
+dotnet tool update --global dotnet-ef --version 10.0.9
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.Platform.Data.PostgreSql/VirtoCommerce.Platform.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.Platform.Data.PostgreSql/VirtoCommerce.Platform.Data.PostgreSql.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Npgsql" Version="10.0.2" />
-    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.1" />
+    <PackageReference Include="Npgsql" Version="10.0.3" />
+    <PackageReference Include="Npgsql.EntityFrameworkCore.PostgreSQL" Version="10.0.2" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.Platform.Data.SqlServer/Readme.md
+++ b/src/VirtoCommerce.Platform.Data.SqlServer/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.7
+dotnet tool install --global dotnet-ef --version 10.0.9
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.7
+dotnet tool update --global dotnet-ef --version 10.0.9
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.Platform.Data.SqlServer/VirtoCommerce.Platform.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.Platform.Data.SqlServer/VirtoCommerce.Platform.Data.SqlServer.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.7">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.7" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.Platform.Data/VirtoCommerce.Platform.Data.csproj
+++ b/src/VirtoCommerce.Platform.Data/VirtoCommerce.Platform.Data.csproj
@@ -21,9 +21,9 @@
     <PackageReference Include="EntityFrameworkCore.Triggers" Version="1.2.3" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="Humanizer.Core" Version="3.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.7" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.7" />
-    <PackageReference Include="Nager.Country" Version="4.4.0" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageReference Include="Nager.Country" Version="4.7.1" />
     <PackageReference Include="Serialize.Linq" Version="4.0.167" />
   </ItemGroup>
 

--- a/src/VirtoCommerce.Platform.DistributedLock/VirtoCommerce.Platform.DistributedLock.csproj
+++ b/src/VirtoCommerce.Platform.DistributedLock/VirtoCommerce.Platform.DistributedLock.csproj
@@ -19,7 +19,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="StackExchange.Redis" Version="2.12.14" />
+    <PackageReference Include="StackExchange.Redis" Version="3.0.0" />
     <PackageReference Include="RedLock.net" Version="2.3.2" />
   </ItemGroup>
 

--- a/src/VirtoCommerce.Platform.Hangfire/VirtoCommerce.Platform.Hangfire.csproj
+++ b/src/VirtoCommerce.Platform.Hangfire/VirtoCommerce.Platform.Hangfire.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Hangfire.MySqlStorage" Version="2.0.3" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.21.1" />
     <PackageReference Include="HangFire.SqlServer" Version="1.8.23" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.Platform.Modules/VirtoCommerce.Platform.Modules.csproj
+++ b/src/VirtoCommerce.Platform.Modules/VirtoCommerce.Platform.Modules.csproj
@@ -22,9 +22,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.Platform.Security/VirtoCommerce.Platform.Security.csproj
+++ b/src/VirtoCommerce.Platform.Security/VirtoCommerce.Platform.Security.csproj
@@ -18,13 +18,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.7" />
-    <PackageReference Include="Microsoft.IdentityModel.Validators" Version="8.17.0" />
-    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.2.0" />
-    <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.9" />
+    <PackageReference Include="Microsoft.IdentityModel.Validators" Version="8.19.1" />
+    <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.5.0" />
+    <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="7.5.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
+++ b/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
@@ -18,44 +18,44 @@
 
   <!-- Added to bump to latest version sp other modules can consume them -->
   <ItemGroup>
-    <PackageReference Include="Azure.Core" Version="1.56.0" />
+    <PackageReference Include="Azure.Core" Version="1.59.0" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client.Core" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.7" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.7" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client.Core" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.9" />
     <PackageReference Include="Microsoft.Azure.SignalR" Version="1.33.0" />
-    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="10.0.9" />
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.32" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="10.0.7" />
-    <PackageReference Include="Microsoft.Identity.Client" Version="4.83.3" />
-    <PackageReference Include="Microsoft.OpenApi" Version="2.3.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Identity.Client" Version="4.84.2" />
+    <PackageReference Include="Microsoft.OpenApi" Version="[2.9.0, 3.0.0)" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="10.0.7" />
+    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="10.0.9" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="1.3.1" />
-    <PackageReference Include="OpenIddict.AspNetCore" Version="7.2.0" />
+    <PackageReference Include="OpenIddict.AspNetCore" Version="7.5.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
     <PackageReference Include="Serilog.Extensions.Hosting" Version="10.0.0" />
     <PackageReference Include="Serilog.Sinks.Console" Version="6.1.1" />
     <PackageReference Include="Serilog.Sinks.Debug" Version="3.0.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.1.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.1.0" />
+    <PackageReference Include="Swashbuckle.AspNetCore" Version="10.2.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Annotations" Version="10.2.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
-    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.1.0" />
-    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.1.0" />
-    <PackageReference Include="System.CodeDom" Version="10.0.7" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.7" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.7" />
-    <PackageReference Include="System.Management" Version="10.0.7" />
-    <PackageReference Include="System.Runtime.Caching" Version="10.0.7" />
-    <PackageReference Include="System.Security.Permissions" Version="10.0.7" />
-    <PackageReference Include="System.Windows.Extensions" Version="10.0.7" />
+    <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.2.1" />
+    <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.1" />
+    <PackageReference Include="System.CodeDom" Version="10.0.9" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.9" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
+    <PackageReference Include="System.Management" Version="10.0.9" />
+    <PackageReference Include="System.Runtime.Caching" Version="10.0.9" />
+    <PackageReference Include="System.Security.Permissions" Version="10.0.9" />
+    <PackageReference Include="System.Windows.Extensions" Version="10.0.9" />
     <PackageReference Include="VirtoCommerce.BuildWebpack" Version="1.0.0" />
   </ItemGroup>
 

--- a/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
+++ b/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
@@ -20,6 +20,7 @@
   <ItemGroup>
     <PackageReference Include="Azure.Core" Version="1.59.0" />
     <PackageReference Include="Azure.Identity" Version="1.21.0" />
+    <PackageReference Include="Pipelines.Sockets.Unofficial" Version="2.2.16" />
   </ItemGroup>
 
   <ItemGroup>

--- a/tests/VirtoCommerce.Platform.Caching.Tests/VirtoCommerce.Platform.Caching.Tests.csproj
+++ b/tests/VirtoCommerce.Platform.Caching.Tests/VirtoCommerce.Platform.Caching.Tests.csproj
@@ -10,7 +10,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/VirtoCommerce.Platform.Core.Tests/VirtoCommerce.Platform.Core.Tests.csproj
+++ b/tests/VirtoCommerce.Platform.Core.Tests/VirtoCommerce.Platform.Core.Tests.csproj
@@ -12,7 +12,7 @@
     </PackageReference>
     <!--Don't update. FluentAssertions 8+ requires a paid license for commercial use.-->
     <PackageReference Include="FluentAssertions" Version="[7.2.2, 8.0.0)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/VirtoCommerce.Platform.Tests/VirtoCommerce.Platform.Tests.csproj
+++ b/tests/VirtoCommerce.Platform.Tests/VirtoCommerce.Platform.Tests.csproj
@@ -16,9 +16,9 @@
     </PackageReference>
     <!--Don't update. FluentAssertions 8+ requires a paid license for commercial use.-->
     <PackageReference Include="FluentAssertions" Version="[7.2.2, 8.0.0)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
-    <PackageReference Include="MockQueryable.Moq" Version="10.0.5" />
+    <PackageReference Include="MockQueryable.Moq" Version="10.0.8" />
     <PackageReference Include="System.IO.Abstractions.TestingHelpers" Version="22.1.1" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">

--- a/tests/VirtoCommerce.Platform.Web.Tests/VirtoCommerce.Platform.Web.Tests.csproj
+++ b/tests/VirtoCommerce.Platform.Web.Tests/VirtoCommerce.Platform.Web.Tests.csproj
@@ -15,7 +15,7 @@
     </PackageReference>
     <!--Don't update. FluentAssertions 8+ requires a paid license for commercial use.-->
     <PackageReference Include="FluentAssertions" Version="[7.2.2, 8.0.0)" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.4.0" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">


### PR DESCRIPTION
## Description
fix: Bump 3rd party dependency to latest release

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5261
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Major **StackExchange.Redis 3.0** and **OpenIddict** updates touch caching, locks, SignalR, and auth stacks; broad EF/Npgsql bumps warrant regression on all DB providers and Redis-enabled deployments.
> 
> **Overview**
> Bumps **NuGet package versions** across platform, data, security, web, caching, Hangfire, and test projects—no application source changes in this diff.
> 
> **Microsoft / ASP.NET** packages move from **10.0.7 → 10.0.9** (EF Core, Identity, SignalR, JWT/OIDC, extensions, and related `System.*` references on **Platform.Web**). **dotnet-ef** CLI version in MySQL/PostgreSQL/SQL Server **Readme** files is updated to **10.0.9** to match.
> 
> **Notable non-patch bumps:** **StackExchange.Redis** **2.12.14 → 3.0.0** (Caching + DistributedLock; Web adds **Pipelines.Sockets.Unofficial** and keeps Redis-backed SignalR/data protection on 10.0.9). **OpenIddict** **7.2.0 → 7.5.0** on Security and Web. **Npgsql** / **Npgsql.EntityFrameworkCore.PostgreSQL** minor bumps. **Swashbuckle** **10.1.0 → 10.2.1**; **Microsoft.OpenApi** constrained to **`[2.9.0, 3.0.0)`**. **Azure.Core**, **Microsoft.Identity.Client**, **Microsoft.IdentityModel.Validators**, **Polly**, **Nager.Country**, and test **Microsoft.NET.Test.Sdk** / **MockQueryable.Moq** are also raised.
> 
> **VirtoCommerce.Platform.Data.MySql** gains an inline comment documenting the **Microting** vs **Pomelo** MySQL provider namespace change (package reference unchanged in this diff).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit c107e1f872af1f5e63a52c03f0a4cac0038112f8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1038.0-pr-3058-c107-vcst-5261-c107e1f8