### PR TITLE
VCST-5386: Detect unsupported PostgreSQL version via health check

### DIFF
--- a/src/VirtoCommerce.Platform.Data.PostgreSql/HealthCheck/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Data.PostgreSql/HealthCheck/NpgSqlHealthCheckBuilderExtensions.cs
@@ -11,6 +11,15 @@ public static class NpgSqlHealthCheckBuilderExtensions
 {
     private const string NAME = "npgsql";
     internal const string HEALTH_QUERY = "SELECT 1;";
+    internal const string VERSION_QUERY = "SHOW server_version_num;";
+
+    /// <summary>
+    /// Minimum supported PostgreSQL <c>server_version_num</c> (180000 = PostgreSQL 18.0).
+    /// User and role search use <c>LIKE</c> over a case-insensitive (nondeterministic) collation,
+    /// which is only supported by PostgreSQL 18 and later. Earlier versions reject it with
+    /// SqlState 0A000 'nondeterministic collations are not supported for LIKE'.
+    /// </summary>
+    public const int MinSupportedServerVersionNum = 180000;
 
     /// <summary>
     /// Add a health check for Postgres databases.
@@ -169,5 +178,47 @@ public static class NpgSqlHealthCheckBuilderExtensions
             failureStatus,
             tags,
             timeout));
+    }
+
+    /// <summary>
+    /// Add a health check for Postgres databases that also verifies the server version is supported.
+    /// Reports unhealthy when the server is older than <paramref name="minServerVersionNum"/>
+    /// (defaults to <see cref="MinSupportedServerVersionNum"/>).
+    /// </summary>
+    /// <param name="builder">The <see cref="IHealthChecksBuilder"/>.</param>
+    /// <param name="connectionString">The Postgres connection string to be used.</param>
+    /// <param name="minServerVersionNum">The minimum supported <c>server_version_num</c>. Optional.</param>
+    /// <param name="name">The health check name. Optional. If <c>null</c> the type name 'npgsql' will be used for the name.</param>
+    /// <param name="failureStatus">
+    /// The <see cref="HealthStatus"/> that should be reported when the health check fails. Optional. If <c>null</c> then
+    /// the default status of <see cref="HealthStatus.Unhealthy"/> will be reported.
+    /// </param>
+    /// <param name="tags">A list of tags that can be used to filter sets of health checks. Optional.</param>
+    /// <param name="timeout">An optional <see cref="TimeSpan"/> representing the timeout of the check.</param>
+    /// <returns>The specified <paramref name="builder"/>.</returns>
+    public static IHealthChecksBuilder AddNpgSqlVersionCheck(
+        this IHealthChecksBuilder builder,
+        string connectionString,
+        int minServerVersionNum = MinSupportedServerVersionNum,
+        string? name = default,
+        HealthStatus? failureStatus = default,
+        IEnumerable<string>? tags = default,
+        TimeSpan? timeout = default)
+    {
+        return builder.AddNpgSql(new NpgSqlHealthCheckOptions(connectionString)
+        {
+            // server_version_num is an integer, e.g. "170004" => 17.4, "180000" => 18.0
+            CommandText = VERSION_QUERY,
+            HealthCheckResultBuilder = result => BuildVersionHealthCheckResult(result, minServerVersionNum),
+        }, name, failureStatus, tags, timeout);
+    }
+
+    private static HealthCheckResult BuildVersionHealthCheckResult(object? result, int minServerVersionNum)
+    {
+        var versionNum = int.TryParse(result?.ToString(), out var v) ? v : 0;
+
+        return versionNum >= minServerVersionNum
+            ? HealthCheckResult.Healthy($"PostgreSQL OK")
+            : HealthCheckResult.Unhealthy($"PostgreSQL {versionNum} is not supported. Virto Commerce requires PostgreSQL ");
     }
 }

--- a/src/VirtoCommerce.Platform.Data.PostgreSql/HealthCheck/NpgSqlHealthCheckBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Data.PostgreSql/HealthCheck/NpgSqlHealthCheckBuilderExtensions.cs
@@ -219,6 +219,6 @@ public static class NpgSqlHealthCheckBuilderExtensions
 
         return versionNum >= minServerVersionNum
             ? HealthCheckResult.Healthy($"PostgreSQL OK")
-            : HealthCheckResult.Unhealthy($"PostgreSQL {versionNum} is not supported. Virto Commerce requires PostgreSQL ");
+            : HealthCheckResult.Unhealthy($"PostgreSQL {versionNum} is not supported. Virto Commerce requires PostgreSQL 18+.");
     }
 }

--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -651,7 +651,7 @@ namespace VirtoCommerce.Platform.Web
                         tags: ["Database"]);
                     break;
                 case "PostgreSql":
-                    healthBuilder.AddNpgSql(connectionString,
+                    healthBuilder.AddNpgSqlVersionCheck(connectionString,
                         name: "PostgreSql health",
                         failureStatus: HealthStatus.Unhealthy,
                         tags: ["Database"]);


### PR DESCRIPTION
## Description
fix: Detect unsupported PostgreSQL version (< 18) via health check

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5386
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Changes only affect the `/health` database check registration and messaging; application database access behavior is unchanged.
> 
> **Overview**
> PostgreSQL deployments now fail the **Database** health check when the server is below **18.0** (`server_version_num` &lt; 180000), instead of only verifying connectivity with `SELECT 1`.
> 
> A new `AddNpgSqlVersionCheck` extension runs `SHOW server_version_num` and maps the result through the existing `HealthCheckResultBuilder` hook on `NpgSqlHealthCheck`, exposing `MinSupportedServerVersionNum` (180000) with documentation tying the requirement to case-insensitive `LIKE` / nondeterministic collation support. **Startup** registers this version check for the `PostgreSql` `DatabaseProvider` path in place of the plain `AddNpgSql` call.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit da4082509f386009756d38e810cc584311bc381f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Image tag:
ghcr.io/VirtoCommerce/platform:3.1042.0-pr-3067-da40-vcst-5386-da408250