### PR TITLE
VCST-5554: Safe setting value converter

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Settings/SettingValueConverter.cs
+++ b/src/VirtoCommerce.Platform.Core/Settings/SettingValueConverter.cs
@@ -1,0 +1,126 @@
+using System;
+using System.Globalization;
+
+namespace VirtoCommerce.Platform.Core.Settings
+{
+    /// <summary>
+    /// Converts loosely-typed setting values to the CLR type implied by the registered setting descriptor.
+    /// <para>
+    /// The descriptor is the authority on a setting's type; the type a value was persisted with is not.
+    /// A stored value can drift away from the descriptor (e.g. a row written as <see cref="SettingValueType.ShortText"/>
+    /// for a setting that is declared <see cref="SettingValueType.Boolean"/>), and a single drifted value must never
+    /// take down the caller — hence every entry point here reports failure instead of throwing.
+    /// </para>
+    /// </summary>
+    public static class SettingValueConverter
+    {
+        /// <summary>
+        /// Converts <paramref name="value"/> to the CLR type declared by <paramref name="valueType"/>.
+        /// A null value passes through as null (converting it would silently invent <c>false</c>, <c>0</c>
+        /// or <see cref="DateTime.MinValue"/>).
+        /// </summary>
+        /// <returns>False when the value is present but cannot be converted.</returns>
+        public static bool TryConvert(object value, SettingValueType valueType, out object result)
+        {
+            if (value == null)
+            {
+                result = null;
+                return true;
+            }
+
+            return TryChangeType(value, GetClrType(valueType), out result);
+        }
+
+        /// <summary>
+        /// Converts <paramref name="value"/> to <typeparamref name="T"/>, unwrapping nullable target types.
+        /// </summary>
+        /// <returns>False when the value is null or cannot be converted, leaving <paramref name="result"/> at its default.</returns>
+        public static bool TryConvert<T>(object value, out T result)
+        {
+            result = default;
+
+            if (value == null)
+            {
+                return false;
+            }
+
+            if (value is T typedValue)
+            {
+                result = typedValue;
+                return true;
+            }
+
+            var targetType = Nullable.GetUnderlyingType(typeof(T)) ?? typeof(T);
+
+            if (TryChangeType(value, targetType, out var converted))
+            {
+                result = (T)converted;
+                return true;
+            }
+
+            return false;
+        }
+
+        /// <summary>
+        /// The CLR type a setting of the given <see cref="SettingValueType"/> is expected to hold.
+        /// </summary>
+        public static Type GetClrType(SettingValueType valueType)
+        {
+            return valueType switch
+            {
+                SettingValueType.Boolean => typeof(bool),
+                SettingValueType.DateTime => typeof(DateTime),
+                SettingValueType.Decimal => typeof(decimal),
+                SettingValueType.Integer or SettingValueType.PositiveInteger => typeof(int),
+                _ => typeof(string),
+            };
+        }
+
+        private static bool TryChangeType(object value, Type targetType, out object result)
+        {
+            if (targetType.IsInstanceOfType(value))
+            {
+                result = value;
+                return true;
+            }
+
+            // Convert.ToBoolean only accepts "True"/"False" from a string, so "1" and "0" — both plausible in a
+            // drifted text row — would throw. Handle booleans before falling through to the generic conversion.
+            if (targetType == typeof(bool) && value is string booleanText)
+            {
+                return TryParseBoolean(booleanText, out result);
+            }
+
+            try
+            {
+                result = Convert.ChangeType(value, targetType, CultureInfo.InvariantCulture);
+                return true;
+            }
+            catch (Exception ex) when (ex is InvalidCastException or FormatException or OverflowException or ArgumentException)
+            {
+                result = null;
+                return false;
+            }
+        }
+
+        private static bool TryParseBoolean(string text, out object result)
+        {
+            var trimmed = text.Trim();
+
+            if (bool.TryParse(trimmed, out var parsed))
+            {
+                result = parsed;
+                return true;
+            }
+
+            if (decimal.TryParse(trimmed, NumberStyles.Any, CultureInfo.InvariantCulture, out var number))
+            {
+                result = number != 0m;
+                return true;
+            }
+
+            result = null;
+            return false;
+        }
+    }
+}

