### PR TITLE
VCST-4923: Harden admin session validation to prevent stale-cookie user enumeration

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Security/AuthorizationOptions.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/AuthorizationOptions.cs
@@ -9,6 +9,25 @@ namespace VirtoCommerce.Platform.Core.Security
         public TimeSpan RefreshTokenLifeTime { get; set; }
         public TimeSpan AccessTokenLifeTime { get; set; }
 
+        /// <summary>
+        /// Interval after which the authentication cookie's security stamp is re-validated
+        /// against the store. Lower values reject stale or replayed cookies faster at the cost
+        /// of more frequent database calls. By default, 5 minutes.
+        /// </summary>
+        public TimeSpan SecurityStampValidationInterval { get; set; } = TimeSpan.FromMinutes(5);
+
+        /// <summary>
+        /// Lifetime of the application authentication cookie. With sliding expiration enabled,
+        /// this acts as the inactivity timeout. By default, 60 minutes.
+        /// </summary>
+        public TimeSpan CookieExpireTimeSpan { get; set; } = TimeSpan.FromMinutes(60);
+
+        /// <summary>
+        /// When true, the authentication cookie is reissued with a new expiration once a request
+        /// is made more than halfway through the expiration window. By default, true.
+        /// </summary>
+        public bool CookieSlidingExpiration { get; set; } = true;
+
         // LimitedPermissions claims that will be granted to the user by cookies when bearer token authentication is enabled.
         // This can help to authorize the user for direct(non - AJAX) GET requests to the VC platform API and / or to use some 3rd - party web applications for the VC platform(like Hangfire dashboard).
         //

--- a/src/VirtoCommerce.Platform.Security/ConfigureSecurityStampValidatorOptions.cs
+++ b/src/VirtoCommerce.Platform.Security/ConfigureSecurityStampValidatorOptions.cs
@@ -1,17 +1,24 @@
-using System;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.AspNetCore.Identity;
 using Microsoft.Extensions.Options;
+using VirtoCommerce.Platform.Core.Security;
 using VirtoCommerce.Platform.Security.Extensions;
 
 namespace VirtoCommerce.Platform.Security
 {
     public class ConfigureSecurityStampValidatorOptions : IConfigureOptions<SecurityStampValidatorOptions>
     {
+        private readonly AuthorizationOptions _authorizationOptions;
+
+        public ConfigureSecurityStampValidatorOptions(IOptions<AuthorizationOptions> authorizationOptions)
+        {
+            _authorizationOptions = authorizationOptions.Value;
+        }
+
         public void Configure(SecurityStampValidatorOptions options)
         {
-            options.ValidationInterval = TimeSpan.FromMinutes(30);
+            options.ValidationInterval = _authorizationOptions.SecurityStampValidationInterval;
 
             // When refreshing the principal, ensure custom claims that
             // might have been set with an external identity continue

--- a/src/VirtoCommerce.Platform.Web/Controllers/Api/SecurityController.cs
+++ b/src/VirtoCommerce.Platform.Web/Controllers/Api/SecurityController.cs
@@ -195,6 +195,10 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
             var user = await GetCurrentUserAsync();
             if (user != null)
             {
+                // Rotate the security stamp so any previously issued (and potentially captured)
+                // authentication cookie is rejected at the next security-stamp validation.
+                // This enforces server-side session revocation on logout.
+                await UserManager.UpdateSecurityStampAsync(user);
                 await _signInManager.SignOutAsync();
                 await _eventPublisher.Publish(new UserLogoutEvent(user));
             }

--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -545,6 +545,11 @@ namespace VirtoCommerce.Platform.Web
             services.ConfigureApplicationCookie(options =>
             {
                 options.Cookie.Name = platformOptions.ApplicationCookieName;
+                options.Cookie.HttpOnly = true;
+                options.Cookie.SecurePolicy = CookieSecurePolicy.Always;
+                options.Cookie.SameSite = SameSiteMode.Lax;
+                options.ExpireTimeSpan = authorizationOptions?.CookieExpireTimeSpan ?? TimeSpan.FromMinutes(60);
+                options.SlidingExpiration = authorizationOptions?.CookieSlidingExpiration ?? true;
                 options.LoginPath = "/";
             });
 

--- a/src/VirtoCommerce.Platform.Web/appsettings.json
+++ b/src/VirtoCommerce.Platform.Web/appsettings.json
@@ -271,6 +271,12 @@
     "ReturnPasswordHash": false,
     "RefreshTokenLifeTime": "30.00:00:00",
     "AccessTokenLifeTime": "00:30:00",
+    // Interval after which the authentication cookie's security stamp is re-validated against the store.
+    // Lower values reject stale or replayed cookies faster at the cost of more frequent database calls.
+    "SecurityStampValidationInterval": "00:05:00",
+    // Lifetime of the application authentication cookie. With sliding expiration this acts as the inactivity timeout.
+    "CookieExpireTimeSpan": "01:00:00",
+    "CookieSlidingExpiration": true,
     "LimitedCookiePermissions": "platform:asset:read;platform:export;content:read;platform:asset:create;licensing:issue;export:download",
     "AllowApiAccessForCustomers": false
   },


### PR DESCRIPTION
## Description
fix: Harden admin session validation to prevent stale-cookie user enumeration.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-4923
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **High Risk**
> Changes authentication cookie policy, security stamp validation frequency, and logout behavior—security-critical paths that affect all admin sessions and may impact local/dev HTTPS setups due to Secure cookies.
> 
> **Overview**
> **Hardens admin cookie authentication** so stale or replayed sessions are rejected sooner and logout invalidates captured cookies server-side.
> 
> New **`Authorization`** settings expose **`SecurityStampValidationInterval`** (default **5 minutes**, down from a hard-coded **30**), **`CookieExpireTimeSpan`**, and **`CookieSlidingExpiration`**. **`ConfigureSecurityStampValidatorOptions`** reads the interval from config instead of a fixed value. **`Logout`** now calls **`UpdateSecurityStampAsync`** before sign-out so old cookies fail the next stamp check.
> 
> Application cookies are tightened in **`Startup`**: **`HttpOnly`**, **`SecurePolicy.Always`**, **`SameSiteMode.Lax`**, plus expiration and sliding behavior wired from **`Authorization`** (with the same defaults as **`AuthorizationOptions`**). Sample values are documented in **`appsettings.json`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit a8a6ff5f1dae877a7133717e5e2e224ce7512f81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1042.0-pr-3068-a8a6-vcst-4923-a8a6ff5f