### PR TITLE
VCST-5468: Add request-scoped cache primitive (IRequestScopedCache)

### DIFF
--- a/src/VirtoCommerce.Platform.Caching/RequestScopedCache.cs
+++ b/src/VirtoCommerce.Platform.Caching/RequestScopedCache.cs
@@ -39,7 +39,7 @@ namespace VirtoCommerce.Platform.Caching
             return (Task<T>)lazy.Value;
         }
 
-        public virtual Task<IDictionary<string, T>> GetOrLoadByIdsAsync<T>(
+        public virtual Task<IDictionary<string, T>> GetOrLoadMapByIdsAsync<T>(
             string keyPrefix,
             ICollection<string> ids,
             Func<T, string> idSelector,
@@ -51,10 +51,10 @@ namespace VirtoCommerce.Platform.Caching
             ArgumentNullException.ThrowIfNull(idSelector);
             ArgumentNullException.ThrowIfNull(loadMissing);
 
-            return GetOrLoadByIdsCoreAsync(keyPrefix, ids, idSelector, loadMissing);
+            return GetOrLoadMapByIdsCoreAsync(keyPrefix, ids, idSelector, loadMissing);
         }
 
-        private async Task<IDictionary<string, T>> GetOrLoadByIdsCoreAsync<T>(
+        private async Task<IDictionary<string, T>> GetOrLoadMapByIdsCoreAsync<T>(
             string keyPrefix,
             ICollection<string> ids,
             Func<T, string> idSelector,

--- a/src/VirtoCommerce.Platform.Caching/RequestScopedCache.cs
+++ b/src/VirtoCommerce.Platform.Caching/RequestScopedCache.cs
@@ -3,6 +3,7 @@ using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using VirtoCommerce.Platform.Core.Caching;
+using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.Platform.Caching
 {
@@ -12,10 +13,22 @@ namespace VirtoCommerce.Platform.Caching
         // The Task<T> itself is stored (not its unwrapped result), so value-type results are never boxed.
         private readonly ConcurrentDictionary<string, Lazy<Task>> _cache = new();
 
+        // OrdinalIgnoreCase per the platform id-cache convention (MemoryCacheExtensions): a case-insensitive DB
+        // collation can return an entity Id cased differently from the requested id, which would otherwise miss
+        // its reservation and be negatively cached. No standard ignore-case comparer exists for a string tuple;
+        // capture-free lambdas keep this static singleton alloc-free per call (vs. an allocating per-id ToLower key).
+        private static readonly IEqualityComparer<(string Prefix, string Id)> _byIdKeyComparer =
+            AnonymousComparer.Create<(string Prefix, string Id)>(
+                (x, y) => string.Equals(x.Prefix, y.Prefix, StringComparison.OrdinalIgnoreCase)
+                    && string.Equals(x.Id, y.Id, StringComparison.OrdinalIgnoreCase),
+                obj => HashCode.Combine(
+                    obj.Prefix is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Prefix),
+                    obj.Id is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Id)));
+
         // By-id entries store the Task<T> directly - single-flight comes from promise reservation, so there
         // is no per-id factory whose start a Lazy could defer. The tuple key avoids the aliasing of string
         // concatenation ("P:A"+"B" vs "P"+"A:B") and can't collide with by-key entries (separate dictionary).
-        private readonly ConcurrentDictionary<(string Prefix, string Id), Task> _cacheById = new();
+        private readonly ConcurrentDictionary<(string Prefix, string Id), Task> _cacheById = new(_byIdKeyComparer);
 
         public virtual Task<T> GetOrAddAsync<T>(string key, Func<Task<T>> factory)
         {
@@ -48,7 +61,7 @@ namespace VirtoCommerce.Platform.Caching
             Func<ICollection<string>, Task<IList<T>>> loadMissing)
             where T : class
         {
-            var result = new Dictionary<string, T>(ids.Count);
+            var result = new Dictionary<string, T>(ids.Count, StringComparer.OrdinalIgnoreCase);
             List<KeyValuePair<string, Task<T>>> pending = null;
             Dictionary<string, TaskCompletionSource<T>> owned = null;
 
@@ -66,7 +79,7 @@ namespace VirtoCommerce.Platform.Caching
                     var task = GetOrReserve<T>((keyPrefix, id), out var reservation);
                     if (reservation is not null)
                     {
-                        (owned ??= new Dictionary<string, TaskCompletionSource<T>>()).Add(id, reservation);
+                        (owned ??= new Dictionary<string, TaskCompletionSource<T>>(StringComparer.OrdinalIgnoreCase)).Add(id, reservation);
                     }
 
                     // A just-won reservation task is never completed here, so it lands in pending.

--- a/src/VirtoCommerce.Platform.Caching/RequestScopedCache.cs
+++ b/src/VirtoCommerce.Platform.Caching/RequestScopedCache.cs
@@ -5,232 +5,231 @@ using System.Threading.Tasks;
 using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Common;
 
-namespace VirtoCommerce.Platform.Caching
+namespace VirtoCommerce.Platform.Caching;
+
+public class RequestScopedCache : IRequestScopedCache
 {
-    public class RequestScopedCache : IRequestScopedCache
+    // Lazy<Task> -> the factory runs at most once per key even under a concurrent same-key miss.
+    // The Task<T> itself is stored (not its unwrapped result), so value-type results are never boxed.
+    private readonly ConcurrentDictionary<string, Lazy<Task>> _cache = new();
+
+    // OrdinalIgnoreCase per the platform id-cache convention (MemoryCacheExtensions): a case-insensitive DB
+    // collation can return an entity Id cased differently from the requested id, which would otherwise miss
+    // its reservation and be negatively cached. No standard ignore-case comparer exists for a string tuple;
+    // capture-free lambdas keep this static singleton alloc-free per call (vs. an allocating per-id ToLower key).
+    private static readonly IEqualityComparer<(string Prefix, string Id)> _byIdKeyComparer =
+        AnonymousComparer.Create<(string Prefix, string Id)>(
+            (x, y) => string.Equals(x.Prefix, y.Prefix, StringComparison.OrdinalIgnoreCase)
+                      && string.Equals(x.Id, y.Id, StringComparison.OrdinalIgnoreCase),
+            obj => HashCode.Combine(
+                obj.Prefix is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Prefix),
+                obj.Id is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Id)));
+
+    // By-id entries store the Task<T> directly - single-flight comes from promise reservation, so there
+    // is no per-id factory whose start a Lazy could defer. The tuple key avoids the aliasing of string
+    // concatenation ("P:A"+"B" vs "P"+"A:B") and can't collide with by-key entries (separate dictionary).
+    private readonly ConcurrentDictionary<(string Prefix, string Id), Task> _cacheById = new(_byIdKeyComparer);
+
+    public virtual Task<T> GetOrAddAsync<T>(string key, Func<Task<T>> factory)
     {
-        // Lazy<Task> -> the factory runs at most once per key even under a concurrent same-key miss.
-        // The Task<T> itself is stored (not its unwrapped result), so value-type results are never boxed.
-        private readonly ConcurrentDictionary<string, Lazy<Task>> _cache = new();
+        ArgumentNullException.ThrowIfNull(factory);
 
-        // OrdinalIgnoreCase per the platform id-cache convention (MemoryCacheExtensions): a case-insensitive DB
-        // collation can return an entity Id cased differently from the requested id, which would otherwise miss
-        // its reservation and be negatively cached. No standard ignore-case comparer exists for a string tuple;
-        // capture-free lambdas keep this static singleton alloc-free per call (vs. an allocating per-id ToLower key).
-        private static readonly IEqualityComparer<(string Prefix, string Id)> _byIdKeyComparer =
-            AnonymousComparer.Create<(string Prefix, string Id)>(
-                (x, y) => string.Equals(x.Prefix, y.Prefix, StringComparison.OrdinalIgnoreCase)
-                    && string.Equals(x.Id, y.Id, StringComparison.OrdinalIgnoreCase),
-                obj => HashCode.Combine(
-                    obj.Prefix is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Prefix),
-                    obj.Id is null ? 0 : StringComparer.OrdinalIgnoreCase.GetHashCode(obj.Id)));
+        var lazy = _cache.GetOrAdd(key, static (_, arg) => new Lazy<Task>(arg), factory);
 
-        // By-id entries store the Task<T> directly - single-flight comes from promise reservation, so there
-        // is no per-id factory whose start a Lazy could defer. The tuple key avoids the aliasing of string
-        // concatenation ("P:A"+"B" vs "P"+"A:B") and can't collide with by-key entries (separate dictionary).
-        private readonly ConcurrentDictionary<(string Prefix, string Id), Task> _cacheById = new(_byIdKeyComparer);
+        return (Task<T>)lazy.Value;
+    }
 
-        public virtual Task<T> GetOrAddAsync<T>(string key, Func<Task<T>> factory)
+    public virtual Task<IDictionary<string, T>> GetOrLoadMapByIdsAsync<T>(
+        string keyPrefix,
+        ICollection<string> ids,
+        Func<T, string> idSelector,
+        Func<ICollection<string>, Task<IList<T>>> loadMissing)
+        where T : class
+    {
+        ArgumentException.ThrowIfNullOrEmpty(keyPrefix);
+        ArgumentNullException.ThrowIfNull(ids);
+        ArgumentNullException.ThrowIfNull(idSelector);
+        ArgumentNullException.ThrowIfNull(loadMissing);
+
+        return GetOrLoadMapByIdsCoreAsync(keyPrefix, ids, idSelector, loadMissing);
+    }
+
+    private async Task<IDictionary<string, T>> GetOrLoadMapByIdsCoreAsync<T>(
+        string keyPrefix,
+        ICollection<string> ids,
+        Func<T, string> idSelector,
+        Func<ICollection<string>, Task<IList<T>>> loadMissing)
+        where T : class
+    {
+        var result = new Dictionary<string, T>(ids.Count, StringComparer.OrdinalIgnoreCase);
+        List<KeyValuePair<string, Task<T>>> pending = null;
+        Dictionary<string, TaskCompletionSource<T>> owned = null;
+
+        try
         {
-            ArgumentNullException.ThrowIfNull(factory);
-
-            var lazy = _cache.GetOrAdd(key, static (_, arg) => new Lazy<Task>(arg), factory);
-
-            return (Task<T>)lazy.Value;
-        }
-
-        public virtual Task<IDictionary<string, T>> GetOrLoadMapByIdsAsync<T>(
-            string keyPrefix,
-            ICollection<string> ids,
-            Func<T, string> idSelector,
-            Func<ICollection<string>, Task<IList<T>>> loadMissing)
-            where T : class
-        {
-            ArgumentException.ThrowIfNullOrEmpty(keyPrefix);
-            ArgumentNullException.ThrowIfNull(ids);
-            ArgumentNullException.ThrowIfNull(idSelector);
-            ArgumentNullException.ThrowIfNull(loadMissing);
-
-            return GetOrLoadMapByIdsCoreAsync(keyPrefix, ids, idSelector, loadMissing);
-        }
-
-        private async Task<IDictionary<string, T>> GetOrLoadMapByIdsCoreAsync<T>(
-            string keyPrefix,
-            ICollection<string> ids,
-            Func<T, string> idSelector,
-            Func<ICollection<string>, Task<IList<T>>> loadMissing)
-            where T : class
-        {
-            var result = new Dictionary<string, T>(ids.Count, StringComparer.OrdinalIgnoreCase);
-            List<KeyValuePair<string, Task<T>>> pending = null;
-            Dictionary<string, TaskCompletionSource<T>> owned = null;
-
-            try
+            // Single pass: only the reservation winner loads an id, so concurrent overlapping callers
+            // load each id at most once. No explicit dedup: a duplicate input id hits the added entry.
+            foreach (var id in ids)
             {
-                // Single pass: only the reservation winner loads an id, so concurrent overlapping callers
-                // load each id at most once. No explicit dedup: a duplicate input id hits the added entry.
-                foreach (var id in ids)
-                {
-                    if (string.IsNullOrEmpty(id))
-                    {
-                        continue;
-                    }
-
-                    var task = GetOrReserve<T>((keyPrefix, id), out var reservation);
-                    if (reservation is not null)
-                    {
-                        (owned ??= new Dictionary<string, TaskCompletionSource<T>>(StringComparer.OrdinalIgnoreCase)).Add(id, reservation);
-                    }
-
-                    // A just-won reservation task is never completed here, so it lands in pending.
-                    if (task.IsCompletedSuccessfully)
-                    {
-                        await CollectHitAsync(result, id, task);
-                    }
-                    else
-                    {
-                        (pending ??= []).Add(new KeyValuePair<string, Task<T>>(id, task));
-                    }
-                }
-            }
-            catch (Exception ex)
-            {
-                // A failure while still reserving (e.g. a wrong-typed cached id throws InvalidCastException)
-                // leaves the ids this call already owned reserved-but-unloaded. Release them - drop each from
-                // the cache so it stays retryable, and fault its promise to unblock any awaiter - so one id's
-                // type mismatch does not negatively cache the innocent ids this call happened to own.
-                ReleaseReservations(keyPrefix, owned, ex);
-                throw;
-            }
-
-            if (owned is not null)
-            {
-                try
-                {
-                    await LoadAndPublishAsync(owned, idSelector, loadMissing);
-                }
-                catch (Exception ex)
-                {
-                    // The load itself failed: owned reservations must never leak incomplete (awaiters would
-                    // hang). The cached fault applies the documented by-id failure semantics - same-id calls
-                    // for the rest of the request rethrow, they are not retried.
-                    FaultReservations(owned, ex);
-                    throw;
-                }
-            }
-
-            await CollectPendingAsync(pending, result);
-
-            return result;
-        }
-
-        private static async Task CollectHitAsync<T>(Dictionary<string, T> result, string id, Task<T> task)
-            where T : class
-        {
-            // Called for completed tasks only - the await continues synchronously, no allocation.
-            var value = await task;
-            if (value is not null)
-            {
-                result[id] = value;
-            }
-        }
-
-        private Task<T> GetOrReserve<T>((string Prefix, string Id) key, out TaskCompletionSource<T> reservation)
-            where T : class
-        {
-            if (_cacheById.TryGetValue(key, out var cached))
-            {
-                reservation = null;
-
-                return (Task<T>)cached;
-            }
-
-            // RunContinuationsAsynchronously: completing the reservation must not run other callers'
-            // continuations inline on the publishing thread.
-            var candidate = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
-            cached = _cacheById.GetOrAdd(key, static (_, arg) => arg.Task, candidate);
-            reservation = ReferenceEquals(cached, candidate.Task) ? candidate : null;
-
-            return (Task<T>)cached;
-        }
-
-        private static async Task LoadAndPublishAsync<T>(
-            Dictionary<string, TaskCompletionSource<T>> owned,
-            Func<T, string> idSelector,
-            Func<ICollection<string>, Task<IList<T>>> loadMissing)
-            where T : class
-        {
-            // Null result counts as empty, mirroring the platform's GetOrLoadByIdsAsync.
-            var loaded = await loadMissing(owned.Keys) ?? [];
-
-            foreach (var item in loaded)
-            {
-                if (item is null)
+                if (string.IsNullOrEmpty(id))
                 {
                     continue;
                 }
 
-                var loadedId = idSelector(item);
-                if (!string.IsNullOrEmpty(loadedId) && owned.TryGetValue(loadedId, out var reservation))
+                var task = GetOrReserve<T>((keyPrefix, id), out var reservation);
+                if (reservation is not null)
                 {
-                    // TrySetResult: duplicate ids from the load - first wins.
-                    reservation.TrySetResult(item);
+                    (owned ??= new Dictionary<string, TaskCompletionSource<T>>(StringComparer.OrdinalIgnoreCase)).Add(id, reservation);
+                }
+
+                // A just-won reservation task is never completed here, so it lands in pending.
+                if (task.IsCompletedSuccessfully)
+                {
+                    await CollectHitAsync(result, id, task);
+                }
+                else
+                {
+                    (pending ??= []).Add(new KeyValuePair<string, Task<T>>(id, task));
                 }
             }
+        }
+        catch (Exception ex)
+        {
+            // A failure while still reserving (e.g. a wrong-typed cached id throws InvalidCastException)
+            // leaves the ids this call already owned reserved-but-unloaded. Release them - drop each from
+            // the cache so it stays retryable, and fault its promise to unblock any awaiter - so one id's
+            // type mismatch does not negatively cache the innocent ids this call happened to own.
+            ReleaseReservations(keyPrefix, owned, ex);
+            throw;
+        }
 
-            // Not-returned owned ids: negatively cache as null for the request.
-            foreach (var reservation in owned.Values)
+        if (owned is not null)
+        {
+            try
             {
-                reservation.TrySetResult(null);
+                await LoadAndPublishAsync(owned, idSelector, loadMissing);
+            }
+            catch (Exception ex)
+            {
+                // The load itself failed: owned reservations must never leak incomplete (awaiters would
+                // hang). The cached fault applies the documented by-id failure semantics - same-id calls
+                // for the rest of the request rethrow, they are not retried.
+                FaultReservations(owned, ex);
+                throw;
             }
         }
 
-        private void ReleaseReservations<T>(string keyPrefix, Dictionary<string, TaskCompletionSource<T>> owned, Exception exception)
-            where T : class
+        await CollectPendingAsync(pending, result);
+
+        return result;
+    }
+
+    private static async Task CollectHitAsync<T>(Dictionary<string, T> result, string id, Task<T> task)
+        where T : class
+    {
+        // Called for completed tasks only - the await continues synchronously, no allocation.
+        var value = await task;
+        if (value is not null)
         {
-            if (owned is null)
+            result[id] = value;
+        }
+    }
+
+    private Task<T> GetOrReserve<T>((string Prefix, string Id) key, out TaskCompletionSource<T> reservation)
+        where T : class
+    {
+        if (_cacheById.TryGetValue(key, out var cached))
+        {
+            reservation = null;
+
+            return (Task<T>)cached;
+        }
+
+        // RunContinuationsAsynchronously: completing the reservation must not run other callers'
+        // continuations inline on the publishing thread.
+        var candidate = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+        cached = _cacheById.GetOrAdd(key, static (_, arg) => arg.Task, candidate);
+        reservation = ReferenceEquals(cached, candidate.Task) ? candidate : null;
+
+        return (Task<T>)cached;
+    }
+
+    private static async Task LoadAndPublishAsync<T>(
+        Dictionary<string, TaskCompletionSource<T>> owned,
+        Func<T, string> idSelector,
+        Func<ICollection<string>, Task<IList<T>>> loadMissing)
+        where T : class
+    {
+        // Null result counts as empty, mirroring the platform's GetOrLoadByIdsAsync.
+        var loaded = await loadMissing(owned.Keys) ?? [];
+
+        foreach (var item in loaded)
+        {
+            if (item is null)
             {
-                return;
+                continue;
             }
 
-            foreach (var (id, reservation) in owned)
+            var loadedId = idSelector(item);
+            if (!string.IsNullOrEmpty(loadedId) && owned.TryGetValue(loadedId, out var reservation))
             {
-                // Remove only our own reservation (match the stored task), then fault it: a later call for
-                // this id re-reserves and loads it fresh instead of hitting a negatively-cached entry.
-                _cacheById.TryRemove(new KeyValuePair<(string Prefix, string Id), Task>((keyPrefix, id), reservation.Task));
-                reservation.TrySetException(exception);
+                // TrySetResult: duplicate ids from the load - first wins.
+                reservation.TrySetResult(item);
             }
         }
 
-        private static void FaultReservations<T>(Dictionary<string, TaskCompletionSource<T>> owned, Exception exception)
-            where T : class
+        // Not-returned owned ids: negatively cache as null for the request.
+        foreach (var reservation in owned.Values)
         {
-            if (owned is null)
-            {
-                return;
-            }
+            reservation.TrySetResult(null);
+        }
+    }
 
-            foreach (var reservation in owned.Values)
-            {
-                reservation.TrySetException(exception);
-            }
+    private void ReleaseReservations<T>(string keyPrefix, Dictionary<string, TaskCompletionSource<T>> owned, Exception exception)
+        where T : class
+    {
+        if (owned is null)
+        {
+            return;
         }
 
-        private static async Task CollectPendingAsync<T>(List<KeyValuePair<string, Task<T>>> pending, Dictionary<string, T> result)
-            where T : class
+        foreach (var (id, reservation) in owned)
         {
-            if (pending is null)
-            {
-                return;
-            }
+            // Remove only our own reservation (match the stored task), then fault it: a later call for
+            // this id re-reserves and loads it fresh instead of hitting a negatively-cached entry.
+            _cacheById.TryRemove(new KeyValuePair<(string Prefix, string Id), Task>((keyPrefix, id), reservation.Task));
+            reservation.TrySetException(exception);
+        }
+    }
 
-            foreach (var (id, task) in pending)
+    private static void FaultReservations<T>(Dictionary<string, TaskCompletionSource<T>> owned, Exception exception)
+        where T : class
+    {
+        if (owned is null)
+        {
+            return;
+        }
+
+        foreach (var reservation in owned.Values)
+        {
+            reservation.TrySetException(exception);
+        }
+    }
+
+    private static async Task CollectPendingAsync<T>(List<KeyValuePair<string, Task<T>>> pending, Dictionary<string, T> result)
+        where T : class
+    {
+        if (pending is null)
+        {
+            return;
+        }
+
+        foreach (var (id, task) in pending)
+        {
+            var value = await task;
+            if (value is not null)
             {
-                var value = await task;
-                if (value is not null)
-                {
-                    result.TryAdd(id, value);
-                }
+                result.TryAdd(id, value);
             }
         }
     }

--- a/src/VirtoCommerce.Platform.Caching/RequestScopedCache.cs
+++ b/src/VirtoCommerce.Platform.Caching/RequestScopedCache.cs
@@ -92,18 +92,31 @@ namespace VirtoCommerce.Platform.Caching
                         (pending ??= []).Add(new KeyValuePair<string, Task<T>>(id, task));
                     }
                 }
