### PR TITLE
VCST-5603: add IRequestScopedCacheAccessor so services outliving a request can reach the cache

### DIFF
--- a/src/VirtoCommerce.Platform.Caching/HttpRequestScopedCacheAccessor.cs
+++ b/src/VirtoCommerce.Platform.Caching/HttpRequestScopedCacheAccessor.cs
@@ -7,23 +7,12 @@ namespace VirtoCommerce.Platform.Caching;
 /// <summary>
 /// <see cref="IRequestScopedCacheAccessor"/> backed by <see cref="IHttpContextAccessor"/>.
 /// </summary>
-/// <remarks>
-/// Safe to register as a singleton: it holds only <see cref="IHttpContextAccessor"/>, which reads the ambient
-/// context from an <c>AsyncLocal</c> rather than capturing one. Resolving through
-/// <see cref="HttpContext.RequestServices"/> - the live request's own scope - is what makes the returned cache
-/// correct no matter which scope constructed the consumer; deferring the resolution alone would not, because a
-/// captured <c>IServiceProvider</c> still belongs to the scope it was captured from.
-/// </remarks>
 public class HttpRequestScopedCacheAccessor(IHttpContextAccessor httpContextAccessor) : IRequestScopedCacheAccessor
 {
-    /// <inheritdoc />
-    /// <remarks>
-    /// Both null-conditionals are load-bearing: <see cref="IHttpContextAccessor.HttpContext"/> is null outside a
-    /// request, and <see cref="HttpContext.RequestServices"/> is null on a fabricated <see cref="DefaultHttpContext"/>.
-    /// <see cref="ServiceProviderServiceExtensions.GetService{T}"/> is used rather than its required counterpart so
-    /// a host that did not call <c>AddCaching</c> yields null instead of throwing. Nothing is memoized: the context
-    /// is re-read on every access, which is what makes the result follow the ambient request.
-    /// </remarks>
-    public virtual IRequestScopedCache Current =>
+    // Safe as a singleton: the only captured dependency is IHttpContextAccessor, whose AsyncLocal holder is
+    // static, so no per-request state is held here.
+    // HttpContext is null outside a request; RequestServices is null on a fabricated DefaultHttpContext.
+    // GetService, not GetRequiredService: a host that never called AddCaching should get null, not an exception.
+    public virtual IRequestScopedCache Cache =>
         httpContextAccessor.HttpContext?.RequestServices?.GetService<IRequestScopedCache>();
 }

--- a/src/VirtoCommerce.Platform.Caching/HttpRequestScopedCacheAccessor.cs
+++ b/src/VirtoCommerce.Platform.Caching/HttpRequestScopedCacheAccessor.cs
@@ -1,0 +1,29 @@
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.DependencyInjection;
+using VirtoCommerce.Platform.Core.Caching;
+
+namespace VirtoCommerce.Platform.Caching;
+
+/// <summary>
+/// <see cref="IRequestScopedCacheAccessor"/> backed by <see cref="IHttpContextAccessor"/>.
+/// </summary>
+/// <remarks>
+/// Safe to register as a singleton: it holds only <see cref="IHttpContextAccessor"/>, which reads the ambient
+/// context from an <c>AsyncLocal</c> rather than capturing one. Resolving through
+/// <see cref="HttpContext.RequestServices"/> - the live request's own scope - is what makes the returned cache
+/// correct no matter which scope constructed the consumer; deferring the resolution alone would not, because a
+/// captured <c>IServiceProvider</c> still belongs to the scope it was captured from.
+/// </remarks>
+public class HttpRequestScopedCacheAccessor(IHttpContextAccessor httpContextAccessor) : IRequestScopedCacheAccessor
+{
+    /// <inheritdoc />
+    /// <remarks>
+    /// Both null-conditionals are load-bearing: <see cref="IHttpContextAccessor.HttpContext"/> is null outside a
+    /// request, and <see cref="HttpContext.RequestServices"/> is null on a fabricated <see cref="DefaultHttpContext"/>.
+    /// <see cref="ServiceProviderServiceExtensions.GetService{T}"/> is used rather than its required counterpart so
+    /// a host that did not call <c>AddCaching</c> yields null instead of throwing. Nothing is memoized: the context
+    /// is re-read on every access, which is what makes the result follow the ambient request.
+    /// </remarks>
+    public virtual IRequestScopedCache Current =>
+        httpContextAccessor.HttpContext?.RequestServices?.GetService<IRequestScopedCache>();
+}