--- a/src/VirtoCommerce.Platform.Core/Settings/SettingsExtension.cs
+++ b/src/VirtoCommerce.Platform.Core/Settings/SettingsExtension.cs
@@ -166,9 +166,10 @@ namespace VirtoCommerce.Platform.Core.Settings
             try
             {
                 var objectSetting = await manager.GetObjectSettingAsync(name);
-                if (objectSetting?.Value != null)
+
+                if (objectSetting?.Value != null && SettingValueConverter.TryConvert<T>(objectSetting.Value, out var value))
                 {
-                    result = (T)objectSetting.Value;
+                    result = value;
                 }
             }
             catch (PlatformException)

--- a/src/VirtoCommerce.Platform.Data/Model/SettingEntity.cs
+++ b/src/VirtoCommerce.Platform.Data/Model/SettingEntity.cs
@@ -37,7 +37,10 @@ namespace VirtoCommerce.Platform.Data.Model
             objSetting.Id = Id;
             objSetting.ObjectType = ObjectType;
             objSetting.ObjectId = ObjectId;
-            var values = SettingValues.Select(x => x.GetValue()).ToArray();
+
+            var values = SettingValues
+                .Select(x => GetValueOrDefault(x.GetValue(), objSetting))
+                .ToArray();
 
             if (objSetting.IsDictionary)
             {
@@ -49,6 +52,13 @@ namespace VirtoCommerce.Platform.Data.Model
             }
 
             return objSetting;
+        }
+
+        private static object GetValueOrDefault(object value, ObjectSettingEntry objSetting)
+        {
+            return SettingValueConverter.TryConvert(value, objSetting.ValueType, out var converted)
+                ? converted
+                : objSetting.DefaultValue;
         }
 
         public virtual SettingEntity FromModel(ObjectSettingEntry objectSettingEntry)

--- a/src/VirtoCommerce.Platform.Data/Settings/SettingsManager.cs
+++ b/src/VirtoCommerce.Platform.Data/Settings/SettingsManager.cs
@@ -5,6 +5,8 @@ using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Logging;
+using Microsoft.Extensions.Logging.Abstractions;
 using Microsoft.Extensions.Options;
 using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Common;
@@ -34,6 +36,7 @@ namespace VirtoCommerce.Platform.Data.Settings
         private readonly IEventPublisher _eventPublisher;
         private readonly Dictionary<string, ObjectSettingEntry> _fixedSettingsDict;
         private readonly ISettingsOverrideProvider _overrideProvider;
+        private readonly ILogger<SettingsManager> _logger;
         private volatile IDictionary<string, string[]> _cachedTypeAssignments;
 
         public SettingsManager(Func<IPlatformRepository> repositoryFactory,
@@ -41,11 +44,22 @@ namespace VirtoCommerce.Platform.Data.Settings
             IEventPublisher eventPublisher,
             IOptions<FixedSettings> fixedSettings,
             ISettingsOverrideProvider overrideProvider)
+            : this(repositoryFactory, memoryCache, eventPublisher, fixedSettings, overrideProvider, NullLogger<SettingsManager>.Instance)
+        {
+        }
+
+        public SettingsManager(Func<IPlatformRepository> repositoryFactory,
+            IPlatformMemoryCache memoryCache,
+            IEventPublisher eventPublisher,
+            IOptions<FixedSettings> fixedSettings,
+            ISettingsOverrideProvider overrideProvider,
+            ILogger<SettingsManager> logger)
         {
             _repositoryFactory = repositoryFactory;
             _memoryCache = memoryCache;
             _eventPublisher = eventPublisher;
             _overrideProvider = overrideProvider;
+            _logger = logger ?? NullLogger<SettingsManager>.Instance;
 
             _fixedSettingsDict = fixedSettings.Value.Settings?.ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase)
                                  ?? new Dictionary<string, ObjectSettingEntry>(StringComparer.OrdinalIgnoreCase);
