### PR TITLE
VCST-5246: Move swagger validation to separate job

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -194,16 +194,6 @@ jobs:
         username: $GITHUB_ACTOR
         password: ${{ secrets.GITHUB_TOKEN }}
 
-    - name: Swagger validation
-      uses: VirtoCommerce/vc-github-actions/docker-env@master
-      if: ${{ github.ref == 'refs/heads/dev' }}
-      with:
-        githubUser: ${{ env.GITHUB_ACTOR }}
-        githubToken: ${{ env.GITHUB_TOKEN }}
-        platformDockerTag: ${{ env.DOCKER_TAG }}
-        platformImage: ${{ env.PACKAGE_SERVER }}/virtocommerce/platform
-        installSampleData: 'false'
-
     - name: Publish Nuget
       if: ${{ github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' }}
       uses: VirtoCommerce/vc-github-actions/publish-nuget@master
@@ -314,7 +304,7 @@ jobs:
     needs: ci
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.38
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-5246 #v3.800.38
     with:
       installModules: 'true'
       installCustomModule: 'false'
@@ -327,6 +317,33 @@ jobs:
       testSecretEnvFile: ${{ secrets.VC_TESTING_MODULE_ENV_FILE }}
       sendgridApiKey: ${{ secrets.SENDGRID_APIKEY_4E2E_AUTOTESTS }}
       appInsightsInstrumentationKey: ${{ secrets.E2E_APPINSIGHTSINSTRUMENTATIONKEY }}
+
+  swagger-validation:
+    if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push')) ||
+        (github.event_name == 'workflow_dispatch') || ((github.base_ref == 'dev') && (github.event_name == 'pull_request')) }}
+    needs: ci
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+    env:
+      GITHUB_TOKEN: ${{ secrets.REPO_TOKEN }}
+      DOCKER_TAG: ${{ needs.ci.outputs.tag }}
+      PACKAGE_SERVER: 'ghcr.io'
+    steps:
+      - name: Install VirtoCommerce.GlobalTool
+        uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
+
+      - name: Swagger validation
+        uses: VirtoCommerce/vc-github-actions/docker-env@VCST-5246 #master
+        if: ${{ github.ref == 'refs/heads/dev' }}
+        with:
+          appInsightsInstrumentationKey: ${{ secrets.E2E_APPINSIGHTSINSTRUMENTATIONKEY }}
+          githubUser: ${{ github.actor }}
+          githubToken: ${{ env.GITHUB_TOKEN }}
+          platformDockerTag: ${{ env.DOCKER_TAG }}
+          platformImage: ${{ env.PACKAGE_SERVER }}/virtocommerce/platform
+          installSampleData: 'false'
 
   deploy-cloud:
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -336,7 +336,6 @@ jobs:
 
       - name: Swagger validation
         uses: VirtoCommerce/vc-github-actions/docker-env@VCST-5246 #master
-        if: ${{ github.ref == 'refs/heads/dev' }}
         with:
           appInsightsInstrumentationKey: ${{ secrets.E2E_APPINSIGHTSINSTRUMENTATIONKEY }}
           githubUser: ${{ github.actor }}

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -343,9 +343,11 @@ jobs:
           installSampleData: 'false'
 
   deploy-cloud:
