### PR TITLE
Fix saving empty dictionary settings

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Settings/ObjectSettingEntry.cs
+++ b/src/VirtoCommerce.Platform.Core/Settings/ObjectSettingEntry.cs
@@ -24,7 +24,7 @@ namespace VirtoCommerce.Platform.Core.Settings
             IsHidden = descriptor.IsHidden;
             IsPublic = descriptor.IsPublic;
         }
-        public bool ItHasValues => Value != null || !AllowedValues.IsNullOrEmpty();
+        public bool ItHasValues => Value != null || (IsDictionary ? AllowedValues != null : !AllowedValues.IsNullOrEmpty());
         /// <summary>
         /// Setting may belong to any object in system
         /// </summary>

--- a/src/VirtoCommerce.Platform.Core/Settings/SettingsExtension.cs
+++ b/src/VirtoCommerce.Platform.Core/Settings/SettingsExtension.cs
@@ -85,7 +85,7 @@ namespace VirtoCommerce.Platform.Core.Settings
                 foreach (var haveSettingsObject in haveSettingsObjects.Where(x => x.Settings != null))
                 {
                     //Save settings
-                    foreach (var setting in haveSettingsObject.Settings.Where(x => !IsUntouchedEmptyDictionaryDefault(x, emptyDictionaryDefaults)))
+                    foreach (var setting in haveSettingsObject.Settings.Where(x => !x.IsUntouchedEmptyDictionaryDefault(emptyDictionaryDefaults)))
                     {
                         setting.ObjectId = haveSettingsObject.Id;
                         setting.ObjectType = haveSettingsObject.TypeName;
@@ -99,7 +99,10 @@ namespace VirtoCommerce.Platform.Core.Settings
             }
         }
 
-        private static bool IsUntouchedEmptyDictionaryDefault(ObjectSettingEntry setting, ISet<string> emptyDictionaryDefaults)
+        /// <summary>
+        /// Determines whether the setting represents an untouched empty dictionary default.
+        /// </summary>
+        private static bool IsUntouchedEmptyDictionaryDefault(this ObjectSettingEntry setting, HashSet<string> emptyDictionaryDefaults)
         {
             return setting.Id == null &&
                    setting.IsDictionary &&

--- a/src/VirtoCommerce.Platform.Core/Settings/SettingsExtension.cs
+++ b/src/VirtoCommerce.Platform.Core/Settings/SettingsExtension.cs
@@ -85,17 +85,8 @@ namespace VirtoCommerce.Platform.Core.Settings
                 foreach (var haveSettingsObject in haveSettingsObjects.Where(x => x.Settings != null))
                 {
                     //Save settings
-                    foreach (var setting in haveSettingsObject.Settings)
+                    foreach (var setting in haveSettingsObject.Settings.Where(x => !IsUntouchedEmptyDictionaryDefault(x, emptyDictionaryDefaults)))
                     {
-                        // Do not turn an untouched empty dictionary default into an explicit DB override.
-                        if (setting.Id == null &&
-                            setting.IsDictionary &&
-                            setting.AllowedValues is { Length: 0 } &&
-                            emptyDictionaryDefaults.Contains(setting.Name))
-                        {
-                            continue;
-                        }
-
                         setting.ObjectId = haveSettingsObject.Id;
                         setting.ObjectType = haveSettingsObject.TypeName;
                         forSaveSettings.Add(setting);
@@ -106,6 +97,14 @@ namespace VirtoCommerce.Platform.Core.Settings
             {
                 await manager.SaveObjectSettingsAsync(forSaveSettings);
             }
+        }
+
+        private static bool IsUntouchedEmptyDictionaryDefault(ObjectSettingEntry setting, ISet<string> emptyDictionaryDefaults)
+        {
+            return setting.Id == null &&
+                   setting.IsDictionary &&
+                   setting.AllowedValues is { Length: 0 } &&
+                   emptyDictionaryDefaults.Contains(setting.Name);
         }
 
         /// <summary>

--- a/src/VirtoCommerce.Platform.Core/Settings/SettingsExtension.cs
+++ b/src/VirtoCommerce.Platform.Core/Settings/SettingsExtension.cs
@@ -73,6 +73,11 @@ namespace VirtoCommerce.Platform.Core.Settings
             }
 
             var forSaveSettings = new List<ObjectSettingEntry>();
+            var emptyDictionaryDefaults = manager.AllRegisteredSettings
+                .Where(x => x.IsDictionary && x.AllowedValues is { Length: 0 })
+                .Select(x => x.Name)
+                .ToHashSet(StringComparer.OrdinalIgnoreCase);
+
             foreach (var entry in entries)
             {
                 var haveSettingsObjects = entry.GetFlatObjectsListWithInterface<IHasSettings>();
@@ -82,6 +87,15 @@ namespace VirtoCommerce.Platform.Core.Settings
                     //Save settings
                     foreach (var setting in haveSettingsObject.Settings)
                     {
+                        // Do not turn an untouched empty dictionary default into an explicit DB override.
+                        if (setting.Id == null &&
+                            setting.IsDictionary &&
+                            setting.AllowedValues is { Length: 0 } &&
+                            emptyDictionaryDefaults.Contains(setting.Name))
+                        {
+                            continue;
+                        }
+
                         setting.ObjectId = haveSettingsObject.Id;
                         setting.ObjectType = haveSettingsObject.TypeName;
                         forSaveSettings.Add(setting);

--- a/src/VirtoCommerce.Platform.Data/Settings/LocalizableSettingService.cs
+++ b/src/VirtoCommerce.Platform.Data/Settings/LocalizableSettingService.cs
@@ -238,12 +238,6 @@ public class LocalizableSettingService : ILocalizableSettingService
 
     private async Task SaveSetting(ObjectSettingEntry setting)
     {
-        // Workaround for saving an empty list of allowed values
-        if (setting.AllowedValues.IsNullOrEmpty() && setting.Value == null)
-        {
-            setting.Value = string.Empty;
-        }
-
         await _settingsManager.SaveObjectSettingsAsync([setting]);
     }
 


### PR DESCRIPTION
## Description
Fixed an issue where clearing all values of a dictionary setting returned a successful response but did not persist the empty list.
Updated the settings value detection logic so an empty AllowedValues array is treated as a valid dictionary value. Also removed the obsolete workaround that used an empty scalar value to force saving.
## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5441
### Artifact URL:

Image tag:
ghcr.io/VirtoCommerce/platform:3.1044.0-pr-3076-3479-vcst-5441-347993a4