-
-                if (owned is not null)
-                {
-                    await LoadAndPublishAsync(owned, idSelector, loadMissing);
-                }
             }
             catch (Exception ex)
             {
-                // Owned reservations must never leak incomplete - concurrent awaiters would hang. The
-                // cached fault makes same-id calls rethrow (by-key failure semantics).
-                FaultReservations(owned, ex);
+                // A failure while still reserving (e.g. a wrong-typed cached id throws InvalidCastException)
+                // leaves the ids this call already owned reserved-but-unloaded. Release them - drop each from
+                // the cache so it stays retryable, and fault its promise to unblock any awaiter - so one id's
+                // type mismatch does not negatively cache the innocent ids this call happened to own.
+                ReleaseReservations(keyPrefix, owned, ex);
                 throw;
+            }
+
+            if (owned is not null)
+            {
+                try
+                {
+                    await LoadAndPublishAsync(owned, idSelector, loadMissing);
+                }
+                catch (Exception ex)
+                {
+                    // The load itself failed: owned reservations must never leak incomplete (awaiters would
+                    // hang). The cached fault applies the documented by-id failure semantics - same-id calls
+                    // for the rest of the request rethrow, they are not retried.
+                    FaultReservations(owned, ex);
+                    throw;
+                }
             }
 
             await CollectPendingAsync(pending, result);
@@ -169,6 +182,23 @@ namespace VirtoCommerce.Platform.Caching
             foreach (var reservation in owned.Values)
             {
                 reservation.TrySetResult(null);
+            }
+        }
+
+        private void ReleaseReservations<T>(string keyPrefix, Dictionary<string, TaskCompletionSource<T>> owned, Exception exception)
+            where T : class
+        {
+            if (owned is null)
+            {
+                return;
+            }
+
+            foreach (var (id, reservation) in owned)
+            {
+                // Remove only our own reservation (match the stored task), then fault it: a later call for
+                // this id re-reserves and loads it fresh instead of hitting a negatively-cached entry.
+                _cacheById.TryRemove(new KeyValuePair<(string Prefix, string Id), Task>((keyPrefix, id), reservation.Task));
+                reservation.TrySetException(exception);
             }
         }
 

--- a/src/VirtoCommerce.Platform.Caching/RequestScopedCache.cs
+++ b/src/VirtoCommerce.Platform.Caching/RequestScopedCache.cs
@@ -1,0 +1,194 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using VirtoCommerce.Platform.Core.Caching;
+
+namespace VirtoCommerce.Platform.Caching
+{
+    public class RequestScopedCache : IRequestScopedCache
+    {
+        // Lazy<Task> -> the factory runs at most once per key even under a concurrent same-key miss.
+        // The Task<T> itself is stored (not its unwrapped result), so value-type results are never boxed.
+        private readonly ConcurrentDictionary<string, Lazy<Task>> _cache = new();
+
+        // By-id entries store the Task<T> directly - single-flight comes from promise reservation, so there
+        // is no per-id factory whose start a Lazy could defer. The tuple key avoids the aliasing of string
+        // concatenation ("P:A"+"B" vs "P"+"A:B") and can't collide with by-key entries (separate dictionary).
+        private readonly ConcurrentDictionary<(string Prefix, string Id), Task> _cacheById = new();
+
+        public virtual Task<T> GetOrAddAsync<T>(string key, Func<Task<T>> factory)
+        {
+            ArgumentNullException.ThrowIfNull(factory);
+
+            var lazy = _cache.GetOrAdd(key, static (_, arg) => new Lazy<Task>(arg), factory);
+
+            return (Task<T>)lazy.Value;
+        }
+
+        public virtual Task<IDictionary<string, T>> GetOrLoadByIdsAsync<T>(
+            string keyPrefix,
+            ICollection<string> ids,
+            Func<T, string> idSelector,
+            Func<ICollection<string>, Task<IList<T>>> loadMissing)
+            where T : class
+        {
+            ArgumentException.ThrowIfNullOrEmpty(keyPrefix);
+            ArgumentNullException.ThrowIfNull(ids);
+            ArgumentNullException.ThrowIfNull(idSelector);
+            ArgumentNullException.ThrowIfNull(loadMissing);
+
+            return GetOrLoadByIdsCoreAsync(keyPrefix, ids, idSelector, loadMissing);
+        }
+
+        private async Task<IDictionary<string, T>> GetOrLoadByIdsCoreAsync<T>(
+            string keyPrefix,
+            ICollection<string> ids,
+            Func<T, string> idSelector,
+            Func<ICollection<string>, Task<IList<T>>> loadMissing)
+            where T : class
+        {
+            var result = new Dictionary<string, T>(ids.Count);
+            List<KeyValuePair<string, Task<T>>> pending = null;
+            Dictionary<string, TaskCompletionSource<T>> owned = null;
+
+            try
+            {
+                // Single pass: only the reservation winner loads an id, so concurrent overlapping callers
+                // load each id at most once. No explicit dedup: a duplicate input id hits the added entry.
+                foreach (var id in ids)
+                {
+                    if (string.IsNullOrEmpty(id))
+                    {
+                        continue;
+                    }
+
+                    var task = GetOrReserve<T>((keyPrefix, id), out var reservation);
+                    if (reservation is not null)
+                    {
+                        (owned ??= new Dictionary<string, TaskCompletionSource<T>>()).Add(id, reservation);
+                    }
+
+                    // A just-won reservation task is never completed here, so it lands in pending.
+                    if (task.IsCompletedSuccessfully)
+                    {
+                        await CollectHitAsync(result, id, task);
+                    }
+                    else
+                    {
+                        (pending ??= []).Add(new KeyValuePair<string, Task<T>>(id, task));
+                    }
+                }
+
+                if (owned is not null)
+                {
+                    await LoadAndPublishAsync(owned, idSelector, loadMissing);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Owned reservations must never leak incomplete - concurrent awaiters would hang. The
+                // cached fault makes same-id calls rethrow (by-key failure semantics).
+                FaultReservations(owned, ex);
+                throw;
+            }
+
+            await CollectPendingAsync(pending, result);
+
+            return result;
+        }
+
+        private static async Task CollectHitAsync<T>(Dictionary<string, T> result, string id, Task<T> task)
+            where T : class
+        {
+            // Called for completed tasks only - the await continues synchronously, no allocation.
+            var value = await task;
+            if (value is not null)
+            {
+                result[id] = value;
+            }
+        }
+
+        private Task<T> GetOrReserve<T>((string Prefix, string Id) key, out TaskCompletionSource<T> reservation)
+            where T : class
+        {
+            if (_cacheById.TryGetValue(key, out var cached))
+            {
+                reservation = null;
+
+                return (Task<T>)cached;
+            }
+
+            // RunContinuationsAsynchronously: completing the reservation must not run other callers'
+            // continuations inline on the publishing thread.
+            var candidate = new TaskCompletionSource<T>(TaskCreationOptions.RunContinuationsAsynchronously);
+            cached = _cacheById.GetOrAdd(key, static (_, arg) => arg.Task, candidate);
+            reservation = ReferenceEquals(cached, candidate.Task) ? candidate : null;
+
+            return (Task<T>)cached;
+        }
+
+        private static async Task LoadAndPublishAsync<T>(
+            Dictionary<string, TaskCompletionSource<T>> owned,
+            Func<T, string> idSelector,
+            Func<ICollection<string>, Task<IList<T>>> loadMissing)
+            where T : class
+        {
+            // Null result counts as empty, mirroring the platform's GetOrLoadByIdsAsync.
+            var loaded = await loadMissing(owned.Keys) ?? [];
+
+            foreach (var item in loaded)
+            {
+                if (item is null)
+                {
+                    continue;
+                }
+
+                var loadedId = idSelector(item);
+                if (!string.IsNullOrEmpty(loadedId) && owned.TryGetValue(loadedId, out var reservation))
+                {
+                    // TrySetResult: duplicate ids from the load - first wins.
+                    reservation.TrySetResult(item);
+                }
+            }
+
+            // Not-returned owned ids: negatively cache as null for the request.
+            foreach (var reservation in owned.Values)
+            {
+                reservation.TrySetResult(null);
+            }
+        }
+
+        private static void FaultReservations<T>(Dictionary<string, TaskCompletionSource<T>> owned, Exception exception)
+            where T : class
+        {
+            if (owned is null)
+            {
+                return;
+            }
+
+            foreach (var reservation in owned.Values)
+            {
+                reservation.TrySetException(exception);
+            }
+        }
+
+        private static async Task CollectPendingAsync<T>(List<KeyValuePair<string, Task<T>>> pending, Dictionary<string, T> result)
+            where T : class
+        {
+            if (pending is null)
+            {
+                return;
+            }
+
+            foreach (var (id, task) in pending)
+            {
+                var value = await task;
+                if (value is not null)
+                {
+                    result.TryAdd(id, value);
+                }
+            }
+        }
+    }
+}

--- a/src/VirtoCommerce.Platform.Caching/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Caching/ServiceCollectionExtensions.cs
@@ -28,6 +28,8 @@ namespace VirtoCommerce.Platform.Caching
                 services.AddSingleton<IPlatformMemoryCache, PlatformMemoryCache>();
             }
 
+            services.AddScoped<IRequestScopedCache, RequestScopedCache>();
+
             return services;
         }
     }

--- a/src/VirtoCommerce.Platform.Core/Caching/IRequestScopedCache.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/IRequestScopedCache.cs
@@ -45,6 +45,10 @@ namespace VirtoCommerce.Platform.Core.Caching
         /// every id is loaded at most once per request.
         /// </summary>
         /// <remarks>
+        /// Ids are matched case-insensitively (OrdinalIgnoreCase), matching the platform's id-cache convention
+        /// (a load may return an entity whose <c>Id</c> casing differs from the requested id under a
+        /// case-insensitive database collation).
+        /// <br/><br/>
         /// An id the load does not return is negatively cached: omitted from results for the rest of the request,
         /// not retried. Loaded items with unrequested ids are ignored; duplicate ids - first wins. The returned
         /// dictionary is created per call and may be mutated; the item instances in it are shared within the

