### PR TITLE
VCST-5427: Register dynamic property validator as singleton

### DIFF
--- a/src/VirtoCommerce.Platform.Data/DynamicProperties/ServiceCollectionExtenions.cs
+++ b/src/VirtoCommerce.Platform.Data/DynamicProperties/ServiceCollectionExtenions.cs
@@ -15,7 +15,7 @@ namespace VirtoCommerce.Platform.Data.DynamicProperties
             services.AddSingleton<IDynamicPropertyDictionaryItemsSearchService, DynamicPropertyDictionaryItemsSearchService>();
             services.AddSingleton<IDynamicPropertyDictionaryItemsService, DynamicPropertyDictionaryItemsService>();
             services.AddSingleton<IDynamicPropertyMetaDataResolver, DynamicPropertyMetaDataResolver>();
-            services.AddTransient<AbstractValidator<DynamicProperty>, DynamicPropertyTypeValidator>();
+            services.AddSingleton<AbstractValidator<DynamicProperty>, DynamicPropertyTypeValidator>();
 
             return services;
         }


### PR DESCRIPTION
## Summary

FluentValidation `AbstractValidator<T>` subclasses are stateless after construction — the rule tree is immutable and per-call state lives in the `ValidationContext`. Registered as transient, `DynamicPropertyTypeValidator` rebuilds its rule tree on every DI resolve.

## Changes

`ServiceCollectionExtenions.AddDynamicProperties`: `AddTransient` → `AddSingleton` for `AbstractValidator<DynamicProperty>` → `DynamicPropertyTypeValidator`. The validator has a parameterless constructor (no captive-dependency hazard), and this aligns it with every other registration in `AddDynamicProperties`, which are already singletons.

## Tests

Lifetime-only DI registration change — no validator rules, messages, or behavior changed.

Part of the same validator-lifetime effort as VirtoCommerce/vc-module-catalog#897 / VirtoCommerce/vc-module-customer#306.

Ref: VCST-5427.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> DI lifetime-only change with no validator rule or behavior modifications.
> 
> **Overview**
> Registers **`AbstractValidator<DynamicProperty>`** / **`DynamicPropertyTypeValidator`** as a **singleton** in **`AddDynamicProperties`** instead of **transient**, so the FluentValidation rule tree is built once per app rather than on every resolve.
> 
> **`DynamicPropertyTypeValidator`** uses a parameterless constructor and matches the other singleton registrations in the same extension method. Validation rules and runtime behavior are unchanged.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e2902744fc51815e7f6548607af698a5ccd2f753. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1048.0-pr-3073-e290-vcst-5427-e2902744
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5427