--- a/src/VirtoCommerce.Platform.Caching/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Caching/ServiceCollectionExtensions.cs
@@ -29,11 +29,6 @@ namespace VirtoCommerce.Platform.Caching
             }
 
             services.AddScoped<IRequestScopedCache, RequestScopedCache>();
-
-            //Lets consumers whose lifetime is not bounded by one request reach the request's cache without
-            //taking IHttpContextAccessor themselves. Singleton: it captures only the accessor, which reads
-            //the ambient context from an AsyncLocal. AddHttpContextAccessor is TryAdd-based, so calling it
-            //here makes the registration self-sufficient without overriding a host that already added it.
             services.AddHttpContextAccessor();
             services.AddSingleton<IRequestScopedCacheAccessor, HttpRequestScopedCacheAccessor>();
 

--- a/src/VirtoCommerce.Platform.Caching/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Caching/ServiceCollectionExtensions.cs
@@ -30,6 +30,13 @@ namespace VirtoCommerce.Platform.Caching
 
             services.AddScoped<IRequestScopedCache, RequestScopedCache>();
 
+            //Lets consumers whose lifetime is not bounded by one request reach the request's cache without
+            //taking IHttpContextAccessor themselves. Singleton: it captures only the accessor, which reads
+            //the ambient context from an AsyncLocal. AddHttpContextAccessor is TryAdd-based, so calling it
+            //here makes the registration self-sufficient without overriding a host that already added it.
+            services.AddHttpContextAccessor();
+            services.AddSingleton<IRequestScopedCacheAccessor, HttpRequestScopedCacheAccessor>();
+
             return services;
         }
     }

--- a/src/VirtoCommerce.Platform.Core/Caching/IRequestScopedCache.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/IRequestScopedCache.cs
@@ -23,8 +23,11 @@ namespace VirtoCommerce.Platform.Core.Caching;
 /// <br/><br/>
 /// Warning: resolve consumers from the request/DI scope (a scoped dependency, or the current request's
 /// service provider) - never constructor-inject this cache into a singleton, or it is captured against the
-/// root scope and silently shared across all requests.
+/// root scope and silently shared across all requests. A consumer whose own lifetime is not bounded by one
+/// request should depend on <see cref="IRequestScopedCacheAccessor"/> instead of reaching for the request
+/// itself.
 /// </remarks>