--- a/src/VirtoCommerce.Platform.Core/Caching/IRequestScopedCache.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/IRequestScopedCache.cs
@@ -2,73 +2,72 @@ using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 
-namespace VirtoCommerce.Platform.Core.Caching
+namespace VirtoCommerce.Platform.Core.Caching;
+
+/// <summary>
+/// Request-scoped cache for expensive loads: deduplicates a load that is re-issued with identical
+/// arguments many times within one request. Concurrent same-key calls share a single factory invocation.
+/// </summary>
+/// <remarks>
+/// Use this when many distinct items issue the same load (identical, or only a few distinct, argument
+/// combinations) and a per-node batching layer above it cannot dedup them: such a layer keys by its own
+/// node id, not by the load's arguments, so a load whose arguments repeat across differently-keyed nodes
+/// still fans out. This cache dedups by the load's own stable argument key instead.
+/// <br/><br/>
+/// Key rules: the key must include EVERY argument that affects the load's result (a missing one causes false
+/// cache hits), multi-value parts of the key must be sorted for order independence, and the key must carry a
+/// type/purpose-discriminating prefix so unrelated callers sharing the same scoped instance don't collide.
+/// <br/><br/>
+/// Failure semantics: a faulted load is cached for the remainder of the request and is not retried - every
+/// same-key call rethrows the original exception.
+/// <br/><br/>
+/// Warning: resolve consumers from the request/DI scope (a scoped dependency, or the current request's
+/// service provider) - never constructor-inject this cache into a singleton, or it is captured against the
+/// root scope and silently shared across all requests.
+/// </remarks>
+public interface IRequestScopedCache
 {
     /// <summary>
-    /// Request-scoped cache for expensive loads: deduplicates a load that is re-issued with identical
-    /// arguments many times within one request. Concurrent same-key calls share a single factory invocation.
+    /// Returns the result of a previous (possibly still in-flight) load registered under <paramref name="key"/>,
+    /// or invokes <paramref name="factory"/> and caches its task for the remainder of the request.
+    /// </summary>
+    /// <typeparam name="T">Result type; every caller of the same key must use the same <typeparamref name="T"/>.</typeparam>
+    /// <param name="key">Stable, order-independent key built from every load-affecting argument.</param>
+    /// <param name="factory">The load to execute on a cache miss; runs at most once per key per request.</param>
+    /// <exception cref="ArgumentNullException"><paramref name="factory"/> is null.</exception>
+    /// <exception cref="InvalidCastException">The key was previously used with a different <typeparamref name="T"/>.</exception>
+    Task<T> GetOrAddAsync<T>(string key, Func<Task<T>> factory);
+
+    /// <summary>
+    /// Batch by-id variant: serves ids already loaded during this request from the cache and loads only the
+    /// not-yet-cached ids in a single <paramref name="loadMissing"/> call, caching each item under its own
+    /// (<paramref name="keyPrefix"/>, id) key - across overlapping id-sets, including concurrent callers,
+    /// every id is loaded at most once per request.
     /// </summary>
     /// <remarks>
-    /// Use this when many distinct items issue the same load (identical, or only a few distinct, argument
-    /// combinations) and a per-node batching layer above it cannot dedup them: such a layer keys by its own
-    /// node id, not by the load's arguments, so a load whose arguments repeat across differently-keyed nodes
-    /// still fans out. This cache dedups by the load's own stable argument key instead.
+    /// Ids are matched case-insensitively (OrdinalIgnoreCase), matching the platform's id-cache convention
+    /// (a load may return an entity whose <c>Id</c> casing differs from the requested id under a
+    /// case-insensitive database collation).
     /// <br/><br/>
-    /// Key rules: the key must include EVERY argument that affects the load's result (a missing one causes false
-    /// cache hits), multi-value parts of the key must be sorted for order independence, and the key must carry a
-    /// type/purpose-discriminating prefix so unrelated callers sharing the same scoped instance don't collide.
-    /// <br/><br/>
-    /// Failure semantics: a faulted load is cached for the remainder of the request and is not retried - every
-    /// same-key call rethrows the original exception.
-    /// <br/><br/>
-    /// Warning: resolve consumers from the request/DI scope (a scoped dependency, or the current request's
-    /// service provider) - never constructor-inject this cache into a singleton, or it is captured against the
-    /// root scope and silently shared across all requests.
+    /// An id the load does not return is negatively cached: omitted from results for the rest of the request,
+    /// not retried. Loaded items with unrequested ids are ignored; duplicate ids - first wins. The returned
+    /// dictionary is created per call and may be mutated; the item instances in it are shared within the
+    /// request - treat them as read-only. <paramref name="loadMissing"/> must not call back into this cache
+    /// for ids it was asked to load (it would await its own load).
     /// </remarks>
-    public interface IRequestScopedCache
-    {
-        /// <summary>
-        /// Returns the result of a previous (possibly still in-flight) load registered under <paramref name="key"/>,
-        /// or invokes <paramref name="factory"/> and caches its task for the remainder of the request.
-        /// </summary>
-        /// <typeparam name="T">Result type; every caller of the same key must use the same <typeparamref name="T"/>.</typeparam>
-        /// <param name="key">Stable, order-independent key built from every load-affecting argument.</param>
-        /// <param name="factory">The load to execute on a cache miss; runs at most once per key per request.</param>
-        /// <exception cref="ArgumentNullException"><paramref name="factory"/> is null.</exception>
-        /// <exception cref="InvalidCastException">The key was previously used with a different <typeparamref name="T"/>.</exception>
-        Task<T> GetOrAddAsync<T>(string key, Func<Task<T>> factory);
-
-        /// <summary>
-        /// Batch by-id variant: serves ids already loaded during this request from the cache and loads only the
-        /// not-yet-cached ids in a single <paramref name="loadMissing"/> call, caching each item under its own
-        /// (<paramref name="keyPrefix"/>, id) key - across overlapping id-sets, including concurrent callers,
-        /// every id is loaded at most once per request.
-        /// </summary>
-        /// <remarks>
-        /// Ids are matched case-insensitively (OrdinalIgnoreCase), matching the platform's id-cache convention
-        /// (a load may return an entity whose <c>Id</c> casing differs from the requested id under a
-        /// case-insensitive database collation).
-        /// <br/><br/>
-        /// An id the load does not return is negatively cached: omitted from results for the rest of the request,
-        /// not retried. Loaded items with unrequested ids are ignored; duplicate ids - first wins. The returned
-        /// dictionary is created per call and may be mutated; the item instances in it are shared within the
-        /// request - treat them as read-only. <paramref name="loadMissing"/> must not call back into this cache
-        /// for ids it was asked to load (it would await its own load).
-        /// </remarks>
-        /// <typeparam name="T">Item type, a reference type so a not-found id is representable as a cached null;
-        /// every caller of the same (<paramref name="keyPrefix"/>, id) pair must use the same <typeparamref name="T"/>.</typeparam>
-        /// <param name="keyPrefix">Type/purpose-discriminating prefix, unique per load kind.</param>
-        /// <param name="ids">Identifiers to resolve; null/empty entries skipped, duplicates collapsed.</param>
-        /// <param name="idSelector">Extracts the cache id from a loaded item.</param>
-        /// <param name="loadMissing">Batch load for the not-yet-cached ids; a null result counts as empty.</param>
-        /// <returns>Found ids mapped to their items; not-found ids are omitted.</returns>
-        /// <exception cref="ArgumentNullException">Any argument is null.</exception>
-        /// <exception cref="InvalidCastException">A (<paramref name="keyPrefix"/>, id) pair was previously used with a different <typeparamref name="T"/>.</exception>
-        Task<IDictionary<string, T>> GetOrLoadMapByIdsAsync<T>(
-            string keyPrefix,
-            ICollection<string> ids,
-            Func<T, string> idSelector,
-            Func<ICollection<string>, Task<IList<T>>> loadMissing)
-            where T : class;
-    }
+    /// <typeparam name="T">Item type, a reference type so a not-found id is representable as a cached null;
+    /// every caller of the same (<paramref name="keyPrefix"/>, id) pair must use the same <typeparamref name="T"/>.</typeparam>
+    /// <param name="keyPrefix">Type/purpose-discriminating prefix, unique per load kind.</param>
+    /// <param name="ids">Identifiers to resolve; null/empty entries skipped, duplicates collapsed.</param>
+    /// <param name="idSelector">Extracts the cache id from a loaded item.</param>
+    /// <param name="loadMissing">Batch load for the not-yet-cached ids; a null result counts as empty.</param>
+    /// <returns>Found ids mapped to their items; not-found ids are omitted.</returns>
+    /// <exception cref="ArgumentNullException">Any argument is null.</exception>
+    /// <exception cref="InvalidCastException">A (<paramref name="keyPrefix"/>, id) pair was previously used with a different <typeparamref name="T"/>.</exception>
+    Task<IDictionary<string, T>> GetOrLoadMapByIdsAsync<T>(
+        string keyPrefix,
+        ICollection<string> ids,
+        Func<T, string> idSelector,
+        Func<ICollection<string>, Task<IList<T>>> loadMissing)
+        where T : class;
 }

--- a/src/VirtoCommerce.Platform.Core/Caching/IRequestScopedCache.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/IRequestScopedCache.cs
@@ -1,0 +1,70 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+
+namespace VirtoCommerce.Platform.Core.Caching
+{
+    /// <summary>
+    /// Request-scoped cache for expensive loads: deduplicates a load that is re-issued with identical
+    /// arguments many times within one request. Concurrent same-key calls share a single factory invocation.
+    /// </summary>
+    /// <remarks>
+    /// Use this when many distinct items issue the same load (identical, or only a few distinct, argument
+    /// combinations) and a per-node batching layer above it cannot dedup them: such a layer keys by its own
+    /// node id, not by the load's arguments, so a load whose arguments repeat across differently-keyed nodes
+    /// still fans out. This cache dedups by the load's own stable argument key instead.
+    /// <br/><br/>
+    /// Key rules: the key must include EVERY argument that affects the load's result (a missing one causes false
+    /// cache hits), multi-value parts of the key must be sorted for order independence, and the key must carry a
+    /// type/purpose-discriminating prefix so unrelated callers sharing the same scoped instance don't collide.
+    /// <br/><br/>
+    /// Failure semantics: a faulted load is cached for the remainder of the request and is not retried - every
+    /// same-key call rethrows the original exception.
+    /// <br/><br/>
+    /// Warning: resolve consumers from the request/DI scope (a scoped dependency, or the current request's
+    /// service provider) - never constructor-inject this cache into a singleton, or it is captured against the
+    /// root scope and silently shared across all requests.
+    /// </remarks>
+    public interface IRequestScopedCache
+    {
+        /// <summary>
+        /// Returns the result of a previous (possibly still in-flight) load registered under <paramref name="key"/>,
+        /// or invokes <paramref name="factory"/> and caches its task for the remainder of the request.
+        /// </summary>
+        /// <typeparam name="T">Result type; every caller of the same key must use the same <typeparamref name="T"/>.</typeparam>
+        /// <param name="key">Stable, order-independent key built from every load-affecting argument.</param>
+        /// <param name="factory">The load to execute on a cache miss; runs at most once per key per request.</param>
+        /// <exception cref="ArgumentNullException"><paramref name="factory"/> is null.</exception>
+        /// <exception cref="InvalidCastException">The key was previously used with a different <typeparamref name="T"/>.</exception>
+        Task<T> GetOrAddAsync<T>(string key, Func<Task<T>> factory);
+
+        /// <summary>
+        /// Batch by-id variant: serves ids already loaded during this request from the cache and loads only the
+        /// not-yet-cached ids in a single <paramref name="loadMissing"/> call, caching each item under its own
+        /// (<paramref name="keyPrefix"/>, id) key - across overlapping id-sets, including concurrent callers,
+        /// every id is loaded at most once per request.
+        /// </summary>
+        /// <remarks>
+        /// An id the load does not return is negatively cached: omitted from results for the rest of the request,
+        /// not retried. Loaded items with unrequested ids are ignored; duplicate ids - first wins. The returned
+        /// dictionary is created per call and may be mutated; the item instances in it are shared within the
+        /// request - treat them as read-only. <paramref name="loadMissing"/> must not call back into this cache
+        /// for ids it was asked to load (it would await its own load).
+        /// </remarks>
+        /// <typeparam name="T">Item type, a reference type so a not-found id is representable as a cached null;
+        /// every caller of the same (<paramref name="keyPrefix"/>, id) pair must use the same <typeparamref name="T"/>.</typeparam>
+        /// <param name="keyPrefix">Type/purpose-discriminating prefix, unique per load kind.</param>
+        /// <param name="ids">Identifiers to resolve; null/empty entries skipped, duplicates collapsed.</param>
+        /// <param name="idSelector">Extracts the cache id from a loaded item.</param>
+        /// <param name="loadMissing">Batch load for the not-yet-cached ids; a null result counts as empty.</param>
+        /// <returns>Found ids mapped to their items; not-found ids are omitted.</returns>
+        /// <exception cref="ArgumentNullException">Any argument is null.</exception>
+        /// <exception cref="InvalidCastException">A (<paramref name="keyPrefix"/>, id) pair was previously used with a different <typeparamref name="T"/>.</exception>
+        Task<IDictionary<string, T>> GetOrLoadByIdsAsync<T>(
+            string keyPrefix,
+            ICollection<string> ids,
+            Func<T, string> idSelector,
+            Func<ICollection<string>, Task<IList<T>>> loadMissing)
+            where T : class;
+    }
+}

--- a/src/VirtoCommerce.Platform.Core/Caching/IRequestScopedCache.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/IRequestScopedCache.cs
@@ -64,7 +64,7 @@ namespace VirtoCommerce.Platform.Core.Caching
         /// <returns>Found ids mapped to their items; not-found ids are omitted.</returns>
         /// <exception cref="ArgumentNullException">Any argument is null.</exception>
         /// <exception cref="InvalidCastException">A (<paramref name="keyPrefix"/>, id) pair was previously used with a different <typeparamref name="T"/>.</exception>
-        Task<IDictionary<string, T>> GetOrLoadByIdsAsync<T>(
+        Task<IDictionary<string, T>> GetOrLoadMapByIdsAsync<T>(
             string keyPrefix,
             ICollection<string> ids,
             Func<T, string> idSelector,

--- a/src/VirtoCommerce.Platform.Core/Caching/RequestScopedCacheExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/RequestScopedCacheExtensions.cs
@@ -8,17 +8,17 @@ namespace VirtoCommerce.Platform.Core.Caching
     public static class RequestScopedCacheExtensions
     {
         /// <summary>
-        /// By-id form for items keyed by <see cref="IEntity.Id"/>: delegates to
-        /// <see cref="IRequestScopedCache.GetOrLoadMapByIdsAsync{T}(string, ICollection{string}, Func{T, string}, Func{ICollection{string}, Task{IList{T}}})"/>.
+        /// Values-only, by-<see cref="IEntity.Id"/> form: returns just the resolved items (not-found ids omitted),
+        /// for callers that do not need the id map.
         /// </summary>
-        public static Task<IDictionary<string, T>> GetOrLoadMapByIdsAsync<T>(
+        public static async Task<ICollection<T>> GetOrLoadByIdsAsync<T>(
             this IRequestScopedCache cache,
             string keyPrefix,
             ICollection<string> ids,
             Func<ICollection<string>, Task<IList<T>>> loadMissing)
             where T : class, IEntity
         {
-            return cache.GetOrLoadMapByIdsAsync(keyPrefix, ids, static x => x.Id, loadMissing);
+            return (await GetOrLoadMapByIdsAsync(cache, keyPrefix, ids, loadMissing)).Values;
         }
 
         /// <summary>
@@ -33,22 +33,21 @@ namespace VirtoCommerce.Platform.Core.Caching
             Func<ICollection<string>, Task<IList<T>>> loadMissing)
             where T : class
         {
-            // Interface method (not a sibling extension) - must be called on the instance.
             return (await cache.GetOrLoadMapByIdsAsync(keyPrefix, ids, idSelector, loadMissing)).Values;
         }
 
         /// <summary>
-        /// Values-only, by-<see cref="IEntity.Id"/> form: returns just the resolved items (not-found ids omitted),
-        /// for callers that do not need the id map.
+        /// By-id form for items keyed by <see cref="IEntity.Id"/>: delegates to
+        /// <see cref="IRequestScopedCache.GetOrLoadMapByIdsAsync{T}(string, ICollection{string}, Func{T, string}, Func{ICollection{string}, Task{IList{T}}})"/>.
         /// </summary>
-        public static async Task<ICollection<T>> GetOrLoadByIdsAsync<T>(
+        public static Task<IDictionary<string, T>> GetOrLoadMapByIdsAsync<T>(
             this IRequestScopedCache cache,
             string keyPrefix,
             ICollection<string> ids,
             Func<ICollection<string>, Task<IList<T>>> loadMissing)
             where T : class, IEntity
         {
-            return (await GetOrLoadMapByIdsAsync(cache, keyPrefix, ids, loadMissing)).Values;
+            return cache.GetOrLoadMapByIdsAsync(keyPrefix, ids, static x => x.Id, loadMissing);
         }
     }
 }

--- a/src/VirtoCommerce.Platform.Core/Caching/RequestScopedCacheExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/RequestScopedCacheExtensions.cs
@@ -9,16 +9,45 @@ namespace VirtoCommerce.Platform.Core.Caching
     {
         /// <summary>
         /// By-id form for items keyed by <see cref="IEntity.Id"/>: delegates to
-        /// <see cref="IRequestScopedCache.GetOrLoadByIdsAsync{T}(string, ICollection{string}, Func{T, string}, Func{ICollection{string}, Task{IList{T}}})"/>.
+        /// <see cref="IRequestScopedCache.GetOrLoadMapByIdsAsync{T}(string, ICollection{string}, Func{T, string}, Func{ICollection{string}, Task{IList{T}}})"/>.
         /// </summary>
-        public static Task<IDictionary<string, T>> GetOrLoadByIdsAsync<T>(
+        public static Task<IDictionary<string, T>> GetOrLoadMapByIdsAsync<T>(
             this IRequestScopedCache cache,
             string keyPrefix,
             ICollection<string> ids,
             Func<ICollection<string>, Task<IList<T>>> loadMissing)
             where T : class, IEntity
         {
-            return cache.GetOrLoadByIdsAsync(keyPrefix, ids, static x => x.Id, loadMissing);
+            return cache.GetOrLoadMapByIdsAsync(keyPrefix, ids, static x => x.Id, loadMissing);
+        }
+
+        /// <summary>
+        /// Values-only form of <see cref="IRequestScopedCache.GetOrLoadMapByIdsAsync{T}(string, ICollection{string}, Func{T, string}, Func{ICollection{string}, Task{IList{T}}})"/>:
+        /// returns just the resolved items (not-found ids omitted), for callers that do not need the id map.
+        /// </summary>
+        public static async Task<ICollection<T>> GetOrLoadByIdsAsync<T>(
+            this IRequestScopedCache cache,
+            string keyPrefix,
+            ICollection<string> ids,
+            Func<T, string> idSelector,
+            Func<ICollection<string>, Task<IList<T>>> loadMissing)
+            where T : class
+        {
+            return (await cache.GetOrLoadMapByIdsAsync(keyPrefix, ids, idSelector, loadMissing)).Values;
+        }
+
+        /// <summary>
+        /// Values-only, by-<see cref="IEntity.Id"/> form: returns just the resolved items (not-found ids omitted),
+        /// for callers that do not need the id map.
+        /// </summary>
+        public static async Task<ICollection<T>> GetOrLoadByIdsAsync<T>(
+            this IRequestScopedCache cache,
+            string keyPrefix,
+            ICollection<string> ids,
+            Func<ICollection<string>, Task<IList<T>>> loadMissing)
+            where T : class, IEntity
+        {
+            return (await cache.GetOrLoadMapByIdsAsync(keyPrefix, ids, loadMissing)).Values;
         }
     }
 }

--- a/src/VirtoCommerce.Platform.Core/Caching/RequestScopedCacheExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/RequestScopedCacheExtensions.cs
@@ -3,51 +3,50 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using VirtoCommerce.Platform.Core.Common;
 
-namespace VirtoCommerce.Platform.Core.Caching
+namespace VirtoCommerce.Platform.Core.Caching;
+
+public static class RequestScopedCacheExtensions
 {
-    public static class RequestScopedCacheExtensions
+    /// <summary>
+    /// Values-only, by-<see cref="IEntity.Id"/> form: returns just the resolved items (not-found ids omitted),
+    /// for callers that do not need the id map.
+    /// </summary>
+    public static async Task<ICollection<T>> GetOrLoadByIdsAsync<T>(
+        this IRequestScopedCache cache,
+        string keyPrefix,
+        ICollection<string> ids,
+        Func<ICollection<string>, Task<IList<T>>> loadMissing)
+        where T : class, IEntity
     {
-        /// <summary>
-        /// Values-only, by-<see cref="IEntity.Id"/> form: returns just the resolved items (not-found ids omitted),
-        /// for callers that do not need the id map.
-        /// </summary>
-        public static async Task<ICollection<T>> GetOrLoadByIdsAsync<T>(
-            this IRequestScopedCache cache,
-            string keyPrefix,
-            ICollection<string> ids,
-            Func<ICollection<string>, Task<IList<T>>> loadMissing)
-            where T : class, IEntity
-        {
-            return (await GetOrLoadMapByIdsAsync(cache, keyPrefix, ids, loadMissing)).Values;
-        }
+        return (await GetOrLoadMapByIdsAsync(cache, keyPrefix, ids, loadMissing)).Values;
+    }
 
-        /// <summary>
-        /// Values-only form of <see cref="IRequestScopedCache.GetOrLoadMapByIdsAsync{T}(string, ICollection{string}, Func{T, string}, Func{ICollection{string}, Task{IList{T}}})"/>:
-        /// returns just the resolved items (not-found ids omitted), for callers that do not need the id map.
-        /// </summary>
-        public static async Task<ICollection<T>> GetOrLoadByIdsAsync<T>(
-            this IRequestScopedCache cache,
-            string keyPrefix,
-            ICollection<string> ids,
-            Func<T, string> idSelector,
-            Func<ICollection<string>, Task<IList<T>>> loadMissing)
-            where T : class
-        {
-            return (await cache.GetOrLoadMapByIdsAsync(keyPrefix, ids, idSelector, loadMissing)).Values;
-        }
+    /// <summary>
+    /// Values-only form of <see cref="IRequestScopedCache.GetOrLoadMapByIdsAsync{T}(string, ICollection{string}, Func{T, string}, Func{ICollection{string}, Task{IList{T}}})"/>:
+    /// returns just the resolved items (not-found ids omitted), for callers that do not need the id map.
+    /// </summary>
+    public static async Task<ICollection<T>> GetOrLoadByIdsAsync<T>(
+        this IRequestScopedCache cache,
+        string keyPrefix,
+        ICollection<string> ids,
+        Func<T, string> idSelector,
+        Func<ICollection<string>, Task<IList<T>>> loadMissing)
+        where T : class
+    {
+        return (await cache.GetOrLoadMapByIdsAsync(keyPrefix, ids, idSelector, loadMissing)).Values;
+    }
 
-        /// <summary>
-        /// By-id form for items keyed by <see cref="IEntity.Id"/>: delegates to
-        /// <see cref="IRequestScopedCache.GetOrLoadMapByIdsAsync{T}(string, ICollection{string}, Func{T, string}, Func{ICollection{string}, Task{IList{T}}})"/>.
-        /// </summary>
-        public static Task<IDictionary<string, T>> GetOrLoadMapByIdsAsync<T>(
-            this IRequestScopedCache cache,
-            string keyPrefix,
-            ICollection<string> ids,
-            Func<ICollection<string>, Task<IList<T>>> loadMissing)
-            where T : class, IEntity
-        {
-            return cache.GetOrLoadMapByIdsAsync(keyPrefix, ids, static x => x.Id, loadMissing);
-        }
+    /// <summary>
+    /// By-id form for items keyed by <see cref="IEntity.Id"/>: delegates to
+    /// <see cref="IRequestScopedCache.GetOrLoadMapByIdsAsync{T}(string, ICollection{string}, Func{T, string}, Func{ICollection{string}, Task{IList{T}}})"/>.
+    /// </summary>
+    public static Task<IDictionary<string, T>> GetOrLoadMapByIdsAsync<T>(
+        this IRequestScopedCache cache,
+        string keyPrefix,
+        ICollection<string> ids,
+        Func<ICollection<string>, Task<IList<T>>> loadMissing)
+        where T : class, IEntity
+    {
+        return cache.GetOrLoadMapByIdsAsync(keyPrefix, ids, static x => x.Id, loadMissing);
     }
 }

--- a/src/VirtoCommerce.Platform.Core/Caching/RequestScopedCacheExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/RequestScopedCacheExtensions.cs
@@ -1,0 +1,24 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using VirtoCommerce.Platform.Core.Common;
+
+namespace VirtoCommerce.Platform.Core.Caching
+{
+    public static class RequestScopedCacheExtensions
+    {
+        /// <summary>
+        /// By-id form for items keyed by <see cref="IEntity.Id"/>: delegates to
+        /// <see cref="IRequestScopedCache.GetOrLoadByIdsAsync{T}(string, ICollection{string}, Func{T, string}, Func{ICollection{string}, Task{IList{T}}})"/>.
+        /// </summary>
+        public static Task<IDictionary<string, T>> GetOrLoadByIdsAsync<T>(
+            this IRequestScopedCache cache,
+            string keyPrefix,
+            ICollection<string> ids,
+            Func<ICollection<string>, Task<IList<T>>> loadMissing)
+            where T : class, IEntity
+        {
+            return cache.GetOrLoadByIdsAsync(keyPrefix, ids, static x => x.Id, loadMissing);
+        }
+    }
+}

--- a/src/VirtoCommerce.Platform.Core/Caching/RequestScopedCacheExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/RequestScopedCacheExtensions.cs
@@ -33,6 +33,7 @@ namespace VirtoCommerce.Platform.Core.Caching
             Func<ICollection<string>, Task<IList<T>>> loadMissing)
             where T : class
         {
+            // Interface method (not a sibling extension) - must be called on the instance.
             return (await cache.GetOrLoadMapByIdsAsync(keyPrefix, ids, idSelector, loadMissing)).Values;
         }
 
@@ -47,7 +48,7 @@ namespace VirtoCommerce.Platform.Core.Caching
             Func<ICollection<string>, Task<IList<T>>> loadMissing)
             where T : class, IEntity
         {
-            return (await cache.GetOrLoadMapByIdsAsync(keyPrefix, ids, loadMissing)).Values;
+            return (await GetOrLoadMapByIdsAsync(cache, keyPrefix, ids, loadMissing)).Values;
         }
     }
 }