@@ -336,10 +350,29 @@ namespace VirtoCommerce.Platform.Data.Settings
             var dbSetting = dbStoredSettings.FirstOrDefault(x => x.Name.EqualsIgnoreCase(name));
             if (dbSetting != null)
             {
+                WarnOnValueTypeDrift(dbSetting, settingDescriptor, objectType, objectId);
                 objectSetting = dbSetting.ToModel(objectSetting);
             }
 
             return objectSetting;
+        }
+
+        private void WarnOnValueTypeDrift(SettingEntity dbSetting, SettingDescriptor descriptor, string objectType, string objectId)
+        {
+            var declaredValueType = descriptor.ValueType.ToString();
+
+            var storedValueTypes = dbSetting.SettingValues
+                .Select(x => x.ValueType)
+                .Where(x => !x.EqualsIgnoreCase(declaredValueType))
+                .Distinct()
+                .ToArray();
+
+            if (storedValueTypes.Length != 0)
+            {
+                _logger.LogWarning(
+                    "Setting '{SettingName}' (ObjectType: {ObjectType}, ObjectId: {ObjectId}) has value(s) stored as '{StoredValueType}' but is registered as '{DeclaredValueType}'. The stored value is coerced to the registered type; correct or remove the persisted value to clear this warning.",
+                    descriptor.Name, objectType, objectId, string.Join(", ", storedValueTypes), declaredValueType);
+            }
         }
 
         protected virtual ObjectSettingEntry GetSettingWithOverrides(string name, List<SettingEntity> dbStoredSettings, string objectType, string objectId)
@@ -400,10 +433,26 @@ namespace VirtoCommerce.Platform.Data.Settings
             var entry = _fixedSettingsDict[name];
             entry.IsReadOnly = true;
 
-            entry.Value = ConvertValueType(entry.Value, entry.ValueType);
-            entry.DefaultValue = ConvertValueType(entry.DefaultValue, entry.ValueType);
+            entry.Value = ConvertValueTypeSafe(entry.Value, entry.ValueType, entry.DefaultValue, name);
+            entry.DefaultValue = ConvertValueTypeSafe(entry.DefaultValue, entry.ValueType, null, name);
 
             return entry;
+        }
+
+        private object ConvertValueTypeSafe(object value, SettingValueType valueType, object fallback, string name)
+        {
+            try
+            {
+                return ConvertValueType(value, valueType);
+            }
+            catch (Exception ex) when (ex is InvalidCastException or FormatException or OverflowException or ArgumentException)
+            {
+                _logger.LogWarning(ex,
+                    "Fixed setting '{SettingName}' has a configured value that cannot be converted to its declared type '{DeclaredValueType}'. Falling back to the default value.",
+                    name, valueType);
+
+                return fallback;
+            }
         }
 
         private static object ConvertValueType(object value, SettingValueType valueType)

--- a/src/VirtoCommerce.Platform.Data/Settings/SettingsManager.cs
+++ b/src/VirtoCommerce.Platform.Data/Settings/SettingsManager.cs
@@ -1,6 +1,5 @@
 using System;
 using System.Collections.Generic;
-using System.Globalization;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.EntityFrameworkCore;
@@ -433,40 +432,45 @@ namespace VirtoCommerce.Platform.Data.Settings
             var entry = _fixedSettingsDict[name];
             entry.IsReadOnly = true;
 
-            entry.Value = ConvertValueTypeSafe(entry.Value, entry.ValueType, entry.DefaultValue, name);
-            entry.DefaultValue = ConvertValueTypeSafe(entry.DefaultValue, entry.ValueType, null, name);
+            // Convert the default first, so that a value which cannot be converted falls back to an already-typed
+            // default rather than to the raw configured object.
+            entry.DefaultValue = ConvertFixedValue(entry.DefaultValue, entry.ValueType, fallback: null, name);
+            entry.Value = ConvertFixedValue(entry.Value, entry.ValueType, entry.DefaultValue, name);
 
             return entry;
         }
 