-    if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
-    needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.39    
+    if: ${{ !failure() && !cancelled() && (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
+    needs:
+      - ci
+      - swagger-validation
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.39
     with:
       releaseSource: platform
       platformVer: ${{ needs.ci.outputs.version }}

--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -1,5 +1,3 @@
-# v3.800.35
-# https://virtocommerce.atlassian.net/browse/VCST-5063
 name: Platform CI
 
 on:
@@ -304,7 +302,7 @@ jobs:
     needs: ci
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@VCST-5246 #v3.800.38
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.39
     with:
       installModules: 'true'
       installCustomModule: 'false'
@@ -335,7 +333,7 @@ jobs:
         uses: VirtoCommerce/vc-github-actions/setup-vcbuild@master
 
       - name: Swagger validation
-        uses: VirtoCommerce/vc-github-actions/docker-env@VCST-5246 #master
+        uses: VirtoCommerce/vc-github-actions/docker-env@master
         with:
           appInsightsInstrumentationKey: ${{ secrets.E2E_APPINSIGHTSINSTRUMENTATIONKEY }}
           githubUser: ${{ github.actor }}
@@ -347,7 +345,7 @@ jobs:
   deploy-cloud:
     if: ${{ (github.ref == 'refs/heads/master' || github.ref == 'refs/heads/main' || github.ref == 'refs/heads/dev') && github.event_name == 'push' }}
     needs: ci
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.38    
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.39    
     with:
       releaseSource: platform
       platformVer: ${{ needs.ci.outputs.version }}
@@ -372,7 +370,7 @@ jobs:
   trivy-scan:
     if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.38
+    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.39
     with:
       assigneeAccountId: '621c47c0302c6b006af0a1cd'
       assigneeEmailAddress: 'andrew.kubyshkin@virtoworks.com'

--- a/.github/workflows/platform-release-hotfix.yml
+++ b/.github/workflows/platform-release-hotfix.yml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.38    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.39    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.38    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.39    
     with:
       uploadPackage: 'true'
       uploadDocker: 'true'
@@ -47,7 +47,7 @@ jobs:
   publish-docker:
     needs:
       [build, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.38    
+    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.39    
     with:
       fullKey: ${{ needs.build.outputs.dockerFullKey }}
       shortKey: '${{ needs.build.outputs.dockerShortKey }}-'
@@ -61,7 +61,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.38    
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.39    
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.38 
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.39 
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.38 
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.39 
     with:
       uploadDocker: 'true'
     secrets:

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -41,7 +41,7 @@ jobs:
   publish:
     needs:
       get-cache-key
-    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.38
+    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.39
     with:
       fullKey: ${{ needs.get-cache-key.outputs.dockerFullKey }}
       shortKey: '${{ needs.get-cache-key.outputs.dockerShortKey }}-'
@@ -54,7 +54,7 @@ jobs:
   deploy-argoCD:
     needs:
       publish
-    uses: VirtoCommerce/.github/.github/workflows/deploy.yml@v3.800.38
+    uses: VirtoCommerce/.github/.github/workflows/deploy.yml@v3.800.39
     with:
       artifactUrl: ${{ needs.publish.outputs.imagePath }}
       matrix: '{"include":[{"envName": "qa", "confPath": "argoDeploy.json"}]}'
@@ -63,7 +63,7 @@ jobs:
   deploy-cloud:
     needs:
       [get-cache-key, publish]
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.38
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.39
     with:
       releaseSource: platform
       platformVer: ${{ needs.get-cache-key.outputs.version }}

--- a/.github/workflows/publish-nugets.yml
+++ b/.github/workflows/publish-nugets.yml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.38    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.39    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.38    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.39    
     with:
       uploadPackage: 'true'
       uploadDocker: 'false'
@@ -29,7 +29,7 @@ jobs:
   publish-nuget:
     needs:
       [build, test]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.38
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.39
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       forceGithub: false


### PR DESCRIPTION
## Description
Move swagger validation to a separate job run, run in parallel with auto-tests, to reduce execution time. Logging to Application Insights was added.
## References
### QA-test:
### Jira-link: https://virtocommerce.atlassian.net/browse/VCST-5246
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Cloud deploy is newly gated on swagger-validation success and runs on a broader set of events than the old dev-only in-job step, which can block or change when dev deployments run.
> 
> **Overview**
> **Swagger validation** is removed from the serial `ci` job and added as a dedicated **`swagger-validation`** job that runs after `ci` on the same triggers as auto-tests (dev push, `workflow_dispatch`, and PRs targeting `dev`). The step now passes **`appInsightsInstrumentationKey`** into `docker-env` for Application Insights logging.
> 
> **`deploy-cloud`** now **`needs: swagger-validation`** in addition to `ci`, and its `if` condition requires the workflow not be failed or cancelled before push deploys proceed—so cloud deploy waits on swagger validation finishing successfully.
> 
> Reusable workflow references are bumped from **`v3.800.38` to `v3.800.39`** across platform CI, hotfix, PR CI/deploy, and publish-nugets workflows.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 7e6fad708b018caa1562d0a1ddad1b841f018e2c. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1041.0-pr-3063-7e6f-vcst-5246-7e6fad70