--- a/tests/VirtoCommerce.Platform.Caching.Tests/RequestScopedCacheTests.cs
+++ b/tests/VirtoCommerce.Platform.Caching.Tests/RequestScopedCacheTests.cs
@@ -101,12 +101,12 @@ namespace VirtoCommerce.Platform.Caching.Tests
         }
 
         [Fact]
-        public async Task GetOrLoadByIdsAsync_LoadsAllMissingIdsInOneBatch()
+        public async Task GetOrLoadMapByIdsAsync_LoadsAllMissingIdsInOneBatch()
         {
             var sut = new RequestScopedCache();
             var batches = new List<string[]>();
 
-            var result = await sut.GetOrLoadByIdsAsync("prefix", ["a", "b", "c"], x => x.Id, CreateLoader(batches));
+            var result = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b", "c"], x => x.Id, CreateLoader(batches));
 
             AssertSameIds(["a", "b", "c"], Assert.Single(batches));
             AssertSameIds(["a", "b", "c"], result.Keys);
@@ -114,15 +114,15 @@ namespace VirtoCommerce.Platform.Caching.Tests
         }
 
         [Fact]
-        public async Task GetOrLoadByIdsAsync_OverlappingCall_LoadsOnlyNotYetCachedIds()
+        public async Task GetOrLoadMapByIdsAsync_OverlappingCall_LoadsOnlyNotYetCachedIds()
         {
             var sut = new RequestScopedCache();
             var batches = new List<string[]>();
             var loadMissing = CreateLoader(batches);
 
-            var first = await sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], x => x.Id, loadMissing);
-            var second = await sut.GetOrLoadByIdsAsync("prefix", ["b", "c"], x => x.Id, loadMissing);
-            var third = await sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], x => x.Id, loadMissing);
+            var first = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, loadMissing);
+            var second = await sut.GetOrLoadMapByIdsAsync("prefix", ["b", "c"], x => x.Id, loadMissing);
+            var third = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, loadMissing);
 
             // The second call must load only the ids the first call did not cache, and the third must load nothing.
             Assert.Equal(2, batches.Count);
@@ -134,7 +134,7 @@ namespace VirtoCommerce.Platform.Caching.Tests
         }
 
         [Fact]
-        public async Task GetOrLoadByIdsAsync_IdCasingDiffers_MatchesCaseInsensitively()
+        public async Task GetOrLoadMapByIdsAsync_IdCasingDiffers_MatchesCaseInsensitively()
         {
             var sut = new RequestScopedCache();
             var batches = new List<string[]>();
@@ -142,8 +142,8 @@ namespace VirtoCommerce.Platform.Caching.Tests
             // case-insensitive DB collation would): request "ABC", stored id "abc".
             var loadMissing = CreateLoader(batches, x => new Item(x.ToLowerInvariant()));
 
-            var first = await sut.GetOrLoadByIdsAsync("prefix", ["ABC"], x => x.Id, loadMissing);
-            var second = await sut.GetOrLoadByIdsAsync("prefix", ["abc"], x => x.Id, loadMissing);
+            var first = await sut.GetOrLoadMapByIdsAsync("prefix", ["ABC"], x => x.Id, loadMissing);
+            var second = await sut.GetOrLoadMapByIdsAsync("prefix", ["abc"], x => x.Id, loadMissing);
 
             // The loaded item publishes to the requested reservation despite the casing difference,
             // and a differently-cased repeat dedups against the cached entry instead of re-loading.
@@ -153,15 +153,15 @@ namespace VirtoCommerce.Platform.Caching.Tests
         }
 
         [Fact]
-        public async Task GetOrLoadByIdsAsync_NotFoundId_OmittedAndNegativelyCached()
+        public async Task GetOrLoadMapByIdsAsync_NotFoundId_OmittedAndNegativelyCached()
         {
             var sut = new RequestScopedCache();
             var batches = new List<string[]>();
             // The loader never returns an item for "ghost".
             var loadMissing = CreateLoader(batches, x => x == "ghost" ? null : new Item(x));
 
-            var first = await sut.GetOrLoadByIdsAsync("prefix", ["a", "ghost"], x => x.Id, loadMissing);
-            var second = await sut.GetOrLoadByIdsAsync("prefix", ["a", "ghost"], x => x.Id, loadMissing);
+            var first = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "ghost"], x => x.Id, loadMissing);
+            var second = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "ghost"], x => x.Id, loadMissing);
 
             AssertSameIds(["a"], first.Keys);
             AssertSameIds(["a"], second.Keys);
@@ -170,31 +170,31 @@ namespace VirtoCommerce.Platform.Caching.Tests
         }
 
         [Fact]
-        public async Task GetOrLoadByIdsAsync_NullEmptyAndDuplicateIds_NormalizedWithinCall()
+        public async Task GetOrLoadMapByIdsAsync_NullEmptyAndDuplicateIds_NormalizedWithinCall()
         {
             var sut = new RequestScopedCache();
             var batches = new List<string[]>();
 
-            var result = await sut.GetOrLoadByIdsAsync("prefix", [null, "", "a", "a", "b"], x => x.Id, CreateLoader(batches));
+            var result = await sut.GetOrLoadMapByIdsAsync("prefix", [null, "", "a", "a", "b"], x => x.Id, CreateLoader(batches));
 
             AssertSameIds(["a", "b"], Assert.Single(batches));
             AssertSameIds(["a", "b"], result.Keys);
         }
 
         [Fact]
-        public async Task GetOrLoadByIdsAsync_EmptyIds_ReturnsEmptyWithoutLoad()
+        public async Task GetOrLoadMapByIdsAsync_EmptyIds_ReturnsEmptyWithoutLoad()
         {
             var sut = new RequestScopedCache();
             var batches = new List<string[]>();
 
-            var result = await sut.GetOrLoadByIdsAsync("prefix", Array.Empty<string>(), x => x.Id, CreateLoader(batches));
+            var result = await sut.GetOrLoadMapByIdsAsync("prefix", Array.Empty<string>(), x => x.Id, CreateLoader(batches));
 
             Assert.Empty(result);
             Assert.Empty(batches);
         }
 
         [Fact]
-        public async Task GetOrLoadByIdsAsync_FaultedLoad_CachedForTheRequestAndRethrown()
+        public async Task GetOrLoadMapByIdsAsync_FaultedLoad_CachedForTheRequestAndRethrown()
         {
             var sut = new RequestScopedCache();
             var callCount = 0;
@@ -205,8 +205,8 @@ namespace VirtoCommerce.Platform.Caching.Tests
                 throw new InvalidOperationException("boom");
             }
 
-            Func<Task<IDictionary<string, Item>>> firstCall = () => sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
-            Func<Task<IDictionary<string, Item>>> secondCall = () => sut.GetOrLoadByIdsAsync("prefix", ["a"], x => x.Id, LoadMissing);
+            Func<Task<IDictionary<string, Item>>> firstCall = () => sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
+            Func<Task<IDictionary<string, Item>>> secondCall = () => sut.GetOrLoadMapByIdsAsync("prefix", ["a"], x => x.Id, LoadMissing);
 
             var firstEx = await Assert.ThrowsAsync<InvalidOperationException>(firstCall);
             var secondEx = await Assert.ThrowsAsync<InvalidOperationException>(secondCall);
@@ -217,7 +217,7 @@ namespace VirtoCommerce.Platform.Caching.Tests
         }
 
         [Fact]
-        public async Task GetOrLoadByIdsAsync_NullLoaderResult_TreatedAsEmptyAndNegativelyCached()
+        public async Task GetOrLoadMapByIdsAsync_NullLoaderResult_TreatedAsEmptyAndNegativelyCached()
         {
             var sut = new RequestScopedCache();
             var callCount = 0;
@@ -228,8 +228,8 @@ namespace VirtoCommerce.Platform.Caching.Tests
                 return Task.FromResult<IList<Item>>(null);
             }
 
-            var first = await sut.GetOrLoadByIdsAsync("prefix", ["a"], x => x.Id, LoadMissing);
-            var second = await sut.GetOrLoadByIdsAsync("prefix", ["a"], x => x.Id, LoadMissing);
+            var first = await sut.GetOrLoadMapByIdsAsync("prefix", ["a"], x => x.Id, LoadMissing);
+            var second = await sut.GetOrLoadMapByIdsAsync("prefix", ["a"], x => x.Id, LoadMissing);
 
             Assert.Empty(first);
             Assert.Empty(second);
@@ -238,7 +238,7 @@ namespace VirtoCommerce.Platform.Caching.Tests
         }
 
         [Fact]
-        public async Task GetOrLoadByIdsAsync_InFlightLoad_SharedByLaterCallInsteadOfSecondLoad()
+        public async Task GetOrLoadMapByIdsAsync_InFlightLoad_SharedByLaterCallInsteadOfSecondLoad()
         {
             var sut = new RequestScopedCache();
             var release = new TaskCompletionSource();
@@ -252,8 +252,8 @@ namespace VirtoCommerce.Platform.Caching.Tests
             }
 
             // The first call dispatches the load synchronously up to the await, then stays in flight.
-            var firstTask = sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
-            var secondTask = sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
+            var firstTask = sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
+            var secondTask = sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
 
             Assert.False(firstTask.IsCompleted);
             Assert.False(secondTask.IsCompleted);
@@ -268,7 +268,7 @@ namespace VirtoCommerce.Platform.Caching.Tests
         }
 
         [Fact]
-        public async Task GetOrLoadByIdsAsync_ConcurrentOverlappingCallers_EachIdLoadedAtMostOnce()
+        public async Task GetOrLoadMapByIdsAsync_ConcurrentOverlappingCallers_EachIdLoadedAtMostOnce()
         {
             // Regression guard for per-caller full-batch amplification: under concurrent overlapping
             // misses, each id must be loaded by exactly one caller, so the total load across all
@@ -295,7 +295,7 @@ namespace VirtoCommerce.Platform.Caching.Tests
             for (var i = 0; i < callers; i++)
             {
                 var callerIds = Enumerable.Range(i * windowStride, windowSize).Select(x => $"id-{x}").ToArray();
-                tasks[i] = Task.Run(() => sut.GetOrLoadByIdsAsync("prefix", callerIds, x => x.Id, LoadMissing));
+                tasks[i] = Task.Run(() => sut.GetOrLoadMapByIdsAsync("prefix", callerIds, x => x.Id, LoadMissing));
             }
 
             // Give every caller a chance to reserve its ids before any load completes.
@@ -323,15 +323,15 @@ namespace VirtoCommerce.Platform.Caching.Tests
         }
 
         [Fact]
-        public async Task GetOrLoadByIdsAsync_TupleKeys_DoNotCollideAcrossPrefixesOrWithByKeyEntries()
+        public async Task GetOrLoadMapByIdsAsync_TupleKeys_DoNotCollideAcrossPrefixesOrWithByKeyEntries()
         {
             var sut = new RequestScopedCache();
             var batches = new List<string[]>();
             var loadMissing = CreateLoader(batches);
 
             // "P" + "A:B" and "P:A" + "B" would alias under naive string concatenation.
-            var first = await sut.GetOrLoadByIdsAsync("P", ["A:B"], x => x.Id, loadMissing);
-            var second = await sut.GetOrLoadByIdsAsync("P:A", ["B"], x => x.Id, loadMissing);
+            var first = await sut.GetOrLoadMapByIdsAsync("P", ["A:B"], x => x.Id, loadMissing);
+            var second = await sut.GetOrLoadMapByIdsAsync("P:A", ["B"], x => x.Id, loadMissing);
             var byKey = await sut.GetOrAddAsync("P:A:B", () => Task.FromResult("by-key value"));
 
             // Entries under different prefixes must not alias.
@@ -342,7 +342,7 @@ namespace VirtoCommerce.Platform.Caching.Tests
         }
 
         [Fact]
