### PR TITLE
VCST-5471: Widget tiles overlap, some widget disappears

### DIFF
--- a/src/VirtoCommerce.Platform.Web/npm-shrinkwrap.json
+++ b/src/VirtoCommerce.Platform.Web/npm-shrinkwrap.json
@@ -3563,9 +3563,9 @@
       "license": "MIT"
     },
     "node_modules/ws": {
-      "version": "6.2.3",
-      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.3.tgz",
-      "integrity": "sha512-jmTjYU0j60B+vHey6TfR3Z7RD61z/hmxBS3VMSGIrroOWXQEneK1zNuotOUrGyBHQj0yrpsLHPWtigEFd13ndA==",
+      "version": "6.2.5",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-6.2.5.tgz",
+      "integrity": "sha512-T7pPl+DnmNrKRuttAIQwueReX5GqsedYEWp3/H//CG35+DyUOe1+/voAeE8idxgfLsQf2tO+rdtBd1FnPopgTQ==",
       "license": "MIT",
       "dependencies": {
         "async-limiter": "~1.0.0"

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/app.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/app.js
@@ -530,7 +530,11 @@ angular.module('platformWebApp', AppDependencies).controller('platformWebApp.app
             gridsterConfig.colWidth = 130;
             gridsterConfig.defaultSizeX = 1;
             gridsterConfig.resizable = { enabled: false, handles: [] };
-            gridsterConfig.maxRows = 8;
+            // Must comfortably exceed the number of cells widgets can occupy in the most
+            // populated container (itemDetail easily exceeds 32 cells = 8 rows x 4 columns
+            // with many modules installed). When the grid is full, gridster throws
+            // "Unable to place item!" and renders the leftover widgets on top of each other.
+            gridsterConfig.maxRows = 24;
             gridsterConfig.mobileModeEnabled = false;
             gridsterConfig.outerMargin = false;
 

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/navigation/widget/widget.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/navigation/widget/widget.js
@@ -78,11 +78,6 @@ angular.module('platformWebApp')
                 return (prefix + widget.controller + widget.template + scope.group).hashCode();
             }
 
-            // Persisted row/col may no longer fit the current grid (widget set changed,
-            // module uninstalled, layout saved by an older version). Gridster clamps
-            // out-of-bounds coordinates into the last row/column ON TOP of already
-            // occupied cells, so widgets render overlapped. Drop such positions and let
-            // gridster auto-place the widget instead.
             function resetInvalidStoredPosition(widget) {
                 var columns = scope.gridsterOpts.columns || gridsterConfig.columns;
                 var maxRows = scope.gridsterOpts.maxRows || gridsterConfig.maxRows;
@@ -92,6 +87,7 @@ angular.module('platformWebApp')
                 var colKey = scope.getKey('col', widget);
                 var row = scope.$storage[rowKey];
                 var col = scope.$storage[colKey];
+                
                 if (angular.isDefined(row) || angular.isDefined(col)) {
                     var valid = angular.isNumber(row) && angular.isNumber(col) &&
                         row >= 0 && col >= 0 && row + sizeY <= maxRows && col + sizeX <= columns;

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/navigation/widget/widget.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/navigation/widget/widget.js
@@ -91,6 +91,7 @@ angular.module('platformWebApp')
                 if (angular.isDefined(row) || angular.isDefined(col)) {
                     var valid = angular.isNumber(row) && angular.isNumber(col) &&
                         row >= 0 && col >= 0 && row + sizeY <= maxRows && col + sizeX <= columns;
+                    
                     if (!valid) {
                         delete scope.$storage[rowKey];
                         delete scope.$storage[colKey];
@@ -101,12 +102,15 @@ angular.module('platformWebApp')
             var renderedWidgetsKey = null;
             function refreshWidgets() {
                 var groupWidgets = _.filter(widgetService.widgetsMap[scope.group], function (w) { return !angular.isFunction(w.isVisible) || w.isVisible(scope.blade); });
+                
                 // re-render only when the set of visible widgets actually changed
                 var widgetsKey = _.map(groupWidgets, function (w) { return w.controller + w.template; }).join('|');
                 if (widgetsKey === renderedWidgetsKey) {
                     return;
                 }
+                
                 renderedWidgetsKey = widgetsKey;
+                
                 scope.widgets = angular.copy(groupWidgets);
                 angular.forEach(scope.widgets, function (w) {
                     w.blade = scope.blade;
@@ -116,11 +120,6 @@ angular.module('platformWebApp')
             }
 
             scope.$watch('gridsterOpts', refreshWidgets, true);
-            // Widgets are filtered by isVisible() which commonly calls
-            // authService.checkPermission(). When a blade is opened by a deep link
-            // (e.g. #!/workspace/catalog?productId=...), this directive links before
-            // the current user (and their permissions) is loaded, so such widgets get
-            // filtered out and never come back. Re-evaluate when auth state arrives.
             scope.$on('loginStatusChanged', refreshWidgets);
 
             // Deterministic color marker grouped by MODULE, so all widgets from the same

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/navigation/widget/widget.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/navigation/widget/widget.js
@@ -59,7 +59,7 @@ angular.module('platformWebApp')
     };
     return retVal;
 })
-.directive('vaWidgetContainer', ['$compile', '$localStorage', 'platformWebApp.widgetService', 'platformWebApp.widgetColorPalette', function ($compile, $localStorage, widgetService, widgetColorPalette) {
+.directive('vaWidgetContainer', ['$compile', '$localStorage', 'platformWebApp.widgetService', 'platformWebApp.widgetColorPalette', 'gridsterConfig', function ($compile, $localStorage, widgetService, widgetColorPalette, gridsterConfig) {
     return {
         restrict: 'E',
         replace: true,
@@ -74,18 +74,58 @@ angular.module('platformWebApp')
             if (!scope.gridsterOpts) { scope.gridsterOpts = {}; }
             scope.$storage = $localStorage;
 
-            scope.$watch('gridsterOpts', function () {
+            scope.getKey = function (prefix, widget) {
+                return (prefix + widget.controller + widget.template + scope.group).hashCode();
+            }
+
+            // Persisted row/col may no longer fit the current grid (widget set changed,
+            // module uninstalled, layout saved by an older version). Gridster clamps
+            // out-of-bounds coordinates into the last row/column ON TOP of already
+            // occupied cells, so widgets render overlapped. Drop such positions and let
+            // gridster auto-place the widget instead.
+            function resetInvalidStoredPosition(widget) {
+                var columns = scope.gridsterOpts.columns || gridsterConfig.columns;
+                var maxRows = scope.gridsterOpts.maxRows || gridsterConfig.maxRows;
+                var sizeX = (widget.size && widget.size[0]) || gridsterConfig.defaultSizeX;
+                var sizeY = (widget.size && widget.size[1]) || gridsterConfig.defaultSizeY;
+                var rowKey = scope.getKey('row', widget);
+                var colKey = scope.getKey('col', widget);
+                var row = scope.$storage[rowKey];
+                var col = scope.$storage[colKey];
+                if (angular.isDefined(row) || angular.isDefined(col)) {
+                    var valid = angular.isNumber(row) && angular.isNumber(col) &&
+                        row >= 0 && col >= 0 && row + sizeY <= maxRows && col + sizeX <= columns;
+                    if (!valid) {
+                        delete scope.$storage[rowKey];
+                        delete scope.$storage[colKey];
+                    }
+                }
+            }
+
+            var renderedWidgetsKey = null;
+            function refreshWidgets() {
                 var groupWidgets = _.filter(widgetService.widgetsMap[scope.group], function (w) { return !angular.isFunction(w.isVisible) || w.isVisible(scope.blade); });
+                // re-render only when the set of visible widgets actually changed
+                var widgetsKey = _.map(groupWidgets, function (w) { return w.controller + w.template; }).join('|');
+                if (widgetsKey === renderedWidgetsKey) {
+                    return;
+                }
+                renderedWidgetsKey = widgetsKey;
                 scope.widgets = angular.copy(groupWidgets);
                 angular.forEach(scope.widgets, function (w) {
                     w.blade = scope.blade;
                     w.widgetsInContainer = scope.widgets;
+                    resetInvalidStoredPosition(w);
                 });
-            }, true);
-
-            scope.getKey = function (prefix, widget) {
-                return (prefix + widget.controller + widget.template + scope.group).hashCode();
             }
+
+            scope.$watch('gridsterOpts', refreshWidgets, true);
+            // Widgets are filtered by isVisible() which commonly calls
+            // authService.checkPermission(). When a blade is opened by a deep link
+            // (e.g. #!/workspace/catalog?productId=...), this directive links before
+            // the current user (and their permissions) is loaded, so such widgets get
+            // filtered out and never come back. Re-evaluate when auth state arrives.
+            scope.$on('loginStatusChanged', refreshWidgets);
 
             // Deterministic color marker grouped by MODULE, so all widgets from the same
             // module share one color. The module is the controller prefix up to the


### PR DESCRIPTION
## Description
fix: Widget tiles overlap, some widget disappears

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5471
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Admin UI widget layout only; no auth, API, or data-model changes beyond clearing stale layout keys in browser storage.
> 
> **Overview**
> Fixes **widget tiles overlapping or disappearing** on dense blades (e.g. item detail with many modules) when angular-gridster could not place every tile.
> 
> **Global gridster capacity** in `app.js` raises `gridsterConfig.maxRows` from **8 to 24** so the default 4-column layout can hold more than ~32 cells before gridster fails with "Unable to place item!" and stacks widgets.
> 
> **`vaWidgetContainer`** in `widget.js` now injects `gridsterConfig`, clears **invalid row/column values** from `$localStorage` when they fall outside the current grid bounds (including after the maxRows change), and uses a **`refreshWidgets`** path that only rebuilds the widget list when the visible widget set changes. Widget refresh runs on `gridsterOpts` deep watch and on **`loginStatusChanged`**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 56255251d01e790015a00d5e3d965f24af8b7ca0. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1046.0-pr-3078-563c-vcst-5471-563c6a3b