-        private object ConvertValueTypeSafe(object value, SettingValueType valueType, object fallback, string name)
+        private object ConvertFixedValue(object value, SettingValueType valueType, object fallback, string name)
         {
-            try
+            if (value == null)
             {
-                return ConvertValueType(value, valueType);
+                // Fixed settings have always materialized a missing value as the declared type's empty value
+                // rather than null. Preserve that; only the failure path below is new.
+                return GetEmptyValue(valueType);
             }
-            catch (Exception ex) when (ex is InvalidCastException or FormatException or OverflowException or ArgumentException)
-            {
-                _logger.LogWarning(ex,
-                    "Fixed setting '{SettingName}' has a configured value that cannot be converted to its declared type '{DeclaredValueType}'. Falling back to the default value.",
-                    name, valueType);
 
-                return fallback;
+            if (SettingValueConverter.TryConvert(value, valueType, out var converted))
+            {
+                return converted;
             }
+
+            _logger.LogWarning(
+                "Fixed setting '{SettingName}' has a configured value that cannot be converted to its declared type '{DeclaredValueType}'. Falling back to the default value.",
+                name, valueType);
+
+            return fallback;
         }
 
-        private static object ConvertValueType(object value, SettingValueType valueType)
+        private static object GetEmptyValue(SettingValueType valueType)
         {
-            value = valueType switch
+            return valueType switch
             {
-                SettingValueType.Boolean => Convert.ToBoolean(value),
-                SettingValueType.DateTime => Convert.ToDateTime(value),
-                SettingValueType.Decimal => Convert.ToDecimal(value, CultureInfo.InvariantCulture),
-                SettingValueType.Integer or SettingValueType.PositiveInteger => Convert.ToInt32(value, CultureInfo.InvariantCulture),
-                _ => Convert.ToString(value)
+                SettingValueType.Boolean => false,
+                SettingValueType.DateTime => DateTime.MinValue,
+                SettingValueType.Decimal => 0m,
+                SettingValueType.Integer or SettingValueType.PositiveInteger => 0,
+                _ => string.Empty,
             };
-
-            return value;
         }
     }
 }