-        public async Task GetOrLoadByIdsAsync_ExtraAndDuplicateLoadedItems_FirstWinsAndExtrasIgnored()
+        public async Task GetOrLoadMapByIdsAsync_ExtraAndDuplicateLoadedItems_FirstWinsAndExtrasIgnored()
         {
             var sut = new RequestScopedCache();
             var requestedFirst = new Item("a");
@@ -350,7 +350,7 @@ namespace VirtoCommerce.Platform.Caching.Tests
             var batches = new List<string[]>();
             var loadMissing = CreateLoader(batches);
 
-            var result = await sut.GetOrLoadByIdsAsync(
+            var result = await sut.GetOrLoadMapByIdsAsync(
                 "prefix",
                 ["a"],
                 x => x.Id,
@@ -361,33 +361,33 @@ namespace VirtoCommerce.Platform.Caching.Tests
             Assert.Same(requestedFirst, result["a"]);
 
             // The unrequested extra item must not have been cached.
-            var extra = await sut.GetOrLoadByIdsAsync("prefix", ["x"], x => x.Id, loadMissing);
+            var extra = await sut.GetOrLoadMapByIdsAsync("prefix", ["x"], x => x.Id, loadMissing);
             AssertSameIds(["x"], Assert.Single(batches));
             Assert.NotNull(extra["x"]);
         }
 
         [Fact]
-        public async Task GetOrLoadByIdsAsync_SamePrefixAndIdWithDifferentType_ThrowsInvalidCast()
+        public async Task GetOrLoadMapByIdsAsync_SamePrefixAndIdWithDifferentType_ThrowsInvalidCast()
         {
             var sut = new RequestScopedCache();
 
-            await sut.GetOrLoadByIdsAsync("prefix", ["a"], x => x.Id, CreateLoader([]));
+            await sut.GetOrLoadMapByIdsAsync("prefix", ["a"], x => x.Id, CreateLoader([]));
 
-            Func<Task<IDictionary<string, OtherItem>>> act = () => sut.GetOrLoadByIdsAsync<OtherItem>("prefix", ["a"], x => x.Id, _ => Task.FromResult<IList<OtherItem>>([]));
+            Func<Task<IDictionary<string, OtherItem>>> act = () => sut.GetOrLoadMapByIdsAsync<OtherItem>("prefix", ["a"], x => x.Id, _ => Task.FromResult<IList<OtherItem>>([]));
 
             await Assert.ThrowsAsync<InvalidCastException>(act);
         }
 
         [Fact]
-        public async Task GetOrLoadByIdsAsync_InvalidArguments_Throw()
+        public async Task GetOrLoadMapByIdsAsync_InvalidArguments_Throw()
         {
             var sut = new RequestScopedCache();
             var loadMissing = CreateLoader([]);
 
-            Func<Task<IDictionary<string, Item>>> emptyPrefix = () => sut.GetOrLoadByIdsAsync("", ["a"], x => x.Id, loadMissing);
-            Func<Task<IDictionary<string, Item>>> nullIds = () => sut.GetOrLoadByIdsAsync("prefix", null, x => x.Id, loadMissing);
-            Func<Task<IDictionary<string, Item>>> nullSelector = () => sut.GetOrLoadByIdsAsync<Item>("prefix", ["a"], null, loadMissing);
-            Func<Task<IDictionary<string, Item>>> nullLoader = () => sut.GetOrLoadByIdsAsync<Item>("prefix", ["a"], x => x.Id, null);
+            Func<Task<IDictionary<string, Item>>> emptyPrefix = () => sut.GetOrLoadMapByIdsAsync("", ["a"], x => x.Id, loadMissing);
+            Func<Task<IDictionary<string, Item>>> nullIds = () => sut.GetOrLoadMapByIdsAsync("prefix", null, x => x.Id, loadMissing);
+            Func<Task<IDictionary<string, Item>>> nullSelector = () => sut.GetOrLoadMapByIdsAsync<Item>("prefix", ["a"], null, loadMissing);
+            Func<Task<IDictionary<string, Item>>> nullLoader = () => sut.GetOrLoadMapByIdsAsync<Item>("prefix", ["a"], x => x.Id, null);
 
             await Assert.ThrowsAsync<ArgumentException>(emptyPrefix);
             await Assert.ThrowsAsync<ArgumentNullException>(nullIds);
@@ -396,7 +396,7 @@ namespace VirtoCommerce.Platform.Caching.Tests
         }
 
         [Fact]
-        public async Task GetOrLoadByIdsAsync_EntityOverload_KeysByEntityIdAndSharesEntries()
+        public async Task GetOrLoadMapByIdsAsync_EntityOverload_KeysByEntityIdAndSharesEntries()
         {
             var sut = new RequestScopedCache();
             var batches = new List<string[]>();
@@ -411,13 +411,58 @@ namespace VirtoCommerce.Platform.Caching.Tests
                 return Task.FromResult<IList<EntityItem>>(missingIds.Select(x => new EntityItem { Id = x }).ToList());
             }
 
-            var viaEntityOverload = await sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], LoadMissing);
-            var viaCoreOverload = await sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
+            var viaEntityOverload = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], LoadMissing);
+            var viaCoreOverload = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
 
             // The IEntity overload must delegate to the core overload and share its cache entries.
             Assert.Single(batches);
             AssertSameIds(["a", "b"], viaEntityOverload.Keys);
             Assert.Same(viaEntityOverload["a"], viaCoreOverload["a"]);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_ReturnsResolvedItemValuesSharingTheMapCache()
+        {
+            var sut = new RequestScopedCache();
+            var batches = new List<string[]>();
+
+            var values = await sut.GetOrLoadByIdsAsync(
+                "prefix",
+                ["a", "b", "ghost"],
+                x => x.Id,
+                CreateLoader(batches, x => x == "ghost" ? null : new Item(x)));
+
+            // The values-only overload returns the resolved items, with not-found ids omitted.
+            AssertSameIds(["a", "b"], values.Select(x => x.Id));
+
+            // It shares the underlying cache with the map overload: the same ids resolve without a reload,
+            // to the same instances.
+            var map = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, CreateLoader(batches));
+            Assert.Single(batches);
+            Assert.Same(map["a"], values.Single(x => x.Id == "a"));
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_EntityOverload_ReturnsResolvedItemValues()
+        {
+            var sut = new RequestScopedCache();
+            var batches = new List<string[]>();
+
+            Task<IList<EntityItem>> LoadMissing(ICollection<string> missingIds)
+            {
+                lock (batches)
+                {
+                    batches.Add([.. missingIds]);
+                }
+
+                return Task.FromResult<IList<EntityItem>>(missingIds.Select(x => new EntityItem { Id = x }).ToList());
+            }
+
+            var values = await sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], LoadMissing);
+
+            // The IEntity values-only overload keys by entity Id and returns just the items.
+            AssertSameIds(["a", "b"], values.Select(x => x.Id));
+            Assert.Single(batches);
         }
 
         private static void AssertSameIds(IEnumerable<string> expected, IEnumerable<string> actual)

--- a/tests/VirtoCommerce.Platform.Caching.Tests/RequestScopedCacheTests.cs
+++ b/tests/VirtoCommerce.Platform.Caching.Tests/RequestScopedCacheTests.cs
@@ -379,6 +379,25 @@ namespace VirtoCommerce.Platform.Caching.Tests
         }
 
         [Fact]
+        public async Task GetOrLoadMapByIdsAsync_TypeMismatchOnOneId_LeavesInnocentOwnedIdsRetryable()
+        {
+            var sut = new RequestScopedCache();
+            var batches = new List<string[]>();
+
+            // Cache "b" under a different type first, so a later Item-typed request for it throws on the cast.
+            await sut.GetOrLoadMapByIdsAsync("prefix", ["b"], x => x.Id, _ => Task.FromResult<IList<OtherItem>>([new OtherItem("b")]));
+
+            // This call owns "a" (processed first), then hits the type mismatch on "b" and must throw.
+            Func<Task<IDictionary<string, Item>>> mismatch = () => sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, CreateLoader(batches));
+            await Assert.ThrowsAsync<InvalidCastException>(mismatch);
+
+            // The innocent "a" must NOT be negatively cached by "b"'s type conflict: a later correctly-typed
+            // call re-reserves and loads it successfully.
+            var recovered = await sut.GetOrLoadMapByIdsAsync("prefix", ["a"], x => x.Id, CreateLoader(batches));
+            Assert.Equal("a", recovered["a"].Id);
+        }
+
+        [Fact]
         public async Task GetOrLoadMapByIdsAsync_InvalidArguments_Throw()
         {
             var sut = new RequestScopedCache();

--- a/tests/VirtoCommerce.Platform.Caching.Tests/RequestScopedCacheTests.cs
+++ b/tests/VirtoCommerce.Platform.Caching.Tests/RequestScopedCacheTests.cs
@@ -134,6 +134,25 @@ namespace VirtoCommerce.Platform.Caching.Tests
         }
 
         [Fact]
