### PR TITLE
VCST-5439: Update Virto workflow versions

### DIFF
--- a/.github/workflows/platform-ci.yml
+++ b/.github/workflows/platform-ci.yml
@@ -302,7 +302,7 @@ jobs:
     needs: ci
     if: ${{ ((github.ref == 'refs/heads/dev') && (github.event_name == 'push') && (needs.ci.outputs.run-e2e == 'true')) ||
         (github.event_name == 'workflow_dispatch') || (github.base_ref == 'dev') && (github.event_name == 'pull_request') }}
-    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.39
+    uses: VirtoCommerce/.github/.github/workflows/pytest-tests.yml@v3.800.41
     with:
       installModules: 'true'
       installCustomModule: 'false'
@@ -347,7 +347,7 @@ jobs:
     needs:
       - ci
       - swagger-validation
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.39
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.41
     with:
       releaseSource: platform
       platformVer: ${{ needs.ci.outputs.version }}
@@ -372,7 +372,7 @@ jobs:
   trivy-scan:
     if: ${{ github.ref == 'refs/heads/dev' && github.event_name == 'push' }}
     needs: 'ci'
-    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.39
+    uses: VirtoCommerce/.github/.github/workflows/docker-image-vulnerability-process.yml@v3.800.41
     with:
       assigneeAccountId: '621c47c0302c6b006af0a1cd'
       assigneeEmailAddress: 'andrew.kubyshkin@virtoworks.com'

--- a/.github/workflows/platform-release-hotfix.yml
+++ b/.github/workflows/platform-release-hotfix.yml
@@ -13,12 +13,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.39    
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.41    
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.39    
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.41    
     with:
       uploadPackage: 'true'
       uploadDocker: 'true'
@@ -47,7 +47,7 @@ jobs:
   publish-docker:
     needs:
       [build, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.39    
+    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.41    
     with:
       fullKey: ${{ needs.build.outputs.dockerFullKey }}
       shortKey: '${{ needs.build.outputs.dockerShortKey }}-'
@@ -61,7 +61,7 @@ jobs:
   publish-github-release:
     needs:
       [build, test, get-metadata]
-    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.39    
+    uses: VirtoCommerce/.github/.github/workflows/publish-github.yml@v3.800.41    
     with:
       fullKey: ${{ needs.build.outputs.packageFullKey }}
       changeLog: '${{ needs.get-metadata.outputs.changeLog }}'

--- a/.github/workflows/pr-ci.yml
+++ b/.github/workflows/pr-ci.yml
@@ -17,12 +17,12 @@ on:
 
 jobs:
   test:
-    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.39 
+    uses: VirtoCommerce/.github/.github/workflows/test-and-sonar.yml@v3.800.41 
     secrets:
       sonarToken: ${{ secrets.SONAR_TOKEN }}
 
   build:
-    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.39 
+    uses: VirtoCommerce/.github/.github/workflows/build.yml@v3.800.41 
     with:
       uploadDocker: 'true'
     secrets:

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -41,7 +41,7 @@ jobs:
   publish:
     needs:
       get-cache-key
-    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.39
+    uses: VirtoCommerce/.github/.github/workflows/publish-docker.yml@v3.800.41
     with:
       fullKey: ${{ needs.get-cache-key.outputs.dockerFullKey }}
       shortKey: '${{ needs.get-cache-key.outputs.dockerShortKey }}-'
@@ -54,7 +54,7 @@ jobs:
   deploy-argoCD:
     needs:
       publish
-    uses: VirtoCommerce/.github/.github/workflows/deploy.yml@v3.800.39
+    uses: VirtoCommerce/.github/.github/workflows/deploy.yml@v3.800.41
     with:
       artifactUrl: ${{ needs.publish.outputs.imagePath }}
       matrix: '{"include":[{"envName": "qa", "confPath": "argoDeploy.json"}]}'
@@ -63,7 +63,7 @@ jobs:
   deploy-cloud:
     needs:
       [get-cache-key, publish]
-    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.39
+    uses: VirtoCommerce/.github/.github/workflows/deploy-cloud.yml@v3.800.41
     with:
       releaseSource: platform
       platformVer: ${{ needs.get-cache-key.outputs.version }}


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link: https://virtocommerce.atlassian.net/browse/VCST-5439
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Version-only pin updates for CI reusable workflows with no application or runtime code changes.
> 
> **Overview**
> Bumps all **reusable workflow** references from `VirtoCommerce/.github` from **`v3.800.39`** to **`v3.800.41`** across platform CI/CD pipelines.
> 
> Affected workflows: **`platform-ci.yml`** (pytest auto-tests, deploy-cloud, Trivy scan), **`platform-release-hotfix.yml`** (test, build, publish-docker, publish-github-release), **`pr-ci.yml`** (test, build), and **`pr-deploy.yml`** (publish-docker, deploy ArgoCD/cloud). No job inputs, secrets, or conditions are changed—only the pinned workflow tag.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fc39460fbdeecbe9aab04a277b74f2b0cdab0a2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Image tag:
ghcr.io/VirtoCommerce/platform:3.1044.0-pr-3074-6fc3-vcst-5439-6fc39460