--- a/tests/VirtoCommerce.Platform.Tests/UnitTests/SettingValueConverterTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/UnitTests/SettingValueConverterTests.cs
@@ -1,0 +1,151 @@
+using System;
+using System.Globalization;
+using System.Threading;
+using VirtoCommerce.Platform.Core.Settings;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Tests.UnitTests
+{
+    [Trait("Category", "Unit")]
+    public class SettingValueConverterTests
+    {
+        [Theory]
+        [InlineData("True", true)]
+        [InlineData("true", true)]
+        [InlineData("  true  ", true)]
+        [InlineData("False", false)]
+        [InlineData("1", true)]
+        [InlineData("0", false)]
+        public void TryConvert_StringToBoolean_Converts(string stored, bool expected)
+        {
+            var success = SettingValueConverter.TryConvert(stored, SettingValueType.Boolean, out var result);
+
+            Assert.True(success);
+            Assert.IsType<bool>(result);
+            Assert.Equal(expected, result);
+        }
+
+        [Theory]
+        [InlineData(SettingValueType.Integer, "42", 42)]
+        [InlineData(SettingValueType.PositiveInteger, "42", 42)]
+        public void TryConvert_StringToInteger_Converts(SettingValueType valueType, string stored, int expected)
+        {
+            var success = SettingValueConverter.TryConvert(stored, valueType, out var result);
+
+            Assert.True(success);
+            Assert.Equal(expected, result);
+        }
+
+        [Fact]
+        public void TryConvert_StringToDecimal_UsesInvariantCulture()
+        {
+            // A comma-decimal ambient culture would parse "1.5" as 15 without the invariant culture.
+            var originalCulture = Thread.CurrentThread.CurrentCulture;
+            Thread.CurrentThread.CurrentCulture = new CultureInfo("de-DE");
+            try
+            {
+                var success = SettingValueConverter.TryConvert("1.5", SettingValueType.Decimal, out var result);
+
+                Assert.True(success);
+                Assert.Equal(1.5m, result);
+            }
+            finally
+            {
+                Thread.CurrentThread.CurrentCulture = originalCulture;
+            }
+        }
+
+        [Fact]
+        public void TryConvert_StringToDateTime_Converts()
+        {
+            var success = SettingValueConverter.TryConvert("2026-07-29T10:30:00", SettingValueType.DateTime, out var result);
+
+            Assert.True(success);
+            Assert.Equal(new DateTime(2026, 7, 29, 10, 30, 0), result);
+        }
+
+        [Fact]
+        public void TryConvert_BooleanToString_Converts()
+        {
+            var success = SettingValueConverter.TryConvert(true, SettingValueType.ShortText, out var result);
+
+            Assert.True(success);
+            Assert.Equal("True", result);
+        }
+
+        [Theory]
+        [InlineData(SettingValueType.Boolean)]
+        [InlineData(SettingValueType.DateTime)]
+        [InlineData(SettingValueType.Integer)]
+        [InlineData(SettingValueType.ShortText)]
+        public void TryConvert_Null_StaysNull(SettingValueType valueType)
+        {
+            // Converting null would silently invent false / DateTime.MinValue / 0 / string.Empty.
+            var success = SettingValueConverter.TryConvert(null, valueType, out var result);
+
+            Assert.True(success);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void TryConvert_AlreadyCorrectType_ReturnsValueUnchanged()
+        {
+            var stored = "already text";
+
+            var success = SettingValueConverter.TryConvert(stored, SettingValueType.ShortText, out var result);
+
+            Assert.True(success);
+            Assert.Same(stored, result);
+        }
+
+        [Theory]
+        [InlineData("yes", SettingValueType.Boolean)]
+        [InlineData("abc", SettingValueType.Integer)]
+        [InlineData("abc", SettingValueType.Decimal)]
+        [InlineData("not a date", SettingValueType.DateTime)]
+        public void TryConvert_Unconvertible_ReturnsFalseAndDoesNotThrow(string stored, SettingValueType valueType)
+        {
+            var success = SettingValueConverter.TryConvert(stored, valueType, out var result);
+
+            Assert.False(success);
+            Assert.Null(result);
+        }
+
+        [Fact]
+        public void TryConvertGeneric_StringToBoolean_Converts()
+        {
+            var success = SettingValueConverter.TryConvert<bool>("True", out var result);
+
+            Assert.True(success);
+            Assert.True(result);
+        }
+
+        [Fact]
+        public void TryConvertGeneric_NullableTargets_Converts()
+        {
+            Assert.True(SettingValueConverter.TryConvert<bool?>("true", out var boolean));
+            Assert.Equal(true, boolean);
+
+            Assert.True(SettingValueConverter.TryConvert<DateTime?>("2026-07-29", out var dateTime));
+            Assert.Equal(new DateTime(2026, 7, 29), dateTime);
+        }
+
+        [Fact]
+        public void TryConvertGeneric_Unconvertible_ReturnsFalseWithDefault()
+        {
+            var success = SettingValueConverter.TryConvert<bool>("yes", out var result);
+
+            Assert.False(success);
+            Assert.False(result);
+        }
+
+        [Fact]
+        public void TryConvertGeneric_Null_ReturnsFalse()
+        {
+            var success = SettingValueConverter.TryConvert<bool>(null, out var result);
+
+            Assert.False(success);
+            Assert.False(result);
+        }
+    }
+}

--- a/tests/VirtoCommerce.Platform.Tests/UnitTests/SettingsExtensionTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/UnitTests/SettingsExtensionTests.cs
@@ -1,0 +1,69 @@
+using System.Threading.Tasks;
+using Moq;
+using VirtoCommerce.Platform.Core.Settings;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Tests.UnitTests
+{
+    [Trait("Category", "Unit")]
+    public class SettingsExtensionTests
+    {
+        private static readonly SettingDescriptor _descriptor = new()
+        {
+            Name = "Order.DashboardStatistics.Enable",
+            ValueType = SettingValueType.Boolean,
+            DefaultValue = true,
+        };
+
+        [Fact]
+        public async Task GetValueAsync_ValueIsStringForBooleanSetting_ConvertsInsteadOfThrowing()
+        {
+            // Reproduces the reported 500: "Unable to cast object of type 'System.String' to type 'System.Boolean'".
+            var manager = CreateManager("False");
+
+            var result = await manager.GetValueAsync<bool>(_descriptor);
+
+            Assert.False(result);
+        }
+
+        [Fact]
+        public async Task GetValueAsync_ValueCannotBeConverted_ReturnsDescriptorDefault()
+        {
+            var manager = CreateManager("yes");
+
+            var result = await manager.GetValueAsync<bool>(_descriptor);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task GetValueAsync_ValueIsNull_ReturnsDescriptorDefault()
+        {
+            var manager = CreateManager(null);
+
+            var result = await manager.GetValueAsync<bool>(_descriptor);
+
+            Assert.True(result);
+        }
+
+        [Fact]
+        public async Task GetValueAsync_ValueAlreadyTyped_ReturnsStoredValue()
+        {
+            var manager = CreateManager(false);
+
+            var result = await manager.GetValueAsync<bool>(_descriptor);
+
+            Assert.False(result);
+        }
+
+        private static ISettingsManager CreateManager(object value)
+        {
+            var managerMock = new Mock<ISettingsManager>();
+            managerMock
+                .Setup(x => x.GetObjectSettingAsync(_descriptor.Name, null, null))
+                .ReturnsAsync(new ObjectSettingEntry(_descriptor) { Value = value });
+
+            return managerMock.Object;
+        }
+    }
+}

--- a/tests/VirtoCommerce.Platform.Tests/UnitTests/SettingsManagerTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/UnitTests/SettingsManagerTests.cs
@@ -142,7 +142,50 @@ namespace VirtoCommerce.Platform.Tests.UnitTests
             Assert.Equal(0, WarningCount());
         }
 
-        private SettingsManager CreateManager(Func<string, SettingValueEntity> valueFactory = null)
+        [Theory]
+        [InlineData("True", true)]
+        [InlineData("1", true)]
+        [InlineData("0", false)]
+        public async Task GetObjectSettingAsync_FixedSettingConfiguredAsText_ConvertsToDeclaredType(string configured, bool expected)
+        {
+            // Fixed settings come from appsettings.json, so a boolean arrives as text — including "1"/"0",
+            // which Convert.ToBoolean rejects.
+            var sut = CreateManager(fixedSettings: [FixedSetting("A", SettingValueType.Boolean, configured, defaultValue: false)]);
+
+            var setting = await sut.GetObjectSettingAsync("A");
+
+            Assert.IsType<bool>(setting.Value);
+            Assert.Equal(expected, setting.Value);
+        }
+
+        [Fact]
+        public async Task GetObjectSettingAsync_FixedSettingValueUnconvertible_FallsBackToConvertedDefault()
+        {
+            // The default is configured as text too, so it must be converted before it can serve as the fallback —
+            // otherwise Value ends up holding the raw string.
+            var sut = CreateManager(fixedSettings: [FixedSetting("A", SettingValueType.Boolean, "yes", defaultValue: "true")]);
+
+            var setting = await sut.GetObjectSettingAsync("A");
+
+            Assert.IsType<bool>(setting.Value);
+            Assert.Equal(true, setting.Value);
+            Assert.Equal(true, setting.DefaultValue);
+            Assert.Equal(1, WarningCount());
+        }
+
+        [Fact]
+        public async Task GetObjectSettingAsync_FixedSettingWithoutValue_KeepsEmptyValueSemantics()
+        {
+            // Long-standing behaviour: a missing fixed value materializes as the declared type's empty value.
+            var sut = CreateManager(fixedSettings: [FixedSetting("A", SettingValueType.Boolean, value: null, defaultValue: null)]);
+
+            var setting = await sut.GetObjectSettingAsync("A");
+
+            Assert.Equal(false, setting.Value);
+            Assert.Equal(0, WarningCount());
+        }
+
+        private SettingsManager CreateManager(Func<string, SettingValueEntity> valueFactory = null, ObjectSettingEntry[] fixedSettings = null)
         {
             valueFactory ??= name => new SettingValueEntity().SetValue(SettingValueType.ShortText, $"val-{name}");
 
@@ -169,7 +212,7 @@ namespace VirtoCommerce.Platform.Tests.UnitTests
                 () => repositoryMock.Object,
                 MemoryCacheMockHelper.GetPlatformMemoryCache(),
                 new Mock<IEventPublisher>().Object,
-                Options.Create(new FixedSettings { Settings = [] }),
+                Options.Create(new FixedSettings { Settings = fixedSettings ?? [] }),
                 overrideProvider.Object,
                 _loggerMock.Object);
         }