+        public async Task GetOrLoadByIdsAsync_IdCasingDiffers_MatchesCaseInsensitively()
+        {
+            var sut = new RequestScopedCache();
+            var batches = new List<string[]>();
+            // The loader returns the entity with a different id casing than requested (as a
+            // case-insensitive DB collation would): request "ABC", stored id "abc".
+            var loadMissing = CreateLoader(batches, x => new Item(x.ToLowerInvariant()));
+
+            var first = await sut.GetOrLoadByIdsAsync("prefix", ["ABC"], x => x.Id, loadMissing);
+            var second = await sut.GetOrLoadByIdsAsync("prefix", ["abc"], x => x.Id, loadMissing);
+
+            // The loaded item publishes to the requested reservation despite the casing difference,
+            // and a differently-cased repeat dedups against the cached entry instead of re-loading.
+            Assert.Single(batches);
+            Assert.NotNull(first["ABC"]);
+            Assert.Same(first["ABC"], second["abc"]);
+        }
+
+        [Fact]
         public async Task GetOrLoadByIdsAsync_NotFoundId_OmittedAndNegativelyCached()
         {
             var sut = new RequestScopedCache();

--- a/tests/VirtoCommerce.Platform.Caching.Tests/RequestScopedCacheTests.cs
+++ b/tests/VirtoCommerce.Platform.Caching.Tests/RequestScopedCacheTests.cs
@@ -7,515 +7,514 @@ using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Common;
 using Xunit;
 
-namespace VirtoCommerce.Platform.Caching.Tests
+namespace VirtoCommerce.Platform.Caching.Tests;
+
+public class RequestScopedCacheTests
 {
-    public class RequestScopedCacheTests
+    [Fact]
+    public async Task GetOrAddAsync_SameKey_FactoryExecutedOnce()
     {
-        [Fact]
-        public async Task GetOrAddAsync_SameKey_FactoryExecutedOnce()
-        {
-            var sut = new RequestScopedCache();
-            var callCount = 0;
+        var sut = new RequestScopedCache();
+        var callCount = 0;
 
-            Task<string> Factory()
+        Task<string> Factory()
+        {
+            Interlocked.Increment(ref callCount);
+            return Task.FromResult("value");
+        }
+
+        var first = await sut.GetOrAddAsync("key", Factory);
+        var second = await sut.GetOrAddAsync("key", Factory);
+
+        Assert.Equal("value", first);
+        Assert.Equal("value", second);
+        // The second call for the same key must be served from the cached result, not re-invoke the factory.
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task GetOrAddAsync_DifferentKeys_FactoryExecutedPerKey()
+    {
+        var sut = new RequestScopedCache();
+        var callCount = 0;
+
+        Task<int> Factory()
+        {
+            return Task.FromResult(Interlocked.Increment(ref callCount));
+        }
+
+        var first = await sut.GetOrAddAsync("key-1", Factory);
+        var second = await sut.GetOrAddAsync("key-2", Factory);
+
+        Assert.Equal(1, first);
+        Assert.Equal(2, second);
+        // Distinct keys must not share a cached result.
+        Assert.Equal(2, callCount);
+    }
+
+    [Fact]
+    public async Task GetOrAddAsync_ConcurrentSameKey_FactoryExecutedExactlyOnce()
+    {
+        // The single-flight guarantee: a burst of concurrent callers racing on the same key must
+        // all observe the same in-flight Task rather than each starting its own factory invocation.
+        var sut = new RequestScopedCache();
+        var callCount = 0;
+        var release = new TaskCompletionSource();
+
+        async Task<int> Factory()
+        {
+            Interlocked.Increment(ref callCount);
+            await release.Task;
+            return 42;
+        }
+
+        const int callers = 20;
+        var tasks = new Task<int>[callers];
+        for (var i = 0; i < callers; i++)
+        {
+            // Task.Run forces the callers onto distinct pool threads so they race on GetOrAdd for real,
+            // instead of entering it cooperatively from one thread.
+            tasks[i] = Task.Run(() => sut.GetOrAddAsync("key", Factory));
+        }
+
+        // Give every caller a chance to reach GetOrAddAsync before releasing the factory.
+        await Task.Delay(20, TestContext.Current.CancellationToken);
+        release.SetResult();
+
+        var results = await Task.WhenAll(tasks);
+
+        // Concurrent callers on the same key must share a single in-flight factory invocation.
+        Assert.Equal(1, callCount);
+        Assert.All(results, x => Assert.Equal(42, x));
+    }
+
+    [Fact]
+    public async Task GetOrAddAsync_DifferentResultTypesPerKey_BothResolveCorrectly()
+    {
+        var sut = new RequestScopedCache();
+
+        var stringResult = await sut.GetOrAddAsync("string-key", () => Task.FromResult("text"));
+        var intResult = await sut.GetOrAddAsync("int-key", () => Task.FromResult(7));
+
+        Assert.Equal("text", stringResult);
+        Assert.Equal(7, intResult);
+    }
+
+    [Fact]
+    public async Task GetOrLoadMapByIdsAsync_LoadsAllMissingIdsInOneBatch()
+    {
+        var sut = new RequestScopedCache();
+        var batches = new List<string[]>();
+
+        var result = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b", "c"], x => x.Id, CreateLoader(batches));
+
+        AssertSameIds(["a", "b", "c"], Assert.Single(batches));
+        AssertSameIds(["a", "b", "c"], result.Keys);
+        Assert.Equal("a", result["a"].Id);
+    }
+
+    [Fact]
+    public async Task GetOrLoadMapByIdsAsync_OverlappingCall_LoadsOnlyNotYetCachedIds()
+    {
+        var sut = new RequestScopedCache();
+        var batches = new List<string[]>();
+        var loadMissing = CreateLoader(batches);
+
+        var first = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, loadMissing);
+        var second = await sut.GetOrLoadMapByIdsAsync("prefix", ["b", "c"], x => x.Id, loadMissing);
+        var third = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, loadMissing);
+
+        // The second call must load only the ids the first call did not cache, and the third must load nothing.
+        Assert.Equal(2, batches.Count);
+        AssertSameIds(["c"], batches[1]);
+        AssertSameIds(["b", "c"], second.Keys);
+        // An overlapping id must be served from the cache, not re-loaded.
+        Assert.Same(first["b"], second["b"]);
+        Assert.Same(first["a"], third["a"]);
+    }
+
+    [Fact]
+    public async Task GetOrLoadMapByIdsAsync_IdCasingDiffers_MatchesCaseInsensitively()
+    {
+        var sut = new RequestScopedCache();
+        var batches = new List<string[]>();
+        // The loader returns the entity with a different id casing than requested (as a
+        // case-insensitive DB collation would): request "ABC", stored id "abc".
+        var loadMissing = CreateLoader(batches, x => new Item(x.ToLowerInvariant()));
+
+        var first = await sut.GetOrLoadMapByIdsAsync("prefix", ["ABC"], x => x.Id, loadMissing);
+        var second = await sut.GetOrLoadMapByIdsAsync("prefix", ["abc"], x => x.Id, loadMissing);
+
+        // The loaded item publishes to the requested reservation despite the casing difference,
+        // and a differently-cased repeat dedups against the cached entry instead of re-loading.
+        Assert.Single(batches);
+        Assert.NotNull(first["ABC"]);
+        Assert.Same(first["ABC"], second["abc"]);
+    }
+
+    [Fact]
+    public async Task GetOrLoadMapByIdsAsync_NotFoundId_OmittedAndNegativelyCached()
+    {
+        var sut = new RequestScopedCache();
+        var batches = new List<string[]>();
+        // The loader never returns an item for "ghost".
+        var loadMissing = CreateLoader(batches, x => x == "ghost" ? null : new Item(x));
+
+        var first = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "ghost"], x => x.Id, loadMissing);
+        var second = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "ghost"], x => x.Id, loadMissing);
+
+        AssertSameIds(["a"], first.Keys);
+        AssertSameIds(["a"], second.Keys);
+        // A not-found id must be negatively cached for the request, not re-loaded.
+        Assert.Single(batches);
+    }
+
+    [Fact]
+    public async Task GetOrLoadMapByIdsAsync_NullEmptyAndDuplicateIds_NormalizedWithinCall()
+    {
+        var sut = new RequestScopedCache();
+        var batches = new List<string[]>();
+
+        var result = await sut.GetOrLoadMapByIdsAsync("prefix", [null, "", "a", "a", "b"], x => x.Id, CreateLoader(batches));
+
+        AssertSameIds(["a", "b"], Assert.Single(batches));
+        AssertSameIds(["a", "b"], result.Keys);
+    }
+
+    [Fact]
+    public async Task GetOrLoadMapByIdsAsync_EmptyIds_ReturnsEmptyWithoutLoad()
+    {
+        var sut = new RequestScopedCache();
+        var batches = new List<string[]>();
+
+        var result = await sut.GetOrLoadMapByIdsAsync("prefix", Array.Empty<string>(), x => x.Id, CreateLoader(batches));
+
+        Assert.Empty(result);
+        Assert.Empty(batches);
+    }
+
+    [Fact]
+    public async Task GetOrLoadMapByIdsAsync_FaultedLoad_CachedForTheRequestAndRethrown()
+    {
+        var sut = new RequestScopedCache();
+        var callCount = 0;
+
+        Task<IList<Item>> LoadMissing(ICollection<string> missingIds)
+        {
+            Interlocked.Increment(ref callCount);
+            throw new InvalidOperationException("boom");
+        }
+
+        Func<Task<IDictionary<string, Item>>> firstCall = () => sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
+        Func<Task<IDictionary<string, Item>>> secondCall = () => sut.GetOrLoadMapByIdsAsync("prefix", ["a"], x => x.Id, LoadMissing);
+
+        var firstEx = await Assert.ThrowsAsync<InvalidOperationException>(firstCall);
+        var secondEx = await Assert.ThrowsAsync<InvalidOperationException>(secondCall);
+        Assert.Equal("boom", firstEx.Message);
+        Assert.Equal("boom", secondEx.Message);
+        // A faulted load must be cached for the request - same-id calls rethrow without re-loading.
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task GetOrLoadMapByIdsAsync_NullLoaderResult_TreatedAsEmptyAndNegativelyCached()
+    {
+        var sut = new RequestScopedCache();
+        var callCount = 0;
+
+        Task<IList<Item>> LoadMissing(ICollection<string> missingIds)
+        {
+            Interlocked.Increment(ref callCount);
+            return Task.FromResult<IList<Item>>(null);
+        }
+
+        var first = await sut.GetOrLoadMapByIdsAsync("prefix", ["a"], x => x.Id, LoadMissing);
+        var second = await sut.GetOrLoadMapByIdsAsync("prefix", ["a"], x => x.Id, LoadMissing);
+
+        Assert.Empty(first);
+        Assert.Empty(second);
+        // Ids from a null (empty) load result are negatively cached for the request, not re-loaded.
+        Assert.Equal(1, callCount);
+    }
+
+    [Fact]
+    public async Task GetOrLoadMapByIdsAsync_InFlightLoad_SharedByLaterCallInsteadOfSecondLoad()
+    {
+        var sut = new RequestScopedCache();
+        var release = new TaskCompletionSource();
+        var callCount = 0;
+
+        async Task<IList<Item>> LoadMissing(ICollection<string> missingIds)
+        {
+            Interlocked.Increment(ref callCount);
+            await release.Task;
+            return missingIds.Select(x => new Item(x)).ToList();
+        }
+
+        // The first call dispatches the load synchronously up to the await, then stays in flight.
+        var firstTask = sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
+        var secondTask = sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
+
+        Assert.False(firstTask.IsCompleted);
+        Assert.False(secondTask.IsCompleted);
+        release.SetResult();
+
+        var first = await firstTask;
+        var second = await secondTask;
+
+        // The second caller must await the in-flight load, not start its own.
+        Assert.Equal(1, callCount);
+        Assert.Same(first["a"], second["a"]);
+    }
+
+    [Fact]
+    public async Task GetOrLoadMapByIdsAsync_ConcurrentOverlappingCallers_EachIdLoadedAtMostOnce()
+    {
+        // Regression guard for per-caller full-batch amplification: under concurrent overlapping
+        // misses, each id must be loaded by exactly one caller, so the total load across all
+        // callers is the distinct union - never a caller's full missing set re-loaded.
+        const int callers = 8;
+        const int windowSize = 12;
+        const int windowStride = 4;
+        var sut = new RequestScopedCache();
+        var release = new TaskCompletionSource();
+        var batches = new List<string[]>();
+
+        async Task<IList<Item>> LoadMissing(ICollection<string> missingIds)
+        {
+            lock (batches)
             {
-                Interlocked.Increment(ref callCount);
-                return Task.FromResult("value");
+                batches.Add([.. missingIds]);
             }
 
-            var first = await sut.GetOrAddAsync("key", Factory);
-            var second = await sut.GetOrAddAsync("key", Factory);
-
-            Assert.Equal("value", first);
-            Assert.Equal("value", second);
-            // The second call for the same key must be served from the cached result, not re-invoke the factory.
-            Assert.Equal(1, callCount);
+            await release.Task;
+            return missingIds.Select(x => new Item(x)).ToList();
         }
 
-        [Fact]
-        public async Task GetOrAddAsync_DifferentKeys_FactoryExecutedPerKey()
+        var tasks = new Task<IDictionary<string, Item>>[callers];
+        for (var i = 0; i < callers; i++)
         {
-            var sut = new RequestScopedCache();
-            var callCount = 0;
+            var callerIds = Enumerable.Range(i * windowStride, windowSize).Select(x => $"id-{x}").ToArray();
+            tasks[i] = Task.Run(() => sut.GetOrLoadMapByIdsAsync("prefix", callerIds, x => x.Id, LoadMissing));
+        }
 
-            Task<int> Factory()
+        // Give every caller a chance to reserve its ids before any load completes.
+        await Task.Delay(20, TestContext.Current.CancellationToken);
+        release.SetResult();
+
+        var results = await Task.WhenAll(tasks);
+
+        var idSpace = (callers - 1) * windowStride + windowSize;
+        var loadedIds = batches.SelectMany(x => x).ToList();
+        // An id must never appear in two batches within one request.
+        Assert.Equal(loadedIds.Count, loadedIds.Distinct().Count());
+        // The union of all batches must be exactly the distinct union of requested ids.
+        AssertSameIds(Enumerable.Range(0, idSpace).Select(x => $"id-{x}"), loadedIds);
+        // Each caller dispatches at most one batch.
+        Assert.True(batches.Count <= callers);
+
+        for (var i = 0; i < callers; i++)
+        {
+            AssertSameIds(Enumerable.Range(i * windowStride, windowSize).Select(x => $"id-{x}"), results[i].Keys);
+        }
+
+        // Overlapping ids resolve to the same shared instance across callers.
+        Assert.Same(results[0]["id-4"], results[1]["id-4"]);
+    }
+
+    [Fact]
+    public async Task GetOrLoadMapByIdsAsync_TupleKeys_DoNotCollideAcrossPrefixesOrWithByKeyEntries()
+    {
+        var sut = new RequestScopedCache();
+        var batches = new List<string[]>();
+        var loadMissing = CreateLoader(batches);
+
+        // "P" + "A:B" and "P:A" + "B" would alias under naive string concatenation.
+        var first = await sut.GetOrLoadMapByIdsAsync("P", ["A:B"], x => x.Id, loadMissing);
+        var second = await sut.GetOrLoadMapByIdsAsync("P:A", ["B"], x => x.Id, loadMissing);
+        var byKey = await sut.GetOrAddAsync("P:A:B", () => Task.FromResult("by-key value"));
+
+        // Entries under different prefixes must not alias.
+        Assert.Equal(2, batches.Count);
+        Assert.Equal("A:B", first["A:B"].Id);
+        Assert.Equal("B", second["B"].Id);
+        Assert.Equal("by-key value", byKey);
+    }
+
+    [Fact]
+    public async Task GetOrLoadMapByIdsAsync_ExtraAndDuplicateLoadedItems_FirstWinsAndExtrasIgnored()
+    {
+        var sut = new RequestScopedCache();
+        var requestedFirst = new Item("a");
+        var requestedDuplicate = new Item("a");
+        var batches = new List<string[]>();
+        var loadMissing = CreateLoader(batches);
+
+        var result = await sut.GetOrLoadMapByIdsAsync(
+            "prefix",
+            ["a"],
+            x => x.Id,
+            _ => Task.FromResult<IList<Item>>([requestedFirst, requestedDuplicate, new Item("x")]));
+
+        AssertSameIds(["a"], result.Keys);
+        // The first loaded item for an id wins.
+        Assert.Same(requestedFirst, result["a"]);
+
+        // The unrequested extra item must not have been cached.
+        var extra = await sut.GetOrLoadMapByIdsAsync("prefix", ["x"], x => x.Id, loadMissing);
+        AssertSameIds(["x"], Assert.Single(batches));
+        Assert.NotNull(extra["x"]);
+    }
+
+    [Fact]
+    public async Task GetOrLoadMapByIdsAsync_SamePrefixAndIdWithDifferentType_ThrowsInvalidCast()
+    {
+        var sut = new RequestScopedCache();
+
+        await sut.GetOrLoadMapByIdsAsync("prefix", ["a"], x => x.Id, CreateLoader([]));
+
+        Func<Task<IDictionary<string, OtherItem>>> act = () => sut.GetOrLoadMapByIdsAsync<OtherItem>("prefix", ["a"], x => x.Id, _ => Task.FromResult<IList<OtherItem>>([]));
+
+        await Assert.ThrowsAsync<InvalidCastException>(act);
+    }
+
+    [Fact]
+    public async Task GetOrLoadMapByIdsAsync_TypeMismatchOnOneId_LeavesInnocentOwnedIdsRetryable()
+    {
+        var sut = new RequestScopedCache();
+        var batches = new List<string[]>();
+
+        // Cache "b" under a different type first, so a later Item-typed request for it throws on the cast.
+        await sut.GetOrLoadMapByIdsAsync("prefix", ["b"], x => x.Id, _ => Task.FromResult<IList<OtherItem>>([new OtherItem("b")]));
+
+        // This call owns "a" (processed first), then hits the type mismatch on "b" and must throw.
+        Func<Task<IDictionary<string, Item>>> mismatch = () => sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, CreateLoader(batches));
+        await Assert.ThrowsAsync<InvalidCastException>(mismatch);
+
+        // The innocent "a" must NOT be negatively cached by "b"'s type conflict: a later correctly-typed
+        // call re-reserves and loads it successfully.
+        var recovered = await sut.GetOrLoadMapByIdsAsync("prefix", ["a"], x => x.Id, CreateLoader(batches));
+        Assert.Equal("a", recovered["a"].Id);
+    }
+
+    [Fact]
+    public async Task GetOrLoadMapByIdsAsync_InvalidArguments_Throw()
+    {
+        var sut = new RequestScopedCache();
+        var loadMissing = CreateLoader([]);
+
+        Func<Task<IDictionary<string, Item>>> emptyPrefix = () => sut.GetOrLoadMapByIdsAsync("", ["a"], x => x.Id, loadMissing);
+        Func<Task<IDictionary<string, Item>>> nullIds = () => sut.GetOrLoadMapByIdsAsync("prefix", null, x => x.Id, loadMissing);
+        Func<Task<IDictionary<string, Item>>> nullSelector = () => sut.GetOrLoadMapByIdsAsync<Item>("prefix", ["a"], null, loadMissing);
+        Func<Task<IDictionary<string, Item>>> nullLoader = () => sut.GetOrLoadMapByIdsAsync<Item>("prefix", ["a"], x => x.Id, null);
+
+        await Assert.ThrowsAsync<ArgumentException>(emptyPrefix);
+        await Assert.ThrowsAsync<ArgumentNullException>(nullIds);
+        await Assert.ThrowsAsync<ArgumentNullException>(nullSelector);
+        await Assert.ThrowsAsync<ArgumentNullException>(nullLoader);
+    }
+
+    [Fact]
+    public async Task GetOrLoadMapByIdsAsync_EntityOverload_KeysByEntityIdAndSharesEntries()
+    {
+        var sut = new RequestScopedCache();
+        var batches = new List<string[]>();
+
+        Task<IList<EntityItem>> LoadMissing(ICollection<string> missingIds)
+        {
+            lock (batches)
             {
-                return Task.FromResult(Interlocked.Increment(ref callCount));
+                batches.Add([.. missingIds]);
             }
 
-            var first = await sut.GetOrAddAsync("key-1", Factory);
-            var second = await sut.GetOrAddAsync("key-2", Factory);
-
-            Assert.Equal(1, first);
-            Assert.Equal(2, second);
-            // Distinct keys must not share a cached result.
-            Assert.Equal(2, callCount);
+            return Task.FromResult<IList<EntityItem>>(missingIds.Select(x => new EntityItem { Id = x }).ToList());
         }
 
-        [Fact]
-        public async Task GetOrAddAsync_ConcurrentSameKey_FactoryExecutedExactlyOnce()
-        {
-            // The single-flight guarantee: a burst of concurrent callers racing on the same key must
-            // all observe the same in-flight Task rather than each starting its own factory invocation.
-            var sut = new RequestScopedCache();
-            var callCount = 0;
-            var release = new TaskCompletionSource();
+        var viaEntityOverload = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], LoadMissing);
+        var viaCoreOverload = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
 
-            async Task<int> Factory()
+        // The IEntity overload must delegate to the core overload and share its cache entries.
+        Assert.Single(batches);
+        AssertSameIds(["a", "b"], viaEntityOverload.Keys);
+        Assert.Same(viaEntityOverload["a"], viaCoreOverload["a"]);
+    }
+
+    [Fact]
+    public async Task GetOrLoadByIdsAsync_ReturnsResolvedItemValuesSharingTheMapCache()
+    {
+        var sut = new RequestScopedCache();
+        var batches = new List<string[]>();
+
+        var values = await sut.GetOrLoadByIdsAsync(
+            "prefix",
+            ["a", "b", "ghost"],
+            x => x.Id,
+            CreateLoader(batches, x => x == "ghost" ? null : new Item(x)));
+
+        // The values-only overload returns the resolved items, with not-found ids omitted.
+        AssertSameIds(["a", "b"], values.Select(x => x.Id));
+
+        // It shares the underlying cache with the map overload: the same ids resolve without a reload,
+        // to the same instances.
+        var map = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, CreateLoader(batches));
+        Assert.Single(batches);
+        Assert.Same(map["a"], values.Single(x => x.Id == "a"));
+    }
+
+    [Fact]
+    public async Task GetOrLoadByIdsAsync_EntityOverload_ReturnsResolvedItemValues()
+    {
+        var sut = new RequestScopedCache();
+        var batches = new List<string[]>();
+
+        Task<IList<EntityItem>> LoadMissing(ICollection<string> missingIds)
+        {
+            lock (batches)
             {
-                Interlocked.Increment(ref callCount);
-                await release.Task;
-                return 42;
+                batches.Add([.. missingIds]);
             }
 
-            const int callers = 20;
-            var tasks = new Task<int>[callers];
-            for (var i = 0; i < callers; i++)
+            return Task.FromResult<IList<EntityItem>>(missingIds.Select(x => new EntityItem { Id = x }).ToList());
+        }
+
+        var values = await sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], LoadMissing);
+
+        // The IEntity values-only overload keys by entity Id and returns just the items.
+        AssertSameIds(["a", "b"], values.Select(x => x.Id));
+        Assert.Single(batches);
+    }
+
+    private static void AssertSameIds(IEnumerable<string> expected, IEnumerable<string> actual)
+    {
+        Assert.Equal(
+            expected.OrderBy(x => x, StringComparer.Ordinal),
+            actual.OrderBy(x => x, StringComparer.Ordinal));
+    }
+
+    private static Func<ICollection<string>, Task<IList<Item>>> CreateLoader(
+        List<string[]> batches,
+        Func<string, Item> createItem = null)
+    {
+        createItem ??= x => new Item(x);
+
+        return missingIds =>
+        {
+            lock (batches)
             {
-                // Task.Run forces the callers onto distinct pool threads so they race on GetOrAdd for real,
-                // instead of entering it cooperatively from one thread.
-                tasks[i] = Task.Run(() => sut.GetOrAddAsync("key", Factory));
+                batches.Add([.. missingIds]);
             }
 
-            // Give every caller a chance to reach GetOrAddAsync before releasing the factory.
-            await Task.Delay(20, TestContext.Current.CancellationToken);
-            release.SetResult();
+            var items = missingIds.Select(createItem).Where(x => x is not null).ToList();
 
-            var results = await Task.WhenAll(tasks);
+            return Task.FromResult<IList<Item>>(items);
+        };
+    }
 
-            // Concurrent callers on the same key must share a single in-flight factory invocation.
-            Assert.Equal(1, callCount);
-            Assert.All(results, x => Assert.Equal(42, x));
-        }
+    private sealed record Item(string Id);
 
