### PR TITLE
VCST-5522: Bump .NET to 10.0.10

### DIFF
--- a/src/VirtoCommerce.Platform.Caching/VirtoCommerce.Platform.Caching.csproj
+++ b/src/VirtoCommerce.Platform.Caching/VirtoCommerce.Platform.Caching.csproj
@@ -17,7 +17,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Caching.Memory" Version="10.0.10" />
     <PackageReference Include="Polly" Version="8.7.0" />
     <PackageReference Include="StackExchange.Redis" Version="3.0.0" />
   </ItemGroup>

--- a/src/VirtoCommerce.Platform.Data.MySql/Readme.md
+++ b/src/VirtoCommerce.Platform.Data.MySql/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.9
+dotnet tool install --global dotnet-ef --version 10.0.10
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.9
+dotnet tool update --global dotnet-ef --version 10.0.10
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.Platform.Data.MySql/VirtoCommerce.Platform.Data.MySql.csproj
+++ b/src/VirtoCommerce.Platform.Data.MySql/VirtoCommerce.Platform.Data.MySql.csproj
@@ -8,12 +8,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
     <!-- Breaking Change: After 10.0.5 Microting changed assembly name and C# namespaces from Pomelo.EntityFrameworkCore.MySql to Microting.EntityFrameworkCore.MySql. -->
     <PackageReference Include="Microting.EntityFrameworkCore.MySql" Version="10.0.5" />
   </ItemGroup>

--- a/src/VirtoCommerce.Platform.Data.PostgreSql/Readme.md
+++ b/src/VirtoCommerce.Platform.Data.PostgreSql/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.9
+dotnet tool install --global dotnet-ef --version 10.0.10
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.9
+dotnet tool update --global dotnet-ef --version 10.0.10
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.Platform.Data.PostgreSql/VirtoCommerce.Platform.Data.PostgreSql.csproj
+++ b/src/VirtoCommerce.Platform.Data.PostgreSql/VirtoCommerce.Platform.Data.PostgreSql.csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/src/VirtoCommerce.Platform.Data.SqlServer/Readme.md
+++ b/src/VirtoCommerce.Platform.Data.SqlServer/Readme.md
@@ -2,13 +2,13 @@
 
 ## Install CLI tools for Entity Framework Core
 ```cmd
-dotnet tool install --global dotnet-ef --version 10.0.9
+dotnet tool install --global dotnet-ef --version 10.0.10
 ```
 
 or update
 
 ```cmd
-dotnet tool update --global dotnet-ef --version 10.0.9
+dotnet tool update --global dotnet-ef --version 10.0.10
 ```
 
 ## Add Migration

--- a/src/VirtoCommerce.Platform.Data.SqlServer/VirtoCommerce.Platform.Data.SqlServer.csproj
+++ b/src/VirtoCommerce.Platform.Data.SqlServer/VirtoCommerce.Platform.Data.SqlServer.csproj
@@ -8,11 +8,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.9">
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="10.0.10">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.Platform.Data/VirtoCommerce.Platform.Data.csproj
+++ b/src/VirtoCommerce.Platform.Data/VirtoCommerce.Platform.Data.csproj
@@ -21,8 +21,8 @@
     <PackageReference Include="EntityFrameworkCore.Triggers" Version="1.2.3" />
     <PackageReference Include="FluentValidation" Version="12.1.1" />
     <PackageReference Include="Humanizer.Core" Version="3.0.10" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.9" />
-    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.9" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="10.0.10" />
     <PackageReference Include="Nager.Country" Version="4.7.1" />
     <PackageReference Include="Serialize.Linq" Version="4.0.167" />
   </ItemGroup>

--- a/src/VirtoCommerce.Platform.Hangfire/VirtoCommerce.Platform.Hangfire.csproj
+++ b/src/VirtoCommerce.Platform.Hangfire/VirtoCommerce.Platform.Hangfire.csproj
@@ -26,7 +26,7 @@
     <PackageReference Include="Hangfire.MySqlStorage" Version="2.0.3" />
     <PackageReference Include="Hangfire.PostgreSql" Version="1.21.1" />
     <PackageReference Include="HangFire.SqlServer" Version="1.8.23" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.Platform.Modules/VirtoCommerce.Platform.Modules.csproj
+++ b/src/VirtoCommerce.Platform.Modules/VirtoCommerce.Platform.Modules.csproj
@@ -22,9 +22,9 @@
 
   <ItemGroup>
     <PackageReference Include="Microsoft.DotNet.PlatformAbstractions" Version="3.1.6" />
-    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyModel" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Abstractions" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Options" Version="10.0.10" />
   </ItemGroup>
 
   <ItemGroup>