@@ -182,6 +225,11 @@ namespace VirtoCommerce.Platform.Tests.UnitTests
         private static SettingDescriptor BooleanDescriptor(string name)
         {
             return new SettingDescriptor { Name = name, ValueType = SettingValueType.Boolean, DefaultValue = true };
+        }
+
+        private static ObjectSettingEntry FixedSetting(string name, SettingValueType valueType, object value, object defaultValue)
+        {
+            return new ObjectSettingEntry { Name = name, ValueType = valueType, Value = value, DefaultValue = defaultValue };
         }
 
         private int WarningCount()

--- a/tests/VirtoCommerce.Platform.Tests/UnitTests/SettingsManagerTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/UnitTests/SettingsManagerTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
 using System.Threading.Tasks;
+using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
 using VirtoCommerce.Platform.Core.Caching;
@@ -21,6 +22,7 @@ namespace VirtoCommerce.Platform.Tests.UnitTests
     {
         // Records the name set passed to each DB load, so a test can assert which names actually hit the DB.
         private readonly List<string[]> _loadCalls = new();
+        private readonly Mock<ILogger<SettingsManager>> _loggerMock = new();
 
         [Fact]
         public async Task GetObjectSettingsAsync_PerNameCache_SecondOverlappingRequestLoadsOnlyMissingNames()
@@ -89,8 +91,61 @@ namespace VirtoCommerce.Platform.Tests.UnitTests
             Assert.Equal(2, _loadCalls.Count); // per-name entry was invalidated -> reloaded
         }
 