-        [Fact]
-        public async Task GetOrAddAsync_DifferentResultTypesPerKey_BothResolveCorrectly()
-        {
-            var sut = new RequestScopedCache();
+    private sealed record OtherItem(string Id);
 
-            var stringResult = await sut.GetOrAddAsync("string-key", () => Task.FromResult("text"));
-            var intResult = await sut.GetOrAddAsync("int-key", () => Task.FromResult(7));
-
-            Assert.Equal("text", stringResult);
-            Assert.Equal(7, intResult);
-        }
-
-        [Fact]
-        public async Task GetOrLoadMapByIdsAsync_LoadsAllMissingIdsInOneBatch()
-        {
-            var sut = new RequestScopedCache();
-            var batches = new List<string[]>();
-
-            var result = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b", "c"], x => x.Id, CreateLoader(batches));
-
-            AssertSameIds(["a", "b", "c"], Assert.Single(batches));
-            AssertSameIds(["a", "b", "c"], result.Keys);
-            Assert.Equal("a", result["a"].Id);
-        }
-
-        [Fact]
-        public async Task GetOrLoadMapByIdsAsync_OverlappingCall_LoadsOnlyNotYetCachedIds()
-        {
-            var sut = new RequestScopedCache();
-            var batches = new List<string[]>();
-            var loadMissing = CreateLoader(batches);
-
-            var first = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, loadMissing);
-            var second = await sut.GetOrLoadMapByIdsAsync("prefix", ["b", "c"], x => x.Id, loadMissing);
-            var third = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, loadMissing);
-
-            // The second call must load only the ids the first call did not cache, and the third must load nothing.
-            Assert.Equal(2, batches.Count);
-            AssertSameIds(["c"], batches[1]);
-            AssertSameIds(["b", "c"], second.Keys);
-            // An overlapping id must be served from the cache, not re-loaded.
-            Assert.Same(first["b"], second["b"]);
-            Assert.Same(first["a"], third["a"]);
-        }
-
-        [Fact]
-        public async Task GetOrLoadMapByIdsAsync_IdCasingDiffers_MatchesCaseInsensitively()
-        {
-            var sut = new RequestScopedCache();
-            var batches = new List<string[]>();
-            // The loader returns the entity with a different id casing than requested (as a
-            // case-insensitive DB collation would): request "ABC", stored id "abc".
-            var loadMissing = CreateLoader(batches, x => new Item(x.ToLowerInvariant()));
-
-            var first = await sut.GetOrLoadMapByIdsAsync("prefix", ["ABC"], x => x.Id, loadMissing);
-            var second = await sut.GetOrLoadMapByIdsAsync("prefix", ["abc"], x => x.Id, loadMissing);
-
-            // The loaded item publishes to the requested reservation despite the casing difference,
-            // and a differently-cased repeat dedups against the cached entry instead of re-loading.
-            Assert.Single(batches);
-            Assert.NotNull(first["ABC"]);
-            Assert.Same(first["ABC"], second["abc"]);
-        }
-
-        [Fact]
-        public async Task GetOrLoadMapByIdsAsync_NotFoundId_OmittedAndNegativelyCached()
-        {
-            var sut = new RequestScopedCache();
-            var batches = new List<string[]>();
-            // The loader never returns an item for "ghost".
-            var loadMissing = CreateLoader(batches, x => x == "ghost" ? null : new Item(x));
-
-            var first = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "ghost"], x => x.Id, loadMissing);
-            var second = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "ghost"], x => x.Id, loadMissing);
-
-            AssertSameIds(["a"], first.Keys);
-            AssertSameIds(["a"], second.Keys);
-            // A not-found id must be negatively cached for the request, not re-loaded.
-            Assert.Single(batches);
-        }
-
-        [Fact]
-        public async Task GetOrLoadMapByIdsAsync_NullEmptyAndDuplicateIds_NormalizedWithinCall()
-        {
-            var sut = new RequestScopedCache();
-            var batches = new List<string[]>();
-
-            var result = await sut.GetOrLoadMapByIdsAsync("prefix", [null, "", "a", "a", "b"], x => x.Id, CreateLoader(batches));
-
-            AssertSameIds(["a", "b"], Assert.Single(batches));
-            AssertSameIds(["a", "b"], result.Keys);
-        }
-
-        [Fact]
-        public async Task GetOrLoadMapByIdsAsync_EmptyIds_ReturnsEmptyWithoutLoad()
-        {
-            var sut = new RequestScopedCache();
-            var batches = new List<string[]>();
-
-            var result = await sut.GetOrLoadMapByIdsAsync("prefix", Array.Empty<string>(), x => x.Id, CreateLoader(batches));
-
-            Assert.Empty(result);
-            Assert.Empty(batches);
-        }
-
-        [Fact]
-        public async Task GetOrLoadMapByIdsAsync_FaultedLoad_CachedForTheRequestAndRethrown()
-        {
-            var sut = new RequestScopedCache();
-            var callCount = 0;
-
-            Task<IList<Item>> LoadMissing(ICollection<string> missingIds)
-            {
-                Interlocked.Increment(ref callCount);
-                throw new InvalidOperationException("boom");
-            }
-
-            Func<Task<IDictionary<string, Item>>> firstCall = () => sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
-            Func<Task<IDictionary<string, Item>>> secondCall = () => sut.GetOrLoadMapByIdsAsync("prefix", ["a"], x => x.Id, LoadMissing);
-
-            var firstEx = await Assert.ThrowsAsync<InvalidOperationException>(firstCall);
-            var secondEx = await Assert.ThrowsAsync<InvalidOperationException>(secondCall);
-            Assert.Equal("boom", firstEx.Message);
-            Assert.Equal("boom", secondEx.Message);
-            // A faulted load must be cached for the request - same-id calls rethrow without re-loading.
-            Assert.Equal(1, callCount);
-        }
-
-        [Fact]
-        public async Task GetOrLoadMapByIdsAsync_NullLoaderResult_TreatedAsEmptyAndNegativelyCached()
-        {
-            var sut = new RequestScopedCache();
-            var callCount = 0;
-
-            Task<IList<Item>> LoadMissing(ICollection<string> missingIds)
-            {
-                Interlocked.Increment(ref callCount);
-                return Task.FromResult<IList<Item>>(null);
-            }
-
-            var first = await sut.GetOrLoadMapByIdsAsync("prefix", ["a"], x => x.Id, LoadMissing);
-            var second = await sut.GetOrLoadMapByIdsAsync("prefix", ["a"], x => x.Id, LoadMissing);
-
-            Assert.Empty(first);
-            Assert.Empty(second);
-            // Ids from a null (empty) load result are negatively cached for the request, not re-loaded.
-            Assert.Equal(1, callCount);
-        }
-
-        [Fact]
-        public async Task GetOrLoadMapByIdsAsync_InFlightLoad_SharedByLaterCallInsteadOfSecondLoad()
-        {
-            var sut = new RequestScopedCache();
-            var release = new TaskCompletionSource();
-            var callCount = 0;
-
-            async Task<IList<Item>> LoadMissing(ICollection<string> missingIds)
-            {
-                Interlocked.Increment(ref callCount);
-                await release.Task;
-                return missingIds.Select(x => new Item(x)).ToList();
-            }
-
-            // The first call dispatches the load synchronously up to the await, then stays in flight.
-            var firstTask = sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
-            var secondTask = sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
-
-            Assert.False(firstTask.IsCompleted);
-            Assert.False(secondTask.IsCompleted);
-            release.SetResult();
-
-            var first = await firstTask;
-            var second = await secondTask;
-
-            // The second caller must await the in-flight load, not start its own.
-            Assert.Equal(1, callCount);
-            Assert.Same(first["a"], second["a"]);
-        }
-
-        [Fact]
-        public async Task GetOrLoadMapByIdsAsync_ConcurrentOverlappingCallers_EachIdLoadedAtMostOnce()
-        {
-            // Regression guard for per-caller full-batch amplification: under concurrent overlapping
-            // misses, each id must be loaded by exactly one caller, so the total load across all
-            // callers is the distinct union - never a caller's full missing set re-loaded.
-            const int callers = 8;
-            const int windowSize = 12;
-            const int windowStride = 4;
-            var sut = new RequestScopedCache();
-            var release = new TaskCompletionSource();
-            var batches = new List<string[]>();
-
-            async Task<IList<Item>> LoadMissing(ICollection<string> missingIds)
-            {
-                lock (batches)
-                {
-                    batches.Add([.. missingIds]);
-                }
-
-                await release.Task;
-                return missingIds.Select(x => new Item(x)).ToList();
-            }
-
-            var tasks = new Task<IDictionary<string, Item>>[callers];
-            for (var i = 0; i < callers; i++)
-            {
-                var callerIds = Enumerable.Range(i * windowStride, windowSize).Select(x => $"id-{x}").ToArray();
-                tasks[i] = Task.Run(() => sut.GetOrLoadMapByIdsAsync("prefix", callerIds, x => x.Id, LoadMissing));
-            }
-
-            // Give every caller a chance to reserve its ids before any load completes.
-            await Task.Delay(20, TestContext.Current.CancellationToken);
-            release.SetResult();
-
-            var results = await Task.WhenAll(tasks);
-
-            var idSpace = (callers - 1) * windowStride + windowSize;
-            var loadedIds = batches.SelectMany(x => x).ToList();
-            // An id must never appear in two batches within one request.
-            Assert.Equal(loadedIds.Count, loadedIds.Distinct().Count());
-            // The union of all batches must be exactly the distinct union of requested ids.
-            AssertSameIds(Enumerable.Range(0, idSpace).Select(x => $"id-{x}"), loadedIds);
-            // Each caller dispatches at most one batch.
-            Assert.True(batches.Count <= callers);
-
-            for (var i = 0; i < callers; i++)
-            {
-                AssertSameIds(Enumerable.Range(i * windowStride, windowSize).Select(x => $"id-{x}"), results[i].Keys);
-            }
-
-            // Overlapping ids resolve to the same shared instance across callers.
-            Assert.Same(results[0]["id-4"], results[1]["id-4"]);
-        }
-
-        [Fact]
-        public async Task GetOrLoadMapByIdsAsync_TupleKeys_DoNotCollideAcrossPrefixesOrWithByKeyEntries()
-        {
-            var sut = new RequestScopedCache();
-            var batches = new List<string[]>();
-            var loadMissing = CreateLoader(batches);
-
-            // "P" + "A:B" and "P:A" + "B" would alias under naive string concatenation.
-            var first = await sut.GetOrLoadMapByIdsAsync("P", ["A:B"], x => x.Id, loadMissing);
-            var second = await sut.GetOrLoadMapByIdsAsync("P:A", ["B"], x => x.Id, loadMissing);
-            var byKey = await sut.GetOrAddAsync("P:A:B", () => Task.FromResult("by-key value"));
-
-            // Entries under different prefixes must not alias.
-            Assert.Equal(2, batches.Count);
-            Assert.Equal("A:B", first["A:B"].Id);
-            Assert.Equal("B", second["B"].Id);
-            Assert.Equal("by-key value", byKey);
-        }
-
-        [Fact]
-        public async Task GetOrLoadMapByIdsAsync_ExtraAndDuplicateLoadedItems_FirstWinsAndExtrasIgnored()
-        {
-            var sut = new RequestScopedCache();
-            var requestedFirst = new Item("a");
-            var requestedDuplicate = new Item("a");
-            var batches = new List<string[]>();
-            var loadMissing = CreateLoader(batches);
-
-            var result = await sut.GetOrLoadMapByIdsAsync(
-                "prefix",
-                ["a"],
-                x => x.Id,
-                _ => Task.FromResult<IList<Item>>([requestedFirst, requestedDuplicate, new Item("x")]));
-
-            AssertSameIds(["a"], result.Keys);
-            // The first loaded item for an id wins.
-            Assert.Same(requestedFirst, result["a"]);
-
-            // The unrequested extra item must not have been cached.
-            var extra = await sut.GetOrLoadMapByIdsAsync("prefix", ["x"], x => x.Id, loadMissing);
-            AssertSameIds(["x"], Assert.Single(batches));
-            Assert.NotNull(extra["x"]);
-        }
-
-        [Fact]
-        public async Task GetOrLoadMapByIdsAsync_SamePrefixAndIdWithDifferentType_ThrowsInvalidCast()
-        {
-            var sut = new RequestScopedCache();
-
-            await sut.GetOrLoadMapByIdsAsync("prefix", ["a"], x => x.Id, CreateLoader([]));
-
-            Func<Task<IDictionary<string, OtherItem>>> act = () => sut.GetOrLoadMapByIdsAsync<OtherItem>("prefix", ["a"], x => x.Id, _ => Task.FromResult<IList<OtherItem>>([]));
-
-            await Assert.ThrowsAsync<InvalidCastException>(act);
-        }
-
-        [Fact]
-        public async Task GetOrLoadMapByIdsAsync_TypeMismatchOnOneId_LeavesInnocentOwnedIdsRetryable()
-        {
-            var sut = new RequestScopedCache();
-            var batches = new List<string[]>();
-
-            // Cache "b" under a different type first, so a later Item-typed request for it throws on the cast.
-            await sut.GetOrLoadMapByIdsAsync("prefix", ["b"], x => x.Id, _ => Task.FromResult<IList<OtherItem>>([new OtherItem("b")]));
-
-            // This call owns "a" (processed first), then hits the type mismatch on "b" and must throw.
-            Func<Task<IDictionary<string, Item>>> mismatch = () => sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, CreateLoader(batches));
-            await Assert.ThrowsAsync<InvalidCastException>(mismatch);
-
-            // The innocent "a" must NOT be negatively cached by "b"'s type conflict: a later correctly-typed
-            // call re-reserves and loads it successfully.
-            var recovered = await sut.GetOrLoadMapByIdsAsync("prefix", ["a"], x => x.Id, CreateLoader(batches));
-            Assert.Equal("a", recovered["a"].Id);
-        }
-
-        [Fact]
-        public async Task GetOrLoadMapByIdsAsync_InvalidArguments_Throw()
-        {
-            var sut = new RequestScopedCache();
-            var loadMissing = CreateLoader([]);
-
-            Func<Task<IDictionary<string, Item>>> emptyPrefix = () => sut.GetOrLoadMapByIdsAsync("", ["a"], x => x.Id, loadMissing);
-            Func<Task<IDictionary<string, Item>>> nullIds = () => sut.GetOrLoadMapByIdsAsync("prefix", null, x => x.Id, loadMissing);
-            Func<Task<IDictionary<string, Item>>> nullSelector = () => sut.GetOrLoadMapByIdsAsync<Item>("prefix", ["a"], null, loadMissing);
-            Func<Task<IDictionary<string, Item>>> nullLoader = () => sut.GetOrLoadMapByIdsAsync<Item>("prefix", ["a"], x => x.Id, null);
-
-            await Assert.ThrowsAsync<ArgumentException>(emptyPrefix);
-            await Assert.ThrowsAsync<ArgumentNullException>(nullIds);
-            await Assert.ThrowsAsync<ArgumentNullException>(nullSelector);
-            await Assert.ThrowsAsync<ArgumentNullException>(nullLoader);
-        }
-
-        [Fact]
-        public async Task GetOrLoadMapByIdsAsync_EntityOverload_KeysByEntityIdAndSharesEntries()
-        {
-            var sut = new RequestScopedCache();
-            var batches = new List<string[]>();
-
-            Task<IList<EntityItem>> LoadMissing(ICollection<string> missingIds)
-            {
-                lock (batches)
-                {
-                    batches.Add([.. missingIds]);
-                }
-
-                return Task.FromResult<IList<EntityItem>>(missingIds.Select(x => new EntityItem { Id = x }).ToList());
-            }
-
-            var viaEntityOverload = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], LoadMissing);
-            var viaCoreOverload = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
-
-            // The IEntity overload must delegate to the core overload and share its cache entries.
-            Assert.Single(batches);
-            AssertSameIds(["a", "b"], viaEntityOverload.Keys);
-            Assert.Same(viaEntityOverload["a"], viaCoreOverload["a"]);
-        }
-
-        [Fact]
-        public async Task GetOrLoadByIdsAsync_ReturnsResolvedItemValuesSharingTheMapCache()
-        {
-            var sut = new RequestScopedCache();
-            var batches = new List<string[]>();
-
-            var values = await sut.GetOrLoadByIdsAsync(
-                "prefix",
-                ["a", "b", "ghost"],
-                x => x.Id,
-                CreateLoader(batches, x => x == "ghost" ? null : new Item(x)));
-
-            // The values-only overload returns the resolved items, with not-found ids omitted.
-            AssertSameIds(["a", "b"], values.Select(x => x.Id));
-
-            // It shares the underlying cache with the map overload: the same ids resolve without a reload,
-            // to the same instances.
-            var map = await sut.GetOrLoadMapByIdsAsync("prefix", ["a", "b"], x => x.Id, CreateLoader(batches));
-            Assert.Single(batches);
-            Assert.Same(map["a"], values.Single(x => x.Id == "a"));
-        }
-
-        [Fact]
-        public async Task GetOrLoadByIdsAsync_EntityOverload_ReturnsResolvedItemValues()
-        {
-            var sut = new RequestScopedCache();
-            var batches = new List<string[]>();
-
-            Task<IList<EntityItem>> LoadMissing(ICollection<string> missingIds)
-            {
-                lock (batches)
-                {
-                    batches.Add([.. missingIds]);
-                }
-
-                return Task.FromResult<IList<EntityItem>>(missingIds.Select(x => new EntityItem { Id = x }).ToList());
-            }
-
-            var values = await sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], LoadMissing);
-
-            // The IEntity values-only overload keys by entity Id and returns just the items.
-            AssertSameIds(["a", "b"], values.Select(x => x.Id));
-            Assert.Single(batches);
-        }
-
-        private static void AssertSameIds(IEnumerable<string> expected, IEnumerable<string> actual)
-        {
-            Assert.Equal(
-                expected.OrderBy(x => x, StringComparer.Ordinal),
-                actual.OrderBy(x => x, StringComparer.Ordinal));
-        }
-
-        private static Func<ICollection<string>, Task<IList<Item>>> CreateLoader(
-            List<string[]> batches,
-            Func<string, Item> createItem = null)
-        {
-            createItem ??= x => new Item(x);
-
-            return missingIds =>
-            {
-                lock (batches)
-                {
-                    batches.Add([.. missingIds]);
-                }
-
-                var items = missingIds.Select(createItem).Where(x => x is not null).ToList();
-
-                return Task.FromResult<IList<Item>>(items);
-            };
-        }
-
-        private sealed record Item(string Id);
-
-        private sealed record OtherItem(string Id);
-
-        private sealed class EntityItem : Entity
-        {
-        }
+    private sealed class EntityItem : Entity
+    {
     }
 }