+/// <seealso cref="IRequestScopedCacheAccessor"/>
 public interface IRequestScopedCache
 {
     /// <summary>

--- a/src/VirtoCommerce.Platform.Core/Caching/IRequestScopedCache.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/IRequestScopedCache.cs
@@ -23,9 +23,7 @@ namespace VirtoCommerce.Platform.Core.Caching;
 /// <br/><br/>
 /// Warning: resolve consumers from the request/DI scope (a scoped dependency, or the current request's
 /// service provider) - never constructor-inject this cache into a singleton, or it is captured against the
-/// root scope and silently shared across all requests. A consumer whose own lifetime is not bounded by one
-/// request should depend on <see cref="IRequestScopedCacheAccessor"/> instead of reaching for the request
-/// itself.
+/// root scope and silently shared across all requests.
 /// </remarks>
 /// <seealso cref="IRequestScopedCacheAccessor"/>
 public interface IRequestScopedCache

--- a/src/VirtoCommerce.Platform.Core/Caching/IRequestScopedCacheAccessor.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/IRequestScopedCacheAccessor.cs
@@ -1,0 +1,36 @@
+namespace VirtoCommerce.Platform.Core.Caching;
+
+/// <summary>
+/// Resolves the <see cref="IRequestScopedCache"/> of the ambient request, for consumers whose own lifetime
+/// is not bounded by a single request.
+/// </summary>
+/// <remarks>
+/// <see cref="IRequestScopedCache"/> is registered Scoped, so constructor-injecting it is safe only while the
+/// consumer's own lifetime never exceeds one request. That does not hold for a singleton, for an object that is
+/// cached across requests, or for anything constructed inside a background job's scope - and the DI scope
+/// validator cannot tell the difference, because each of those registrations is individually legal. Depend on
+/// this accessor instead: it reads the cache from the ambient request every time it is asked, so nothing is
+/// captured at construction time.
+/// <br/><br/>
+/// Consumers also gain no dependency on ASP.NET Core, and become testable with a stub returning a plain
+/// <see cref="IRequestScopedCache"/> instead of a fabricated HTTP context.
+/// </remarks>
+public interface IRequestScopedCacheAccessor
+{
+    /// <summary>
+    /// The current request's cache, or <c>null</c> when there is no ambient request scope.
+    /// </summary>
+    /// <remarks>
+    /// <c>null</c> is an expected value rather than an error: it means a background job, application startup,
+    /// or a fabricated context carrying no request services. Outside a request there is nothing to bound a
+    /// per-request cache to, so a caller should run its load uncached instead of falling back to a cache with a
+    /// wider lifetime. A background job in particular must not deduplicate loads across its own steps, or it
+    /// stops observing its own writes for the rest of its run.
+    /// <br/><br/>
+    /// Work that outlives the response must not read this property. A continuation started inside a request but
+    /// not awaited by it still carries the ambient context, whose request scope has since been disposed - the
+    /// read then throws <see cref="System.ObjectDisposedException"/> rather than returning <c>null</c>.
+    /// That exception is a correct signal about the caller's lifetime and must not be swallowed.
+    /// </remarks>
+    IRequestScopedCache Current { get; }
+}

--- a/src/VirtoCommerce.Platform.Core/Caching/IRequestScopedCacheAccessor.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/IRequestScopedCacheAccessor.cs
@@ -18,7 +18,7 @@ namespace VirtoCommerce.Platform.Core.Caching;
 public interface IRequestScopedCacheAccessor
 {
     /// <summary>
-    /// The current request's cache, or <c>null</c> when there is no ambient request scope.
+    /// The ambient request's cache, re-read on every access, or <c>null</c> when there is no ambient request scope.
     /// </summary>
     /// <remarks>
     /// <c>null</c> is an expected value rather than an error: it means a background job, application startup,
@@ -32,5 +32,5 @@ public interface IRequestScopedCacheAccessor
     /// read then throws <see cref="System.ObjectDisposedException"/> rather than returning <c>null</c>.
     /// That exception is a correct signal about the caller's lifetime and must not be swallowed.
     /// </remarks>
-    IRequestScopedCache Current { get; }
+    IRequestScopedCache Cache { get; }
 }

--- a/tests/VirtoCommerce.Platform.Caching.Tests/HttpRequestScopedCacheAccessorTests.cs
+++ b/tests/VirtoCommerce.Platform.Caching.Tests/HttpRequestScopedCacheAccessorTests.cs
@@ -20,7 +20,7 @@ public class HttpRequestScopedCacheAccessorTests
     }
 
     [Fact]