-        private SettingsManager CreateManager()
+        [Fact]
+        public async Task GetObjectSettingAsync_StoredValueTypeDriftedFromDescriptor_CoercesToDeclaredType()
         {
+            // The vcst-qa dashboard outage: descriptor declares Boolean, the persisted row says ShortText.
+            // Before the fix this string reached an unguarded (bool) cast and 500'd the whole endpoint.
+            var sut = CreateManager(_ => new SettingValueEntity().SetValue(SettingValueType.ShortText, "True"));
+            sut.RegisterSettings([BooleanDescriptor("Order.DashboardStatistics.Enable")]);
+
+            var setting = await sut.GetObjectSettingAsync("Order.DashboardStatistics.Enable");
+
+            Assert.IsType<bool>(setting.Value);
+            Assert.Equal(true, setting.Value);
+        }
+
+        [Fact]
+        public async Task GetObjectSettingAsync_StoredValueUnconvertible_FallsBackToDescriptorDefault()
+        {
+            var sut = CreateManager(_ => new SettingValueEntity().SetValue(SettingValueType.ShortText, "yes"));
+            sut.RegisterSettings([BooleanDescriptor("A")]);
+
+            var setting = await sut.GetObjectSettingAsync("A");
+
+            Assert.Equal(true, setting.Value); // the descriptor's DefaultValue, not an exception
+        }
+
+        [Fact]
+        public async Task GetObjectSettingAsync_ValueTypeDrift_LogsSingleWarningPerCacheLoad()
+        {
+            var sut = CreateManager(_ => new SettingValueEntity().SetValue(SettingValueType.ShortText, "True"));
+            sut.RegisterSettings([BooleanDescriptor("A")]);
+
+            await sut.GetObjectSettingAsync("A");
+            await sut.GetObjectSettingAsync("A"); // cache hit — must not re-warn
+            await sut.GetObjectSettingAsync("A");
+
+            Assert.Single(_loadCalls);
+            Assert.Equal(1, WarningCount());
+        }
+
+        [Fact]
+        public async Task GetObjectSettingAsync_StoredValueTypeMatchesDescriptor_LogsNoWarning()
+        {
+            var sut = CreateManager(); // default factory stores ShortText, matching the ShortText descriptor
+            sut.RegisterSettings([Descriptor("A")]);
+
+            var setting = await sut.GetObjectSettingAsync("A");
+
+            Assert.Equal("val-A", setting.Value);
+            Assert.Equal(0, WarningCount());
+        }
+
+        private SettingsManager CreateManager(Func<string, SettingValueEntity> valueFactory = null)
+        {
+            valueFactory ??= name => new SettingValueEntity().SetValue(SettingValueType.ShortText, $"val-{name}");
+
             var repositoryMock = new Mock<IPlatformRepository>();
             repositoryMock
                 .Setup(x => x.GetObjectSettingsByNamesAsync(It.IsAny<string[]>(), It.IsAny<string>(), It.IsAny<string>()))
@@ -102,7 +157,7 @@ namespace VirtoCommerce.Platform.Tests.UnitTests
                         Name = name,
                         ObjectType = objectType,
                         ObjectId = objectId,
-                        SettingValues = [new SettingValueEntity().SetValue(SettingValueType.ShortText, $"val-{name}")],
+                        SettingValues = [valueFactory(name)],
                     }).ToArray();
 
                     return Task.FromResult(rows);