--- a/tests/VirtoCommerce.Platform.Caching.Tests/RequestScopedCacheTests.cs
+++ b/tests/VirtoCommerce.Platform.Caching.Tests/RequestScopedCacheTests.cs
@@ -1,0 +1,438 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using VirtoCommerce.Platform.Core.Caching;
+using VirtoCommerce.Platform.Core.Common;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Caching.Tests
+{
+    public class RequestScopedCacheTests
+    {
+        [Fact]
+        public async Task GetOrAddAsync_SameKey_FactoryExecutedOnce()
+        {
+            var sut = new RequestScopedCache();
+            var callCount = 0;
+
+            Task<string> Factory()
+            {
+                Interlocked.Increment(ref callCount);
+                return Task.FromResult("value");
+            }
+
+            var first = await sut.GetOrAddAsync("key", Factory);
+            var second = await sut.GetOrAddAsync("key", Factory);
+
+            Assert.Equal("value", first);
+            Assert.Equal("value", second);
+            // The second call for the same key must be served from the cached result, not re-invoke the factory.
+            Assert.Equal(1, callCount);
+        }
+
+        [Fact]
+        public async Task GetOrAddAsync_DifferentKeys_FactoryExecutedPerKey()
+        {
+            var sut = new RequestScopedCache();
+            var callCount = 0;
+
+            Task<int> Factory()
+            {
+                return Task.FromResult(Interlocked.Increment(ref callCount));
+            }
+
+            var first = await sut.GetOrAddAsync("key-1", Factory);
+            var second = await sut.GetOrAddAsync("key-2", Factory);
+
+            Assert.Equal(1, first);
+            Assert.Equal(2, second);
+            // Distinct keys must not share a cached result.
+            Assert.Equal(2, callCount);
+        }
+
+        [Fact]
+        public async Task GetOrAddAsync_ConcurrentSameKey_FactoryExecutedExactlyOnce()
+        {
+            // The single-flight guarantee: a burst of concurrent callers racing on the same key must
+            // all observe the same in-flight Task rather than each starting its own factory invocation.
+            var sut = new RequestScopedCache();
+            var callCount = 0;
+            var release = new TaskCompletionSource();
+
+            async Task<int> Factory()
+            {
+                Interlocked.Increment(ref callCount);
+                await release.Task;
+                return 42;
+            }
+
+            const int callers = 20;
+            var tasks = new Task<int>[callers];
+            for (var i = 0; i < callers; i++)
+            {
+                // Task.Run forces the callers onto distinct pool threads so they race on GetOrAdd for real,
+                // instead of entering it cooperatively from one thread.
+                tasks[i] = Task.Run(() => sut.GetOrAddAsync("key", Factory));
+            }
+
+            // Give every caller a chance to reach GetOrAddAsync before releasing the factory.
+            await Task.Delay(20, TestContext.Current.CancellationToken);
+            release.SetResult();
+
+            var results = await Task.WhenAll(tasks);
+
+            // Concurrent callers on the same key must share a single in-flight factory invocation.
+            Assert.Equal(1, callCount);
+            Assert.All(results, x => Assert.Equal(42, x));
+        }
+
+        [Fact]
+        public async Task GetOrAddAsync_DifferentResultTypesPerKey_BothResolveCorrectly()
+        {
+            var sut = new RequestScopedCache();
+
+            var stringResult = await sut.GetOrAddAsync("string-key", () => Task.FromResult("text"));
+            var intResult = await sut.GetOrAddAsync("int-key", () => Task.FromResult(7));
+
+            Assert.Equal("text", stringResult);
+            Assert.Equal(7, intResult);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_LoadsAllMissingIdsInOneBatch()
+        {
+            var sut = new RequestScopedCache();
+            var batches = new List<string[]>();
+
+            var result = await sut.GetOrLoadByIdsAsync("prefix", ["a", "b", "c"], x => x.Id, CreateLoader(batches));
+
+            AssertSameIds(["a", "b", "c"], Assert.Single(batches));
+            AssertSameIds(["a", "b", "c"], result.Keys);
+            Assert.Equal("a", result["a"].Id);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_OverlappingCall_LoadsOnlyNotYetCachedIds()
+        {
+            var sut = new RequestScopedCache();
+            var batches = new List<string[]>();
+            var loadMissing = CreateLoader(batches);
+
+            var first = await sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], x => x.Id, loadMissing);
+            var second = await sut.GetOrLoadByIdsAsync("prefix", ["b", "c"], x => x.Id, loadMissing);
+            var third = await sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], x => x.Id, loadMissing);
+
+            // The second call must load only the ids the first call did not cache, and the third must load nothing.
+            Assert.Equal(2, batches.Count);
+            AssertSameIds(["c"], batches[1]);
+            AssertSameIds(["b", "c"], second.Keys);
+            // An overlapping id must be served from the cache, not re-loaded.
+            Assert.Same(first["b"], second["b"]);
+            Assert.Same(first["a"], third["a"]);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_NotFoundId_OmittedAndNegativelyCached()
+        {
+            var sut = new RequestScopedCache();
+            var batches = new List<string[]>();
+            // The loader never returns an item for "ghost".
+            var loadMissing = CreateLoader(batches, x => x == "ghost" ? null : new Item(x));
+
+            var first = await sut.GetOrLoadByIdsAsync("prefix", ["a", "ghost"], x => x.Id, loadMissing);
+            var second = await sut.GetOrLoadByIdsAsync("prefix", ["a", "ghost"], x => x.Id, loadMissing);
+
+            AssertSameIds(["a"], first.Keys);
+            AssertSameIds(["a"], second.Keys);
+            // A not-found id must be negatively cached for the request, not re-loaded.
+            Assert.Single(batches);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_NullEmptyAndDuplicateIds_NormalizedWithinCall()
+        {
+            var sut = new RequestScopedCache();
+            var batches = new List<string[]>();
+
+            var result = await sut.GetOrLoadByIdsAsync("prefix", [null, "", "a", "a", "b"], x => x.Id, CreateLoader(batches));
+
+            AssertSameIds(["a", "b"], Assert.Single(batches));
+            AssertSameIds(["a", "b"], result.Keys);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_EmptyIds_ReturnsEmptyWithoutLoad()
+        {
+            var sut = new RequestScopedCache();
+            var batches = new List<string[]>();
+
+            var result = await sut.GetOrLoadByIdsAsync("prefix", Array.Empty<string>(), x => x.Id, CreateLoader(batches));
+
+            Assert.Empty(result);
+            Assert.Empty(batches);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_FaultedLoad_CachedForTheRequestAndRethrown()
+        {
+            var sut = new RequestScopedCache();
+            var callCount = 0;
+
+            Task<IList<Item>> LoadMissing(ICollection<string> missingIds)
+            {
+                Interlocked.Increment(ref callCount);
+                throw new InvalidOperationException("boom");
+            }
+
+            Func<Task<IDictionary<string, Item>>> firstCall = () => sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
+            Func<Task<IDictionary<string, Item>>> secondCall = () => sut.GetOrLoadByIdsAsync("prefix", ["a"], x => x.Id, LoadMissing);
+
+            var firstEx = await Assert.ThrowsAsync<InvalidOperationException>(firstCall);
+            var secondEx = await Assert.ThrowsAsync<InvalidOperationException>(secondCall);
+            Assert.Equal("boom", firstEx.Message);
+            Assert.Equal("boom", secondEx.Message);
+            // A faulted load must be cached for the request - same-id calls rethrow without re-loading.
+            Assert.Equal(1, callCount);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_NullLoaderResult_TreatedAsEmptyAndNegativelyCached()
+        {
+            var sut = new RequestScopedCache();
+            var callCount = 0;
+
+            Task<IList<Item>> LoadMissing(ICollection<string> missingIds)
+            {
+                Interlocked.Increment(ref callCount);
+                return Task.FromResult<IList<Item>>(null);
+            }
+
+            var first = await sut.GetOrLoadByIdsAsync("prefix", ["a"], x => x.Id, LoadMissing);
+            var second = await sut.GetOrLoadByIdsAsync("prefix", ["a"], x => x.Id, LoadMissing);
+
+            Assert.Empty(first);
+            Assert.Empty(second);
+            // Ids from a null (empty) load result are negatively cached for the request, not re-loaded.
+            Assert.Equal(1, callCount);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_InFlightLoad_SharedByLaterCallInsteadOfSecondLoad()
+        {
+            var sut = new RequestScopedCache();
+            var release = new TaskCompletionSource();
+            var callCount = 0;
+
+            async Task<IList<Item>> LoadMissing(ICollection<string> missingIds)
+            {
+                Interlocked.Increment(ref callCount);
+                await release.Task;
+                return missingIds.Select(x => new Item(x)).ToList();
+            }
+
+            // The first call dispatches the load synchronously up to the await, then stays in flight.
+            var firstTask = sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
+            var secondTask = sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
+
+            Assert.False(firstTask.IsCompleted);
+            Assert.False(secondTask.IsCompleted);
+            release.SetResult();
+
+            var first = await firstTask;
+            var second = await secondTask;
+
+            // The second caller must await the in-flight load, not start its own.
+            Assert.Equal(1, callCount);
+            Assert.Same(first["a"], second["a"]);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_ConcurrentOverlappingCallers_EachIdLoadedAtMostOnce()
+        {
+            // Regression guard for per-caller full-batch amplification: under concurrent overlapping
+            // misses, each id must be loaded by exactly one caller, so the total load across all
+            // callers is the distinct union - never a caller's full missing set re-loaded.
+            const int callers = 8;
+            const int windowSize = 12;
+            const int windowStride = 4;
+            var sut = new RequestScopedCache();
+            var release = new TaskCompletionSource();
+            var batches = new List<string[]>();
+
+            async Task<IList<Item>> LoadMissing(ICollection<string> missingIds)
+            {
+                lock (batches)
+                {
+                    batches.Add([.. missingIds]);
+                }
+
+                await release.Task;
+                return missingIds.Select(x => new Item(x)).ToList();
+            }
+
+            var tasks = new Task<IDictionary<string, Item>>[callers];
+            for (var i = 0; i < callers; i++)
+            {
+                var callerIds = Enumerable.Range(i * windowStride, windowSize).Select(x => $"id-{x}").ToArray();
+                tasks[i] = Task.Run(() => sut.GetOrLoadByIdsAsync("prefix", callerIds, x => x.Id, LoadMissing));
+            }
+
+            // Give every caller a chance to reserve its ids before any load completes.
+            await Task.Delay(20, TestContext.Current.CancellationToken);
+            release.SetResult();
+
+            var results = await Task.WhenAll(tasks);
+
+            var idSpace = (callers - 1) * windowStride + windowSize;
+            var loadedIds = batches.SelectMany(x => x).ToList();
+            // An id must never appear in two batches within one request.
+            Assert.Equal(loadedIds.Count, loadedIds.Distinct().Count());
+            // The union of all batches must be exactly the distinct union of requested ids.
+            AssertSameIds(Enumerable.Range(0, idSpace).Select(x => $"id-{x}"), loadedIds);
+            // Each caller dispatches at most one batch.
+            Assert.True(batches.Count <= callers);
+
+            for (var i = 0; i < callers; i++)
+            {
+                AssertSameIds(Enumerable.Range(i * windowStride, windowSize).Select(x => $"id-{x}"), results[i].Keys);
+            }
+
+            // Overlapping ids resolve to the same shared instance across callers.
+            Assert.Same(results[0]["id-4"], results[1]["id-4"]);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_TupleKeys_DoNotCollideAcrossPrefixesOrWithByKeyEntries()
+        {
+            var sut = new RequestScopedCache();
+            var batches = new List<string[]>();
+            var loadMissing = CreateLoader(batches);
+
+            // "P" + "A:B" and "P:A" + "B" would alias under naive string concatenation.
+            var first = await sut.GetOrLoadByIdsAsync("P", ["A:B"], x => x.Id, loadMissing);
+            var second = await sut.GetOrLoadByIdsAsync("P:A", ["B"], x => x.Id, loadMissing);
+            var byKey = await sut.GetOrAddAsync("P:A:B", () => Task.FromResult("by-key value"));
+
+            // Entries under different prefixes must not alias.
+            Assert.Equal(2, batches.Count);
+            Assert.Equal("A:B", first["A:B"].Id);
+            Assert.Equal("B", second["B"].Id);
+            Assert.Equal("by-key value", byKey);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_ExtraAndDuplicateLoadedItems_FirstWinsAndExtrasIgnored()
+        {
+            var sut = new RequestScopedCache();
+            var requestedFirst = new Item("a");
+            var requestedDuplicate = new Item("a");
+            var batches = new List<string[]>();
+            var loadMissing = CreateLoader(batches);
+
+            var result = await sut.GetOrLoadByIdsAsync(
+                "prefix",
+                ["a"],
+                x => x.Id,
+                _ => Task.FromResult<IList<Item>>([requestedFirst, requestedDuplicate, new Item("x")]));
+
+            AssertSameIds(["a"], result.Keys);
+            // The first loaded item for an id wins.
+            Assert.Same(requestedFirst, result["a"]);
+
+            // The unrequested extra item must not have been cached.
+            var extra = await sut.GetOrLoadByIdsAsync("prefix", ["x"], x => x.Id, loadMissing);
+            AssertSameIds(["x"], Assert.Single(batches));
+            Assert.NotNull(extra["x"]);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_SamePrefixAndIdWithDifferentType_ThrowsInvalidCast()
+        {
+            var sut = new RequestScopedCache();
+
+            await sut.GetOrLoadByIdsAsync("prefix", ["a"], x => x.Id, CreateLoader([]));
+
+            Func<Task<IDictionary<string, OtherItem>>> act = () => sut.GetOrLoadByIdsAsync<OtherItem>("prefix", ["a"], x => x.Id, _ => Task.FromResult<IList<OtherItem>>([]));
+
+            await Assert.ThrowsAsync<InvalidCastException>(act);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_InvalidArguments_Throw()
+        {
+            var sut = new RequestScopedCache();
+            var loadMissing = CreateLoader([]);
+
+            Func<Task<IDictionary<string, Item>>> emptyPrefix = () => sut.GetOrLoadByIdsAsync("", ["a"], x => x.Id, loadMissing);
+            Func<Task<IDictionary<string, Item>>> nullIds = () => sut.GetOrLoadByIdsAsync("prefix", null, x => x.Id, loadMissing);
+            Func<Task<IDictionary<string, Item>>> nullSelector = () => sut.GetOrLoadByIdsAsync<Item>("prefix", ["a"], null, loadMissing);
+            Func<Task<IDictionary<string, Item>>> nullLoader = () => sut.GetOrLoadByIdsAsync<Item>("prefix", ["a"], x => x.Id, null);
+
+            await Assert.ThrowsAsync<ArgumentException>(emptyPrefix);
+            await Assert.ThrowsAsync<ArgumentNullException>(nullIds);
+            await Assert.ThrowsAsync<ArgumentNullException>(nullSelector);
+            await Assert.ThrowsAsync<ArgumentNullException>(nullLoader);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_EntityOverload_KeysByEntityIdAndSharesEntries()
+        {
+            var sut = new RequestScopedCache();
+            var batches = new List<string[]>();
+
+            Task<IList<EntityItem>> LoadMissing(ICollection<string> missingIds)
+            {
+                lock (batches)
+                {
+                    batches.Add([.. missingIds]);
+                }
+
+                return Task.FromResult<IList<EntityItem>>(missingIds.Select(x => new EntityItem { Id = x }).ToList());
+            }
+
+            var viaEntityOverload = await sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], LoadMissing);
+            var viaCoreOverload = await sut.GetOrLoadByIdsAsync("prefix", ["a", "b"], x => x.Id, LoadMissing);
+
+            // The IEntity overload must delegate to the core overload and share its cache entries.
+            Assert.Single(batches);
+            AssertSameIds(["a", "b"], viaEntityOverload.Keys);
+            Assert.Same(viaEntityOverload["a"], viaCoreOverload["a"]);
+        }
+
+        private static void AssertSameIds(IEnumerable<string> expected, IEnumerable<string> actual)
+        {
+            Assert.Equal(
+                expected.OrderBy(x => x, StringComparer.Ordinal),
+                actual.OrderBy(x => x, StringComparer.Ordinal));
+        }
+
+        private static Func<ICollection<string>, Task<IList<Item>>> CreateLoader(
+            List<string[]> batches,
+            Func<string, Item> createItem = null)
+        {
+            createItem ??= x => new Item(x);
+
+            return missingIds =>
+            {
+                lock (batches)
+                {
+                    batches.Add([.. missingIds]);
+                }
+
+                var items = missingIds.Select(createItem).Where(x => x is not null).ToList();
+
+                return Task.FromResult<IList<Item>>(items);
+            };
+        }
+
+        private sealed record Item(string Id);
+
+        private sealed record OtherItem(string Id);
+
+        private sealed class EntityItem : Entity
+        {
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Moves the request-scoped dedup cache — prototyped in vc-module-x-api (VCST-5468) — into the platform so any module can consume it without taking a dependency on x-api.

## Changes

- `IRequestScopedCache` (`GetOrAddAsync<T>` + batch `GetOrLoadByIdsAsync<T>`) in `VirtoCommerce.Platform.Core.Caching`, plus an `IEntity` convenience overload.
- `RequestScopedCache` implementation in `VirtoCommerce.Platform.Caching`: pure BCL, stores the `Task<T>` itself (value-type results never boxed), single-flight for concurrent same-key/same-id callers, faulted loads cached for the remainder of the request.
- Registered `Scoped` in `AddCaching`, so the primitive is available to every module.
- Tests in `VirtoCommerce.Platform.Caching.Tests`.

## Notes

- Complements a per-node batching layer: that dedups by node key, this dedups by the load's own argument key.
- First consumer is x-cart (VCST-5303).

Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5468

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New shared caching primitive affects load behavior and failure/retry semantics across consumers; mis-scoped DI (singleton capture) could leak cache across requests.
> 
> **Overview**
> Introduces a **request-scoped cache** in platform core/caching so modules can deduplicate expensive loads within a single HTTP request without depending on x-api.
> 
> **`IRequestScopedCache`** exposes `GetOrAddAsync` (single-key, concurrent single-flight via cached `Task`) and **`GetOrLoadMapByIdsAsync`** (batch by-id loads with case-insensitive id keys, negative caching for missing ids, and per-id reservation so overlapping/concurrent callers load each id at most once). Extension methods add values-only and `IEntity.Id` convenience overloads.
> 
> **`RequestScopedCache`** is registered **scoped** in `AddCaching`. Documented semantics include fault caching for the rest of the request and a warning against injecting the cache into singletons.
> 
> Broad **unit tests** cover dedup, concurrency, casing, failures, type mismatches, and key collision avoidance.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit bc010ae9dd054ea80bf0f0ae15e6ed781a4d996f. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->



Image tag:
ghcr.io/VirtoCommerce/platform:3.1048.0-pr-3084-bc01-vcst-5468-request-scoped-cache-bc010ae9