-    public void Current_LiveRequestWithCacheRegistered_ReturnsThatRequestsCache()
+    public void Cache_LiveRequestWithCacheRegistered_ReturnsThatRequestsCache()
     {
         using var provider = BuildProviderWithCache();
         using var scope = provider.CreateScope();
@@ -31,13 +31,13 @@ public class HttpRequestScopedCacheAccessorTests
 
         var sut = new HttpRequestScopedCacheAccessor(accessor);
 
-        Assert.Same(scope.ServiceProvider.GetRequiredService<IRequestScopedCache>(), sut.Current);
+        Assert.Same(scope.ServiceProvider.GetRequiredService<IRequestScopedCache>(), sut.Cache);
     }
 
     [Fact]
-    public void Current_TwoRequests_ReturnsEachRequestsOwnCache()
+    public void Cache_TwoRequests_ReturnsEachRequestsOwnCache()
     {
-        // Pins that Current memoizes nothing: it re-reads the ambient context on every access, so the result
+        // Pins that Cache memoizes nothing: it re-reads the ambient context on every access, so the result
         // follows the request rather than the first one seen. An implementation that cached the context or the
         // resolved cache in a field would hand out the first scope's cache forever.
         using var provider = BuildProviderWithCache();
@@ -47,10 +47,10 @@ public class HttpRequestScopedCacheAccessorTests
         var sut = new HttpRequestScopedCacheAccessor(accessor);
 
         accessor.HttpContext = new DefaultHttpContext { RequestServices = firstScope.ServiceProvider };
-        var first = sut.Current;
+        var first = sut.Cache;
 
         accessor.HttpContext = new DefaultHttpContext { RequestServices = secondScope.ServiceProvider };
-        var second = sut.Current;
+        var second = sut.Cache;
 
         Assert.NotNull(first);
         Assert.NotNull(second);
@@ -58,17 +58,17 @@ public class HttpRequestScopedCacheAccessorTests
     }
 
     [Fact]
-    public void Current_NoHttpContext_ReturnsNull()
+    public void Cache_NoHttpContext_ReturnsNull()
     {
         // A background job: there is no ambient request to scope a per-request cache to, so an uncached path
         // is the correct outcome rather than a degraded one.
         var sut = new HttpRequestScopedCacheAccessor(new HttpContextAccessor());
 
-        Assert.Null(sut.Current);
+        Assert.Null(sut.Cache);
     }
 
     [Fact]
-    public void Current_RequestServicesNotSet_ReturnsNull()
+    public void Cache_RequestServicesNotSet_ReturnsNull()
     {
         // A fabricated DefaultHttpContext leaves RequestServices null, which is why the second null-conditional
         // in the implementation is load-bearing rather than defensive.
@@ -76,11 +76,11 @@ public class HttpRequestScopedCacheAccessorTests
 
         var sut = new HttpRequestScopedCacheAccessor(accessor);
 
-        Assert.Null(sut.Current);
+        Assert.Null(sut.Cache);
     }
 
     [Fact]
-    public void Current_CacheNotRegistered_ReturnsNull()
+    public void Cache_CacheServiceNotRegistered_ReturnsNull()
     {
         using var provider = new ServiceCollection().BuildServiceProvider();
         var accessor = new HttpContextAccessor
@@ -90,7 +90,7 @@ public class HttpRequestScopedCacheAccessorTests
 
         var sut = new HttpRequestScopedCacheAccessor(accessor);
 
-        Assert.Null(sut.Current);
+        Assert.Null(sut.Cache);
     }
 
     [Fact]
@@ -115,7 +115,7 @@ public class HttpRequestScopedCacheAccessorTests
 
         Assert.NotNull(sut);
         // No ambient request on the root provider, so there is nothing to hand out - and no throw either.
-        Assert.Null(sut.Current);
+        Assert.Null(sut.Cache);
     }
 
     [Fact]

