### PR TITLE
fix(VCST-5495): dismiss other transient overlay when opening filter panel or row context menu

### DIFF
--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/filterPanel.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/filterPanel.js
@@ -1,5 +1,10 @@
 angular.module('platformWebApp')
-    .directive('vaFilterPanel', ['$document', function ($document) {
+    .directive('vaFilterPanel', ['$document', '$rootScope', function ($document, $rootScope) {
+        // Shared coordination event so only one transient overlay (this filter panel,
+        // a row context menu, ...) is visible at a time. Payload is the opener's kind;
+        // an overlay ignores events from its own kind (same-kind coordination is handled locally).
+        var overlayOpenedEvent = 'platformWebApp.transientOverlay.opened';
+        var overlayKind = 'filterPanel';
         return {
             restrict: 'E',
             templateUrl: '$(Platform)/Scripts/common/directives/filterPanel.tpl.html',
@@ -21,6 +26,10 @@ angular.module('platformWebApp')
                         $event.stopPropagation();
                     }
                     scope.showPanel = !scope.showPanel;
+                    if (scope.showPanel) {
+                        // Opening this panel dismisses any other open transient overlay.
+                        $rootScope.$broadcast(overlayOpenedEvent, overlayKind);
+                    }
                 };
 
                 scope.clearFilters = function () {
@@ -37,9 +46,17 @@ angular.module('platformWebApp')
                     }
                 }
 
+                // Close this panel when another kind of transient overlay opens.
+                var unsubscribeOverlay = scope.$on(overlayOpenedEvent, function (event, sourceKind) {
+                    if (sourceKind !== overlayKind && scope.showPanel) {
+                        scope.showPanel = false;
+                    }
+                });
+
                 $document.on('click', onDocumentClick);
                 scope.$on('$destroy', function () {
                     $document.off('click', onDocumentClick);
+                    unsubscribeOverlay();
                 });
             }
         };

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/left-click-menu.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/common/directives/left-click-menu.js
@@ -1,7 +1,12 @@
 // leftClickMenu based on: ng-context-menu - v1.0.2 - An AngularJS directive to display a context menu when a right-click event is triggered
 angular
     .module('platformWebApp')
-    .directive("leftClickMenu", ["$document", "ContextMenuService", function ($document, ContextMenuService) {
+    .directive("leftClickMenu", ["$document", "ContextMenuService", "$rootScope", function ($document, ContextMenuService, $rootScope) {
+        // Shared coordination event so only one transient overlay (this context menu,
+        // the filter panel, ...) is visible at a time. Payload is the opener's kind;
+        // an overlay ignores events from its own kind (same-kind coordination is handled locally).
+        var overlayOpenedEvent = 'platformWebApp.transientOverlay.opened';
+        var overlayKind = 'contextMenu';
         return {
             restrict: 'A',
             scope: {
@@ -84,6 +89,8 @@ angular
                         });
                         $scope.$apply(function () {
                             open(event, ContextMenuService.menuElement);
+                            // Opening this menu dismisses any other open transient overlay.
+                            $rootScope.$broadcast(overlayOpenedEvent, overlayKind);
                         });
                     }
                 });
@@ -107,6 +114,13 @@ angular
                     }
                 }
 
+                // Close this menu when another kind of transient overlay opens.
+                var unsubscribeOverlay = $scope.$on(overlayOpenedEvent, function (event, sourceKind) {
+                    if (sourceKind !== overlayKind && opened) {
+                        close(ContextMenuService.menuElement);
+                    }
+                });
+
                 $document.bind('keyup', handleKeyUpEvent);
                 // Firefox treats a right-click as a click and a contextmenu event
                 // while other browsers just treat it as a contextmenu event
@@ -117,6 +131,7 @@ angular
                     $document.unbind('keyup', handleKeyUpEvent);
                     $document.unbind('click', handleClickEvent);
                     $document.unbind('contextmenu', handleClickEvent);
+                    unsubscribeOverlay();
                 });
             }
         };


### PR DESCRIPTION
## VCST-5495 — Contacts filter panel & row "⋮" menu overlap

**DO NOT MERGE until human review.** Opened by `/qa-fix` (autonomous bug-fix), awaiting human review — never auto-merged.

### Problem
In the Contacts (`vc-module-customer`) Admin SPA list blade, the **filter panel** (funnel) and a grid **row "⋮" context menu** could be open at the same time and overlap. Only one transient overlay should be visible at a time.

### Root cause
Both overlays are shared platform directives that close only on an *outside document click*, but each open-trigger calls `stopPropagation()` on its own click — which blocks the **other** overlay's document-level close handler from ever seeing that click:
- `filterPanel.js` (`vaFilterPanel`) — `togglePanel` calls `$event.stopPropagation()`
- `left-click-menu.js` (`leftClickMenu`) — the open-click calls `event.stopPropagation()`

So opening one leaves the other open. The defect is symmetric and latent in **every** admin blade that uses both directives; Contacts is just where it surfaced (customer request VP-9230 / Infosys).

### Fix
A minimal, symmetric coordination on `$rootScope`: opening either overlay broadcasts a **kind-tagged** event `platformWebApp.transientOverlay.opened`; each directive listens and closes itself only when the source kind differs. Keying on *kind* (not instance) leaves same-kind context-menu row-to-row replacement (`ContextMenuService`) untouched.

- 2 files, +34/−2 · `$rootScope` newly injected into both directives · listeners torn down on `$destroy`.
- No public contract change (directive names, `restrict`, isolate scope, template, transclude, DOM all unchanged).
- Digest-safe (broadcasts fire from within existing digests; listeners mutate scope directly, no nested `$apply`); no broadcast loop (close paths never re-broadcast).

### Verification
- **Reproduced red → green** via a throwaway Node/jsdom scratch harness that replays the real target-then-document event flow (uncommitted): panel-then-menu ✓, menu-then-funnel ✓, row-to-row switching preserved ✓.
- `node --check` clean on both files. vc-platform has no JS unit-test harness for these directives; **no existing tests modified**.
- Gate-4 code review: **APPROVE** (single-repo, minimal, idiomatic, non-breaking, BL/UX preserved).

### needs deploy verification
This is a shared-directive JS change — the live symptom needs a redeployed platform to re-confirm across blades. Final confirmation via the regression pipeline + `/qa-verify-fix VCST-5495` once deployed. The widened behavior (one transient overlay at a time) is the intended universal UX invariant.

Fixes VCST-5495.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Image tag:
ghcr.io/VirtoCommerce/platform:3.1045.0-pr-3079-7db6-vcst-5495-7db6828e
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5495