--- a/src/VirtoCommerce.Platform.Security/VirtoCommerce.Platform.Security.csproj
+++ b/src/VirtoCommerce.Platform.Security/VirtoCommerce.Platform.Security.csproj
@@ -18,10 +18,10 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.9" />
-    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Authorization" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Identity.EntityFrameworkCore" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Mvc.NewtonsoftJson" Version="10.0.10" />
+    <PackageReference Include="Microsoft.Extensions.Identity.Core" Version="10.0.10" />
     <PackageReference Include="Microsoft.IdentityModel.Validators" Version="8.19.1" />
     <PackageReference Include="OpenIddict.EntityFrameworkCore" Version="7.5.0" />
     <PackageReference Include="OpenIddict.Validation.AspNetCore" Version="7.5.0" />

--- a/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
+++ b/src/VirtoCommerce.Platform.Web/VirtoCommerce.Platform.Web.csproj
@@ -23,21 +23,21 @@
   </ItemGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client.Core" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.9" />
-    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.9" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.JwtBearer" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.Authentication.OpenIdConnect" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.DataProtection.StackExchangeRedis" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Client.Core" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.Protocols.NewtonsoftJson" Version="10.0.10" />
+    <PackageReference Include="Microsoft.AspNetCore.SignalR.StackExchangeRedis" Version="10.0.10" />
     <PackageReference Include="Microsoft.Azure.SignalR" Version="1.33.0" />
-    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Bcl.TimeProvider" Version="10.0.10" />
     <PackageReference Include="Microsoft.Extensions.DiagnosticAdapter" Version="3.1.32" />
-    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Extensions.Logging.AzureAppServices" Version="10.0.10" />
     <PackageReference Include="Microsoft.Identity.Client" Version="4.84.2" />
     <PackageReference Include="Microsoft.OpenApi" Version="[2.9.0, 3.0.0)" />
     <PackageReference Include="Microsoft.VisualStudio.Azure.Containers.Tools.Targets" Version="1.23.0" />
-    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="10.0.9" />
+    <PackageReference Include="Microsoft.Win32.SystemEvents" Version="10.0.10" />
     <PackageReference Include="NetEscapades.AspNetCore.SecurityHeaders" Version="1.3.1" />
     <PackageReference Include="OpenIddict.AspNetCore" Version="7.5.0" />
     <PackageReference Include="Serilog.AspNetCore" Version="10.0.0" />
@@ -49,13 +49,13 @@
     <PackageReference Include="Swashbuckle.AspNetCore.Filters" Version="10.0.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.Newtonsoft" Version="10.2.1" />
     <PackageReference Include="Swashbuckle.AspNetCore.SwaggerGen" Version="10.2.1" />
-    <PackageReference Include="System.CodeDom" Version="10.0.9" />
-    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.9" />
-    <PackageReference Include="System.Drawing.Common" Version="10.0.9" />
-    <PackageReference Include="System.Management" Version="10.0.9" />
-    <PackageReference Include="System.Runtime.Caching" Version="10.0.9" />
-    <PackageReference Include="System.Security.Permissions" Version="10.0.9" />
-    <PackageReference Include="System.Windows.Extensions" Version="10.0.9" />
+    <PackageReference Include="System.CodeDom" Version="10.0.10" />
+    <PackageReference Include="System.Diagnostics.PerformanceCounter" Version="10.0.10" />
+    <PackageReference Include="System.Drawing.Common" Version="10.0.10" />
+    <PackageReference Include="System.Management" Version="10.0.10" />
+    <PackageReference Include="System.Runtime.Caching" Version="10.0.10" />
+    <PackageReference Include="System.Security.Permissions" Version="10.0.10" />
+    <PackageReference Include="System.Windows.Extensions" Version="10.0.10" />
     <PackageReference Include="VirtoCommerce.BuildWebpack" Version="1.0.0" />
   </ItemGroup>
 


### PR DESCRIPTION
## Description
fix: Bump .NET to 10.0.10

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5522
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Patch-level dependency bumps touch auth, Identity, EF Core, and the web host across the solution; risk is typical for a coordinated runtime update rather than localized code changes.
> 
> **Overview**
> Bumps the platform from **10.0.9** to **10.0.10** across Microsoft package references, with no application code changes.
> 
> **Entity Framework & data:** `Microsoft.EntityFrameworkCore`, relational/design, and SQL Server provider packages move to **10.0.10** in `VirtoCommerce.Platform.Data` and the MySql, PostgreSql, and SqlServer data projects. Migration READMEs for those providers now document installing/updating the global `dotnet-ef` tool at **10.0.10**.
> 
> **ASP.NET Core, extensions, and system:** `VirtoCommerce.Platform.Web` updates auth (JWT/OpenId Connect), SignalR, data protection, logging, and several `System.*` packages. **Security** bumps Identity/Authorization/Mvc packages; **Hangfire**, **Modules**, and **Caching** align related `Microsoft.Extensions.*` and `Microsoft.AspNetCore.*` references to **10.0.10**.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit d0493a440ba2bd7103c3a28afb70b86027066a2d. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->
Image tag:
ghcr.io/VirtoCommerce/platform:3.1046.0-pr-3082-d049-vcst-5522-d0493a44