--- a/tests/VirtoCommerce.Platform.Caching.Tests/HttpRequestScopedCacheAccessorTests.cs
+++ b/tests/VirtoCommerce.Platform.Caching.Tests/HttpRequestScopedCacheAccessorTests.cs
@@ -1,0 +1,136 @@
+using System.Linq;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using VirtoCommerce.Platform.Core.Caching;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Caching.Tests;
+
+public class HttpRequestScopedCacheAccessorTests
+{
+    // A real HttpContextAccessor is used throughout rather than a mock: the whole point of the accessor is that
+    // it reads the ambient context from an AsyncLocal instead of capturing anything, and only the real one has
+    // that behaviour.
+    private static ServiceProvider BuildProviderWithCache()
+    {
+        return new ServiceCollection()
+            .AddScoped<IRequestScopedCache, RequestScopedCache>()
+            .BuildServiceProvider();
+    }
+
+    [Fact]
+    public void Current_LiveRequestWithCacheRegistered_ReturnsThatRequestsCache()
+    {
+        using var provider = BuildProviderWithCache();
+        using var scope = provider.CreateScope();
+        var accessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext { RequestServices = scope.ServiceProvider },
+        };
+
+        var sut = new HttpRequestScopedCacheAccessor(accessor);
+
+        Assert.Same(scope.ServiceProvider.GetRequiredService<IRequestScopedCache>(), sut.Current);
+    }
+
+    [Fact]
+    public void Current_TwoRequests_ReturnsEachRequestsOwnCache()
+    {
+        // Pins that Current memoizes nothing: it re-reads the ambient context on every access, so the result
+        // follows the request rather than the first one seen. An implementation that cached the context or the
+        // resolved cache in a field would hand out the first scope's cache forever.
+        using var provider = BuildProviderWithCache();
+        using var firstScope = provider.CreateScope();
+        using var secondScope = provider.CreateScope();
+        var accessor = new HttpContextAccessor();
+        var sut = new HttpRequestScopedCacheAccessor(accessor);
+
+        accessor.HttpContext = new DefaultHttpContext { RequestServices = firstScope.ServiceProvider };
+        var first = sut.Current;
+
+        accessor.HttpContext = new DefaultHttpContext { RequestServices = secondScope.ServiceProvider };
+        var second = sut.Current;
+
+        Assert.NotNull(first);
+        Assert.NotNull(second);
+        Assert.NotSame(first, second);
+    }
+
+    [Fact]
+    public void Current_NoHttpContext_ReturnsNull()
+    {
+        // A background job: there is no ambient request to scope a per-request cache to, so an uncached path
+        // is the correct outcome rather than a degraded one.
+        var sut = new HttpRequestScopedCacheAccessor(new HttpContextAccessor());
+
+        Assert.Null(sut.Current);
+    }
+
+    [Fact]
+    public void Current_RequestServicesNotSet_ReturnsNull()
+    {
+        // A fabricated DefaultHttpContext leaves RequestServices null, which is why the second null-conditional
+        // in the implementation is load-bearing rather than defensive.
+        var accessor = new HttpContextAccessor { HttpContext = new DefaultHttpContext() };
+
+        var sut = new HttpRequestScopedCacheAccessor(accessor);
+
+        Assert.Null(sut.Current);
+    }
+
+    [Fact]
+    public void Current_CacheNotRegistered_ReturnsNull()
+    {
+        using var provider = new ServiceCollection().BuildServiceProvider();
+        var accessor = new HttpContextAccessor
+        {
+            HttpContext = new DefaultHttpContext { RequestServices = provider },
+        };
+
+        var sut = new HttpRequestScopedCacheAccessor(accessor);
+
+        Assert.Null(sut.Current);
+    }
+
+    [Fact]
+    public void Accessor_ResolvedFromRootUnderFullScopeValidation_IsNotACaptiveDependency()
+    {
+        // The change's central claim: a singleton may depend on the accessor even though the cache it hands out
+        // is Scoped, because the cache is resolved per call from a request's own provider and never injected.
+        // Asserted against the container rather than in prose - ValidateScopes would reject the contrast case of
+        // constructor-injecting IRequestScopedCache into a singleton.
+        var services = new ServiceCollection()
+            .AddHttpContextAccessor()
+            .AddScoped<IRequestScopedCache, RequestScopedCache>();
+        services.AddSingleton<IRequestScopedCacheAccessor, HttpRequestScopedCacheAccessor>();
+
+        using var provider = services.BuildServiceProvider(new ServiceProviderOptions
+        {
+            ValidateScopes = true,
+            ValidateOnBuild = true,
+        });
+
+        var sut = provider.GetRequiredService<IRequestScopedCacheAccessor>();
+
+        Assert.NotNull(sut);
+        // No ambient request on the root provider, so there is nothing to hand out - and no throw either.
+        Assert.Null(sut.Current);
+    }
+
+    [Fact]
+    public void AddCaching_RegistersTheAccessorSingletonAndTheCacheScoped()
+    {
+        var services = new ServiceCollection();
+
+        services.AddCaching(new ConfigurationBuilder().Build());
+
+        var accessor = services.Single(x => x.ServiceType == typeof(IRequestScopedCacheAccessor));
+        var cache = services.Single(x => x.ServiceType == typeof(IRequestScopedCache));
+
+        Assert.Equal(typeof(HttpRequestScopedCacheAccessor), accessor.ImplementationType);
+        Assert.Equal(ServiceLifetime.Singleton, accessor.Lifetime);
+        Assert.Equal(ServiceLifetime.Scoped, cache.Lifetime);
+        Assert.Contains(services, x => x.ServiceType == typeof(IHttpContextAccessor));
+    }
+}


