### PR TITLE
Add SECURITY.md with a vulnerability reporting process

### DIFF
--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,34 @@
+# Security Policy
+
+## Reporting a Vulnerability
+
+We take the security of VirtoCommerce seriously. If you believe you have found a
+security vulnerability, please report it to us privately. **Please do not open a
+public issue.**
+
+### How to report
+
+Preferred: use GitHub's private vulnerability reporting on the affected
+repository — the **Report a vulnerability** button under the Security tab.
+
+Alternatively, email **security@virtocommerce.com** with:
+
+- a description of the issue and its impact
+- the affected component and version
+- steps to reproduce, or a proof of concept
+- any suggested remediation
+
+### What to expect
+
+- Acknowledgement of your report within **7 days**
+- An initial assessment and expected timeline within **14 days**
+- Notification when a fix is released
+
+We support coordinated disclosure and ask that you give us a reasonable
+opportunity to release a fix before public disclosure. We are happy to credit
+reporters in the advisory unless you prefer otherwise.
+
+### Supported versions
+
+Security fixes are provided for the current release of the platform and its
+modules. Users are encouraged to stay on the latest version.


### PR DESCRIPTION
## Description

> Hi — I could not find a way to report a security issue privately: there is no
> `SECURITY.md`, no `security.txt` on virtocommerce.com, and private
> vulnerability reporting is not enabled on the GitHub repositories.
>
> This adds a minimal policy. Please adjust the contact address to whatever suits
> your team — the important part is that one exists.
>
> I would also suggest enabling **GitHub private vulnerability reporting**
> (Settings → Code security → Private vulnerability reporting). It is free, takes
> one click, gives researchers a private channel, and lets you request CVE IDs
> directly since GitHub is a CNA.
>
> I am asking because I currently have findings I would like to report to you
> privately and have no confirmed channel to use.