@@ -115,12 +170,23 @@ namespace VirtoCommerce.Platform.Tests.UnitTests
                 MemoryCacheMockHelper.GetPlatformMemoryCache(),
                 new Mock<IEventPublisher>().Object,
                 Options.Create(new FixedSettings { Settings = [] }),
-                overrideProvider.Object);
+                overrideProvider.Object,
+                _loggerMock.Object);
         }
 
         private static SettingDescriptor Descriptor(string name)
         {
             return new SettingDescriptor { Name = name, ValueType = SettingValueType.ShortText };
+        }
+
+        private static SettingDescriptor BooleanDescriptor(string name)
+        {
+            return new SettingDescriptor { Name = name, ValueType = SettingValueType.Boolean, DefaultValue = true };
+        }
+
+        private int WarningCount()
+        {
+            return _loggerMock.Invocations.Count(x => x.Method.Name == nameof(ILogger.Log) && (LogLevel)x.Arguments[0] == LogLevel.Warning);
         }
     }
 }


### PR DESCRIPTION
## Description
fix: coerce setting values to the descriptor's declared ValueType

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5554
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Touches core settings read paths platform-wide; behavior changes from throw/crash to coerce-or-default, which is safer but could mask bad data until warnings are noticed.
> 
> **Overview**
> Fixes **500 errors** when a setting is registered as one `ValueType` but the database (or config) stores another—e.g. boolean settings persisted as **ShortText** `"True"`/`"False"`.
> 
> Introduces **`SettingValueConverter`** with `TryConvert` overloads that map values to the descriptor’s CLR type using invariant culture, tolerant boolean parsing (`"1"`/`"0"`), and **no throws** on bad data. **`SettingsExtension.GetValueAsync`** now converts via `TryConvert<T>` instead of casting; failed conversion keeps the descriptor default. **`SettingEntity.ToModel`** coerces DB values to the declared type or falls back to **`DefaultValue`**. **`SettingsManager`** replaces throwing `Convert.*` on fixed settings with the same converter (default converted first, then value, with typed empty values when null), logs warnings on **stored vs declared value-type drift** (once per cache load), and accepts an optional **`ILogger<SettingsManager>`**.
> 
> Unit tests cover the converter, extension `GetValueAsync`, and manager coercion/fixed-setting/warning behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 487f0644a8f459a8d0275bca5f65e2fecfd47b81. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1055.0-pr-3089-487f-vcst-5554-487f0644