### PR DESCRIPTION
## Summary

Adds `IRequestScopedCacheAccessor`, so a service whose own lifetime is not bounded by one request can reach the request's `IRequestScopedCache` without depending on ASP.NET Core.

Purely additive: two new files, one registration, one doc cross-reference. Nothing is removed, so there is no source or binary break.

## Why

`IRequestScopedCache` (VCST-5468) is registered `Scoped`. Constructor-injecting it is safe only while the consumer's own lifetime never exceeds one request — which does **not** hold for a singleton, for an object cached across requests, or for anything constructed inside a background job's long-lived scope. The DI scope validator cannot tell the difference, because each of those registrations is individually legal; the leak is in what caches the constructed object, not in the dependency graph.

Consumers in that position currently take `IHttpContextAccessor` themselves and inline the lookup:

```csharp
var cache = _httpContextAccessor.HttpContext?.RequestServices?.GetService<IRequestScopedCache>();
```

That is correct but it puts an HTTP dependency on a domain service, repeats a three-link null chain whose every link is load-bearing, and forces each test to fabricate an `HttpContext` — whose `RequestServices` is null by default, so the fabrication is itself a trap.

### Why not `Func<IRequestScopedCache>` or `IServiceProvider`

Both were tried and rejected on evidence, not taste. A factory registered as `provider => () => provider.GetRequiredService<IRequestScopedCache>()` captures the provider of whichever scope resolved the **`Func`**. Resolved into a singleton that is the root, so invoking it throws `Cannot resolve scoped service ... from root provider`; in the other two cases it silently returns *that* scope's cache — the wrong one, with no error. An injected `IServiceProvider` has the same defect.

Deferring the resolution changes *when* we resolve; the defect is *where from*. Only `HttpContext.RequestServices` reaches the live request's scope, and only `IHttpContextAccessor` reads the ambient context without capturing it — its `AsyncLocal` holder is a `static` field, which is also why the singleton lifetime below is safe.

## What changed

- **`Platform.Core/Caching/IRequestScopedCacheAccessor.cs`** — `Cache` returns the request's cache, or `null` when there is no ambient request scope.
- **`Platform.Caching/HttpRequestScopedCacheAccessor.cs`** — the `IHttpContextAccessor`-backed implementation. Placement mirrors the existing split: interface beside `IRequestScopedCache`, implementation beside `RequestScopedCache`. `Platform.Caching` gets the ASP.NET Core types through the transitive `FrameworkReference` from `Platform.Core`, as `Platform.Security/HttpContextUserResolver` already does.
- **`AddCaching`** — registers the accessor as a singleton and also calls `AddHttpContextAccessor()`. That call is `TryAdd`-based, so it makes the registration self-sufficient for any host without overriding one that already registered its own.
- **`IRequestScopedCache`** — one `<seealso>` tag pointing at the accessor. The warning text itself is deliberately unchanged: constructor-injecting the cache stays correct for anything request-bounded, which is how x-cart's `GetProductConfigurationQueryHandler` already uses it (MediatR registers handlers Transient, resolved per `Send` from the request scope). Whether direct injection is safe is a property of the host, not of the consumer.

`null` is a documented expected value rather than a degraded path. Outside a request there is nothing to bound a per-request cache to, and a background job in particular must **not** deduplicate loads across its own steps, or it stops observing its own writes for the rest of its run. The one case that throws instead of returning `null` — a continuation that outlives the response, whose ambient context survives its disposed scope — is documented as a deliberate signal that must not be swallowed.

## Test plan

- [x] `Platform.Caching.Tests` — 63 of 63, including 7 new.
- [x] Solution build — 0 warnings, 0 errors.
- [x] `Platform.Core.Tests` 154/154, `Platform.Web.Tests` 92/92, `Platform.Tests` 333 passed (its one failure is the pre-existing `FileManagerIntegrationTests.SafeDelete_CreateAndSafeDeleteDirectory`, a Windows-style path on Linux).

The tests pin the two claims that carry the change rather than restating them:

- `Cache` memoizes nothing, so the result follows the ambient request instead of the first one seen.
- The singleton accessor resolves from the **root** provider under `ValidateScopes` + `ValidateOnBuild`. Checked against the contrast case — constructor-injecting `IRequestScopedCache` into a singleton — which that configuration does reject, so the assertion discriminates.

## Follow-up in `vc-module-customer`, sequenced after this is released

`MemberResolver` is the first consumer: it takes `IHttpContextAccessor` **solely** to reach the scoped cache. That parameter will be **replaced outright, not kept as an `[Obsolete]` overload**.

Flagging it here because it is binary-breaking: a subclass compiled against 3.1017.0–3.1020.0 calling `base(memberService, userManagerFactory, httpContextAccessor)` will get a `MissingMethodException` at runtime, behind a green build. The trade-off was taken knowingly — the window before wider adoption is still open, and a compat overload would add a third same-arity constructor to a type whose registration already needs an explicit factory because the container cannot disambiguate the existing two.

Delivery order: this PR → platform release → `vc-module-customer` → module release → consumers raise both pins.

## Related

- VCST-5603 — https://virtocommerce.atlassian.net/browse/VCST-5603
- VCST-5468 — added `IRequestScopedCache`, the primitive this accessor makes reachable

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Additive API and DI registration only; no changes to existing IRequestScopedCache behavior, with null semantics documented for non-request contexts.
> 
> **Overview**
> Introduces **`IRequestScopedCacheAccessor`** so services whose lifetime exceeds a single HTTP request (singletons, cached instances, background work) can use the ambient **`IRequestScopedCache`** without constructor-injecting the scoped cache or depending on **`IHttpContextAccessor`** directly.
> 
> **`HttpRequestScopedCacheAccessor`** resolves the cache on each access via **`HttpContext.RequestServices`**; **`AddCaching`** registers it as a singleton (with **`AddHttpContextAccessor`**) alongside the existing scoped **`RequestScopedCache`**. **`IRequestScopedCache`** docs now point to the accessor as the remedy for the “don’t inject into a singleton” warning. **`Cache`** returns **`null`** when there is no request scope (callers should load uncached); tests cover per-request isolation, null paths, and DI scope validation for the singleton accessor.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 03c69494186a3c13408236a14027b8b1f176c91b. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1052.0-pr-3090-03c6-vcst-5603-request-scoped-cache-accessor-03c69494

