### PR TITLE
VCST-5627: capture the cache change token before the load, not after it

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Caching/MemoryCacheExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/MemoryCacheExtensions.cs
@@ -5,6 +5,7 @@ using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Threading.Tasks;
 using Microsoft.Extensions.Caching.Memory;
+using Microsoft.Extensions.Primitives;
 using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.Platform.Core.Caching
@@ -14,6 +15,12 @@ namespace VirtoCommerce.Platform.Core.Caching
         private static readonly StringComparer _ignoreCase = StringComparer.OrdinalIgnoreCase;
         private static readonly ConcurrentDictionary<string, object> _lockLookup = new();
 
+        // The four overloads below are deliberately explicit rather than one method with an optional
+        // `createExpirationToken`. C# bakes optional arguments in at the CALL SITE, so turning a published
+        // signature into an optional-parameter one removes the arity every already-compiled caller emitted
+        // a reference to. Platform assemblies ship as NuGet and modules load as plugins without being
+        // rebuilt in lockstep, so that would surface as a runtime MissingMethodException in modules that
+        // still build and test clean.
         public static Task<IList<TItem>> GetOrLoadByIdsAsync<TItem>(
             this IMemoryCache memoryCache,
             string keyPrefix,
@@ -22,7 +29,19 @@ namespace VirtoCommerce.Platform.Core.Caching
             Action<MemoryCacheEntryOptions, string, TItem> configureCache)
             where TItem : IEntity
         {
-            return memoryCache.GetOrLoadByIdsCoreAsync(keyPrefix, ids, x => x.Id, loadItems, configureCache);
+            return memoryCache.GetOrLoadByIdsCoreAsync(keyPrefix, ids, x => x.Id, loadItems, configureCache, createExpirationToken: null);
+        }
+
+        public static Task<IList<TItem>> GetOrLoadByIdsAsync<TItem>(
+            this IMemoryCache memoryCache,
+            string keyPrefix,
+            IList<string> ids,
+            Func<IList<string>, Task<IList<TItem>>> loadItems,
+            Action<MemoryCacheEntryOptions, string, TItem> configureCache,
+            Func<string, IChangeToken> createExpirationToken)
+            where TItem : IEntity
+        {
+            return memoryCache.GetOrLoadByIdsCoreAsync(keyPrefix, ids, x => x.Id, loadItems, configureCache, createExpirationToken);
         }
 
         public static Task<IList<TItem>> GetOrLoadByIdsAsync<TItem>(
@@ -36,7 +55,22 @@ namespace VirtoCommerce.Platform.Core.Caching
         {
             ArgumentNullException.ThrowIfNull(idSelector);
 
-            return memoryCache.GetOrLoadByIdsCoreAsync(keyPrefix, ids, idSelector, loadItems, configureCache);
+            return memoryCache.GetOrLoadByIdsCoreAsync(keyPrefix, ids, idSelector, loadItems, configureCache, createExpirationToken: null);
+        }
+
+        public static Task<IList<TItem>> GetOrLoadByIdsAsync<TItem>(
+            this IMemoryCache memoryCache,
+            string keyPrefix,
+            IList<string> ids,
+            Func<TItem, string> idSelector,
+            Func<IList<string>, Task<IList<TItem>>> loadItems,
+            Action<MemoryCacheEntryOptions, string, TItem> configureCache,
+            Func<string, IChangeToken> createExpirationToken)
+            where TItem : class
+        {
+            ArgumentNullException.ThrowIfNull(idSelector);
+
+            return memoryCache.GetOrLoadByIdsCoreAsync(keyPrefix, ids, idSelector, loadItems, configureCache, createExpirationToken);
         }
 
         private static async Task<IList<TItem>> GetOrLoadByIdsCoreAsync<TItem>(
@@ -45,7 +79,8 @@ namespace VirtoCommerce.Platform.Core.Caching
             IList<string> ids,
             Func<TItem, string> idSelector,
             Func<IList<string>, Task<IList<TItem>>> loadItems,
-            Action<MemoryCacheEntryOptions, string, TItem> configureCache)
+            Action<MemoryCacheEntryOptions, string, TItem> configureCache,
+            Func<string, IChangeToken> createExpirationToken)
         {
             ids = DistinctNonEmpty(ids);
 
@@ -85,6 +120,17 @@ namespace VirtoCommerce.Platform.Core.Caching
                         .Except(result.Keys)
                         .ToList();
 
+                    // Capture the invalidation token BEFORE the load runs, not after. A writer's
+                    // commit+invalidation can land while `loadItems` is in flight; if the token were
+                    // minted afterwards (in `configureCache`, as before this fix), the invalidation that
+                    // made the just-loaded value stale would already be gone from
+                    // CancellableCacheRegion<T>'s key-token dictionary (InnerExpireTokenForKey removes it
+                    // on cancel), so the freshly minted token would come back live/uncancelled and the
+                    // stale value would be cached and served until the sliding TTL expires.
+                    var preCapturedTokens = createExpirationToken is null
+                        ? null
+                        : missingIds.ToDictionary(x => x, createExpirationToken, _ignoreCase);
+
                     var items = await loadItems(missingIds) ?? Array.Empty<TItem>();
 
                     var itemsByIds = items
@@ -98,7 +144,14 @@ namespace VirtoCommerce.Platform.Core.Caching
                         result[id] = memoryCache.GetOrCreateExclusive(cacheKey, options =>
                         {
                             var item = itemsByIds.GetValueSafe(id);
+
+                            if (preCapturedTokens is not null)
+                            {
+                                options.AddExpirationToken(preCapturedTokens[id]);
+                            }
+
                             configureCache(options, id, item);
+
                             return item;
                         });
                     }

--- a/src/VirtoCommerce.Platform.Core/Common/ReflectionUtility.cs
+++ b/src/VirtoCommerce.Platform.Core/Common/ReflectionUtility.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
+using System.Diagnostics.CodeAnalysis;
 using System.Linq;
 using System.Linq.Expressions;
 using System.Reflection;
@@ -18,6 +19,7 @@ public static class ReflectionUtility
     private static readonly ConcurrentDictionary<Type, Type[]> _typeInheritanceChains = new();
     private static readonly ConcurrentDictionary<(Type Type, Type ToBaseType), Type[]> _typeInheritanceChainsTo = new();
     private static readonly ConcurrentDictionary<(Type Type, Type Attribute, bool Inherit), PropertyInfo[]> _propertiesWithAttribute = new();
+    private static readonly ConcurrentDictionary<(Type Type, MethodInfo BaseMethod), bool> _overriddenMethods = new();
 
     public static IEnumerable<string> GetPropertyNames<T>(params Expression<Func<T, object>>[] propertyExpressions)
     {
@@ -117,6 +119,54 @@ public static class ReflectionUtility
             }
 
             return retVal.ToArray();
+        });
+    }
+
+    /// <summary>
+    /// Whether <paramref name="type"/> overrides the virtual <paramref name="baseMethod"/> declared by one of
+    /// its base types. Pass the base declaration itself — resolving it by name would be ambiguous between
+    /// overloads, while a <see cref="MethodInfo"/> identifies one virtual slot exactly.
+    /// </summary>
+    /// <remarks>
+    /// <para>
+    /// The answer depends only on the two arguments and cannot change once the types are loaded, so it is
+    /// cached. Callers may therefore ask on a hot path — notably the constructor of a service registered
+    /// AddTransient, where an uncached probe would charge every DI resolve for an answer fixed at load time.
+    /// </para>
+    /// <para>
+    /// A member hidden with <c>new</c> rather than overridden reports false: it occupies a fresh slot, so a
+    /// virtual call still reaches the base implementation.
+    /// </para>
+    /// <para>
+    /// A constructed generic method may be passed as-is: <see cref="MethodInfo.GetBaseDefinition"/> resolves
+    /// it to the open definition, so <c>Foo&lt;int&gt;</c> answers for the <c>Foo&lt;T&gt;</c> slot.
+    /// </para>
+    /// </remarks>
+    [SuppressMessage("Major Code Smell", "S3011:Reflection should not be used to increase accessibility of classes, methods, or fields",
+        Justification = "Detects only WHETHER a subtype overrides a protected virtual member; it neither invokes the member nor widens its accessibility.")]
+    public static bool IsMethodOverridden(
+        [DynamicallyAccessedMembers(DynamicallyAccessedMemberTypes.PublicMethods | DynamicallyAccessedMemberTypes.NonPublicMethods)] this Type type,
+        MethodInfo baseMethod)
+    {
+        ArgumentNullException.ThrowIfNull(type);
+        ArgumentNullException.ThrowIfNull(baseMethod);
+
+        return _overriddenMethods.GetOrAdd((type, baseMethod), static key =>
+        {
+            // Two MethodInfos share a virtual slot exactly when their base definitions match, so this
+            // compares slots rather than re-resolving by name and parameter types — overloads, including
+            // ones that differ only in parameter types at the same arity, can never be confused.
+            var baseDefinition = key.BaseMethod.GetBaseDefinition();
+
+            foreach (var method in key.Type.GetMethods(BindingFlags.Instance | BindingFlags.Public | BindingFlags.NonPublic))
+            {
+                if (method.GetBaseDefinition() == baseDefinition)
+                {
+                    return method.DeclaringType != key.BaseMethod.DeclaringType;
+                }
+            }
+
+            return false;
         });
     }
 

--- a/src/VirtoCommerce.Platform.Core/Common/ValueObject.cs
+++ b/src/VirtoCommerce.Platform.Core/Common/ValueObject.cs
@@ -25,6 +25,14 @@ public abstract class ValueObject : IValueObject, ICacheKey, ICloneable
     // components) or GetProperties (custom property set/order) — those keep the legacy component path.
     private static readonly ConcurrentDictionary<Type, ComponentAccessor[]> _componentAccessors = new();
 
+    // The two declarations the fast-path gate probes for overrides. Passing the declaration itself rather
+    // than a name keeps the probe unambiguous — GetProperties is overloaded here.
+    private static readonly MethodInfo _getEqualityComponentsMethod = typeof(ValueObject)
+        .GetMethod(nameof(GetEqualityComponents), BindingFlags.Instance | BindingFlags.NonPublic, Type.EmptyTypes);
+
+    private static readonly MethodInfo _getPropertiesMethod = typeof(ValueObject)
+        .GetMethod(nameof(GetProperties), BindingFlags.Instance | BindingFlags.NonPublic, Type.EmptyTypes);
+
     private delegate void ValueHasher(object instance, ref HashCode hash);
 
     private delegate bool ValueEqualityCheck(object left, object right);
@@ -183,21 +191,12 @@ public abstract class ValueObject : IValueObject, ICacheKey, ICloneable
         // uses the default component model — i.e. overrides NEITHER GetEqualityComponents (custom
         // components) NOR GetProperties (custom property set/order). Either override means equality
         // must flow through the virtual component path, so fall back to the legacy implementation.
-        if (IsOverridden(type, nameof(GetEqualityComponents)) || IsOverridden(type, nameof(GetProperties)))
+        if (type.IsMethodOverridden(_getEqualityComponentsMethod) || type.IsMethodOverridden(_getPropertiesMethod))
         {
             return null;
         }
 
         return GetProperties(type).Select(ComponentAccessor.Create).ToArray();
-    }
-
-    [SuppressMessage("Major Code Smell", "S3011:Reflection should not be used to increase accessibility of classes, methods, or fields",
-        Justification = "Reflection only detects whether a subtype overrides the protected virtual GetEqualityComponents/GetProperties (the fast-path gate); it neither invokes them nor widens their accessibility.")]
-    private static bool IsOverridden(Type type, string methodName)
-    {
-        var method = type.GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic);
-
-        return method?.DeclaringType != typeof(ValueObject);
     }
 
     // Hashes one reference-typed (or list) component, mirroring the marked stream that ExpandComponent

--- a/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
+++ b/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -30,11 +31,31 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
         where TChangingEvent : GenericChangedEntryEvent<TModel>
         where TChangedEvent : GenericChangedEntryEvent<TModel>
     {
+#pragma warning disable S2743 // Static fields should not be used in generic types
+        // Which virtual members a subclass overrides depends only on its concrete type, never on
+        // instance state - but CRUD services are registered AddTransient and re-constructed on every
+        // DI resolve, so probing by reflection in the constructor charges every resolve for an answer
+        // that cannot change. Cache it per concrete type: measured 170 ns / 208 B per construction for
+        // the two probes, against 3 ns / 0 B for the lookup.
+        // The dictionary being per closed generic is deliberate, not an oversight: each one then holds
+        // only the subclasses of its own closed generic (usually one, two when a client module
+        // overrides the service), and no lock is shared across unrelated services. A single non-generic
+        // holder would save 52 KB once for the whole platform - measured - which does not pay for the
+        // extra type. Only the data duplicates, not the code: every type argument here is a reference
+        // type, so the runtime shares one canonical code body across all instantiations - measured at
+        // 1 extra JIT-compiled method for 40 further closed generics, against 601 had they been value
+        // types. Static fields are per closed generic regardless of that sharing, which is what makes
+        // the dictionary its own.
+        private static readonly ConcurrentDictionary<Type, OverrideFlags> _overrideFlags = new();
+#pragma warning restore S2743
+
         private readonly IEventPublisher _eventPublisher;
         private readonly IPlatformMemoryCache _platformMemoryCache;
         private readonly Func<IRepository> _repositoryFactory;
         private readonly bool _isToModelOverridden;
         private readonly bool _isConfigureCacheOverridden;
+
+        private readonly record struct OverrideFlags(bool IsToModelOverridden, bool IsConfigureCacheOverridden);
 
         /// <summary>
         /// Construct new CrudService
@@ -48,14 +69,26 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
             _platformMemoryCache = platformMemoryCache;
             _eventPublisher = eventPublisher;
 
-            _isToModelOverridden = IsOverridden(nameof(ToModel), [typeof(TEntity)]);
+            var serviceType = GetType();
 
-            _isConfigureCacheOverridden = IsOverridden(nameof(ConfigureCache), [typeof(MemoryCacheEntryOptions), typeof(string), typeof(TModel)]);
+            // TryGetValue rather than GetOrAdd(key, factory): the factory would close over `this` and
+            // allocate a delegate on every construction, which is the cost this cache exists to remove.
+            if (!_overrideFlags.TryGetValue(serviceType, out var overrides))
+            {
+                overrides = new OverrideFlags(
+                    IsOverridden(serviceType, nameof(ToModel), [typeof(TEntity)]),
+                    IsOverridden(serviceType, nameof(ConfigureCache), [typeof(MemoryCacheEntryOptions), typeof(string), typeof(TModel)]));
+
+                _overrideFlags.TryAdd(serviceType, overrides);
+            }
+
+            _isToModelOverridden = overrides.IsToModelOverridden;
+            _isConfigureCacheOverridden = overrides.IsConfigureCacheOverridden;
         }
 
-        private bool IsOverridden(string methodName, Type[] parameterTypes)
+        private static bool IsOverridden(Type serviceType, string methodName, Type[] parameterTypes)
         {
-            return GetType()
+            return serviceType
                 .GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic, parameterTypes)
                 ?.DeclaringType != typeof(CrudService<TModel, TEntity, TChangingEvent, TChangedEvent>);
         }

--- a/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
+++ b/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
@@ -34,7 +34,7 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
         private readonly IPlatformMemoryCache _platformMemoryCache;
         private readonly Func<IRepository> _repositoryFactory;
         private readonly bool _isToModelOverridden;
-        private readonly bool _ownsCacheTokenPairing;
+        private readonly bool _isConfigureCacheOverridden;
 
         /// <summary>
         /// Construct new CrudService
@@ -50,9 +50,7 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
 
             _isToModelOverridden = IsOverridden(nameof(ToModel), [typeof(TEntity)]);
 
-            _ownsCacheTokenPairing =
-                !IsOverridden(nameof(ConfigureCache), [typeof(MemoryCacheEntryOptions), typeof(string), typeof(TModel)]) &&
-                !IsOverridden(nameof(ClearCache), [typeof(IList<TModel>)]);
+            _isConfigureCacheOverridden = IsOverridden(nameof(ConfigureCache), [typeof(MemoryCacheEntryOptions), typeof(string), typeof(TModel)]);
         }
 
         private bool IsOverridden(string methodName, Type[] parameterTypes)
@@ -66,14 +64,17 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
         /// Whether <see cref="GetAsync"/> hands <see cref="CreateCacheToken"/> to the cache helper, which then
         /// captures the invalidation token BEFORE the data is loaded, so an invalidation landing mid-load is
         /// still observed instead of being lost.
-        /// True only while this service still owns BOTH halves of the token pairing: the mint side
-        /// (<see cref="CreateCacheToken"/>, reached through the default <see cref="ConfigureCache"/>) and the
-        /// expire side (<see cref="ClearCache"/>). A subclass overriding either half without calling base
-        /// invalidates through a region of its own, so it gains nothing from the early capture while paying
-        /// one permanently-live token source per id in a region nothing ever expires.
-        /// Override and return true to opt back in when the override does call base.
+        /// True while this service still mints through the default <see cref="ConfigureCache"/>: the early
+        /// capture then reuses the very token source that <see cref="ConfigureCache"/> would create anyway,
+        /// so it adds no state. A subclass that overrides <see cref="ConfigureCache"/> may redirect the mint to
+        /// a region of its own — for such a subclass the early capture would create one permanently-live token
+        /// source per id in <see cref="GenericCachingRegion{TModel}"/>, which it never expires.
+        /// Deliberately NOT conditioned on <see cref="ClearCache"/>: overriding it does not move the mint, so
+        /// gating on it would drop this fix for services that expire extra keys in the very same region
+        /// (vc-module-order CustomerOrderService) while saving nothing.
+        /// Override and return true to opt back in when the <see cref="ConfigureCache"/> override calls base.
         /// </summary>
-        protected virtual bool CaptureCacheTokenBeforeLoad => _ownsCacheTokenPairing;
+        protected virtual bool CaptureCacheTokenBeforeLoad => !_isConfigureCacheOverridden;
 
         /// <summary>
         /// Returns a list of model instances for specified IDs.

--- a/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
+++ b/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
@@ -34,6 +34,7 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
         private readonly IPlatformMemoryCache _platformMemoryCache;
         private readonly Func<IRepository> _repositoryFactory;
         private readonly bool _isToModelOverridden;
+        private readonly bool _ownsCacheTokenPairing;
 
         /// <summary>
         /// Construct new CrudService
@@ -47,10 +48,32 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
             _platformMemoryCache = platformMemoryCache;
             _eventPublisher = eventPublisher;
 
-            _isToModelOverridden = GetType()
-                .GetMethod(nameof(ToModel), BindingFlags.Instance | BindingFlags.NonPublic, [typeof(TEntity)])
+            _isToModelOverridden = IsOverridden(nameof(ToModel), [typeof(TEntity)]);
+
+            _ownsCacheTokenPairing =
+                !IsOverridden(nameof(ConfigureCache), [typeof(MemoryCacheEntryOptions), typeof(string), typeof(TModel)]) &&
+                !IsOverridden(nameof(ClearCache), [typeof(IList<TModel>)]);
+        }
+
+        private bool IsOverridden(string methodName, Type[] parameterTypes)
+        {
+            return GetType()
+                .GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic, parameterTypes)
                 ?.DeclaringType != typeof(CrudService<TModel, TEntity, TChangingEvent, TChangedEvent>);
         }
+
+        /// <summary>
+        /// Whether <see cref="GetAsync"/> hands <see cref="CreateCacheToken"/> to the cache helper, which then
+        /// captures the invalidation token BEFORE the data is loaded, so an invalidation landing mid-load is
+        /// still observed instead of being lost.
+        /// True only while this service still owns BOTH halves of the token pairing: the mint side
+        /// (<see cref="CreateCacheToken"/>, reached through the default <see cref="ConfigureCache"/>) and the
+        /// expire side (<see cref="ClearCache"/>). A subclass overriding either half without calling base
+        /// invalidates through a region of its own, so it gains nothing from the early capture while paying
+        /// one permanently-live token source per id in a region nothing ever expires.
+        /// Override and return true to opt back in when the override does call base.
+        /// </summary>
+        protected virtual bool CaptureCacheTokenBeforeLoad => _ownsCacheTokenPairing;
 
         /// <summary>
         /// Returns a list of model instances for specified IDs.
@@ -63,10 +86,15 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
         {
             var cacheKeyPrefix = CacheKey.With(GetType(), nameof(GetAsync), responseGroup);
 
+            // The opt-out has to sit here, where the factory is passed, and not inside the factory:
+            // GetOrLoadByIdsAsync never invokes a null factory, so no token source is created at all.
+            // CreateCacheToken memoizes into a process-static dictionary, so calling it is a write.
+            Func<string, IChangeToken> createCacheToken = CaptureCacheTokenBeforeLoad ? CreateCacheToken : null;
+
             var models = await _platformMemoryCache.GetOrLoadByIdsAsync(cacheKeyPrefix, ids,
                 missingIds => GetByIdsNoCache(missingIds, responseGroup),
                 ConfigureCache,
-                CreateCacheToken);
+                createCacheToken);
 
             if (!clone)
             {

--- a/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
+++ b/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.Linq;
 using System.Reflection;
@@ -32,21 +31,16 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
         where TChangedEvent : GenericChangedEntryEvent<TModel>
     {
 #pragma warning disable S2743 // Static fields should not be used in generic types
-        // Which virtual members a subclass overrides depends only on its concrete type, never on
-        // instance state - but CRUD services are registered AddTransient and re-constructed on every
-        // DI resolve, so probing by reflection in the constructor charges every resolve for an answer
-        // that cannot change. Cache it per concrete type: measured 170 ns / 208 B per construction for
-        // the two probes, against 3 ns / 0 B for the lookup.
-        // The dictionary being per closed generic is deliberate, not an oversight: each one then holds
-        // only the subclasses of its own closed generic (usually one, two when a client module
-        // overrides the service), and no lock is shared across unrelated services. A single non-generic
-        // holder would save 52 KB once for the whole platform - measured - which does not pay for the
-        // extra type. Only the data duplicates, not the code: every type argument here is a reference
-        // type, so the runtime shares one canonical code body across all instantiations - measured at
-        // 1 extra JIT-compiled method for 40 further closed generics, against 601 had they been value
-        // types. Static fields are per closed generic regardless of that sharing, which is what makes
-        // the dictionary its own.
-        private static readonly ConcurrentDictionary<Type, OverrideFlags> _overrideFlags = new();
+        // Intentional: the probed declarations differ per closed generic, since their parameters are
+        // TEntity and TModel. Resolving them once per instantiation costs two references (measured 47 B)
+        // and hands ReflectionUtility a key it can cache on — the alternative, probing by reflection in
+        // the constructor, charges every DI resolve for an answer fixed at type-load time, and CRUD
+        // services are registered AddTransient (measured 170 ns / 208 B per construction).
+        private static readonly MethodInfo _toModelMethod = typeof(CrudService<TModel, TEntity, TChangingEvent, TChangedEvent>)
+            .GetMethod(nameof(ToModel), BindingFlags.Instance | BindingFlags.NonPublic, [typeof(TEntity)]);
+
+        private static readonly MethodInfo _configureCacheMethod = typeof(CrudService<TModel, TEntity, TChangingEvent, TChangedEvent>)
+            .GetMethod(nameof(ConfigureCache), BindingFlags.Instance | BindingFlags.NonPublic, [typeof(MemoryCacheEntryOptions), typeof(string), typeof(TModel)]);
 #pragma warning restore S2743
 
         private readonly IEventPublisher _eventPublisher;
@@ -54,8 +48,6 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
         private readonly Func<IRepository> _repositoryFactory;
         private readonly bool _isToModelOverridden;
         private readonly bool _isConfigureCacheOverridden;
-
-        private readonly record struct OverrideFlags(bool IsToModelOverridden, bool IsConfigureCacheOverridden);
 
         /// <summary>
         /// Construct new CrudService
@@ -71,26 +63,8 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
 
             var serviceType = GetType();
 
-            // TryGetValue rather than GetOrAdd(key, factory): the factory would close over `this` and
-            // allocate a delegate on every construction, which is the cost this cache exists to remove.
-            if (!_overrideFlags.TryGetValue(serviceType, out var overrides))
-            {
-                overrides = new OverrideFlags(
-                    IsOverridden(serviceType, nameof(ToModel), [typeof(TEntity)]),
-                    IsOverridden(serviceType, nameof(ConfigureCache), [typeof(MemoryCacheEntryOptions), typeof(string), typeof(TModel)]));
-
-                _overrideFlags.TryAdd(serviceType, overrides);
-            }
-
-            _isToModelOverridden = overrides.IsToModelOverridden;
-            _isConfigureCacheOverridden = overrides.IsConfigureCacheOverridden;
-        }
-
-        private static bool IsOverridden(Type serviceType, string methodName, Type[] parameterTypes)
-        {
-            return serviceType
-                .GetMethod(methodName, BindingFlags.Instance | BindingFlags.NonPublic, parameterTypes)
-                ?.DeclaringType != typeof(CrudService<TModel, TEntity, TChangingEvent, TChangedEvent>);
+            _isToModelOverridden = serviceType.IsMethodOverridden(_toModelMethod);
+            _isConfigureCacheOverridden = serviceType.IsMethodOverridden(_configureCacheMethod);
         }
 
         /// <summary>

--- a/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
+++ b/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
@@ -65,7 +65,8 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
 
             var models = await _platformMemoryCache.GetOrLoadByIdsAsync(cacheKeyPrefix, ids,
                 missingIds => GetByIdsNoCache(missingIds, responseGroup),
-                ConfigureCache);
+                ConfigureCache,
+                CreateCacheToken);
 
             if (!clone)
             {

--- a/tests/VirtoCommerce.Platform.Caching.Tests/GetOrLoadByIdsStaleCacheTests.cs
+++ b/tests/VirtoCommerce.Platform.Caching.Tests/GetOrLoadByIdsStaleCacheTests.cs
@@ -1,0 +1,133 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using VirtoCommerce.Platform.Core.Caching;
+using VirtoCommerce.Platform.Core.Common;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Caching.Tests
+{
+    // Reproduces (and pins the fix for) a real defect in MemoryCacheExtensions.GetOrLoadByIdsCoreAsync:
+    // the cache-invalidation change token used to be minted in `configureCache` AFTER `loadItems` had
+    // already run. If a writer commits and invalidates the key WHILE a reader's load is in flight, the
+    // reader's later cache-write mints a brand-new (uncancelled) token via
+    // GenericCachingRegion<T>.CreateChangeTokenForKey — because
+    // CancellableCacheRegion<T>.InnerExpireTokenForKey already TryRemove'd the prior token source from
+    // _keyTokensDict before the reader gets around to writing. The stale value would then be cached under
+    // a token that can never observe the invalidation that made it stale, and would be served on every
+    // subsequent read until the sliding TTL expires.
+    //
+    // The fix adds an explicit, opt-in `createExpirationToken` parameter to `GetOrLoadByIdsAsync`: when
+    // supplied, the token is captured BEFORE `loadItems` runs, so an invalidation landing mid-load is
+    // still visible. Test A proves the fixed (opted-in) path. Test B is a deliberate characterization
+    // test: callers that do NOT pass a token factory keep the pre-fix behaviour by design — the raw
+    // extension without an explicit factory is knowingly still vulnerable, and that is the documented
+    // opt-in boundary, not an oversight.
+    [Trait("Category", "Unit")]
+    [Collection(nameof(NotThreadSafeCollection))]
+    public class GetOrLoadByIdsStaleCacheTests : MemoryCacheTestsBase
+    {
+        // Private, test-only model: GenericCachingRegion<T> keys its static token state on T, so sharing
+        // a model type with another test would let parallel tests bleed into each other.
+        private sealed class StaleCacheProbeModel : Entity
+        {
+            public int Version { get; init; }
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_WithTokenFactory_InvalidationDuringLoad_ServesFreshValue()
+        {
+            var sut = GetPlatformMemoryCache();
+            const string keyPrefix = "stale-cache-probe-fixed";
+            const string id = "probe-1";
+            var secondLoadCalls = 0;
+
+            // Mirrors CrudService.ConfigureCache (src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs:92-95) exactly.
+            static void ConfigureCache(MemoryCacheEntryOptions options, string entityId, StaleCacheProbeModel item)
+            {
+                options.AddExpirationToken(GenericCachingRegion<StaleCacheProbeModel>.CreateChangeTokenForKey(entityId));
+            }
+
+            // First read: the loader models a writer that commits and invalidates the key WHILE the
+            // SELECT is in flight, then returns the value it read before that commit (now stale).
+            Task<IList<StaleCacheProbeModel>> LoadStale(IList<string> ids)
+            {
+                GenericCachingRegion<StaleCacheProbeModel>.ExpireTokenForKey(id);
+
+                IList<StaleCacheProbeModel> items = [new StaleCacheProbeModel { Id = id, Version = 1 }];
+                return Task.FromResult(items);
+            }
+
+            await sut.GetOrLoadByIdsAsync(keyPrefix, [id], LoadStale, ConfigureCache,
+                entityId => GenericCachingRegion<StaleCacheProbeModel>.CreateChangeTokenForKey(entityId));
+
+            // Second read for the same id: the fixed implementation captured the token BEFORE the load
+            // ran, so the mid-load invalidation was observed and the poisoned entry was evicted, forcing
+            // this loader to run and return the fresh value.
+            Task<IList<StaleCacheProbeModel>> LoadFresh(IList<string> ids)
+            {
+                secondLoadCalls++;
+
+                IList<StaleCacheProbeModel> items = [new StaleCacheProbeModel { Id = id, Version = 2 }];
+                return Task.FromResult(items);
+            }
+
+            var second = await sut.GetOrLoadByIdsAsync(keyPrefix, [id], LoadFresh, ConfigureCache,
+                entityId => GenericCachingRegion<StaleCacheProbeModel>.CreateChangeTokenForKey(entityId));
+
+            Assert.Equal(1, secondLoadCalls);
+            Assert.Equal(2, second.Single().Version);
+        }
+
+        [Fact]
+        public async Task GetOrLoadByIdsAsync_WithoutTokenFactory_InvalidationDuringLoad_StillServesStaleValue()
+        {
+            // CHARACTERIZATION TEST — pins the opt-in boundary of the fix, not a bug report.
+            // A caller that does not pass `createExpirationToken` keeps the original (pre-fix) behaviour:
+            // the invalidation-token is minted late, inside `configureCache`, so a mid-load invalidation
+            // is invisible to it and the stale value is cached under a live token. This is the documented,
+            // knowingly-still-vulnerable contract for callers that don't opt in — see
+            // GetOrLoadByIdsAsync_WithTokenFactory_InvalidationDuringLoad_ServesFreshValue for the fixed path.
+            var sut = GetPlatformMemoryCache();
+            const string keyPrefix = "stale-cache-probe-unfixed";
+            const string id = "probe-2"; // different id from test A — GenericCachingRegion<T> state is shared across the class
+            var secondLoadCalls = 0;
+
+            // Mirrors CrudService.ConfigureCache (src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs:92-95) exactly.
+            static void ConfigureCache(MemoryCacheEntryOptions options, string entityId, StaleCacheProbeModel item)
+            {
+                options.AddExpirationToken(GenericCachingRegion<StaleCacheProbeModel>.CreateChangeTokenForKey(entityId));
+            }
+
+            // First read: the loader models a writer that commits and invalidates the key WHILE the
+            // SELECT is in flight, then returns the value it read before that commit (now stale).
+            Task<IList<StaleCacheProbeModel>> LoadStale(IList<string> ids)
+            {
+                GenericCachingRegion<StaleCacheProbeModel>.ExpireTokenForKey(id);
+
+                IList<StaleCacheProbeModel> items = [new StaleCacheProbeModel { Id = id, Version = 1 }];
+                return Task.FromResult(items);
+            }
+
+            // No createExpirationToken argument here — the not-opted-in call shape.
+            await sut.GetOrLoadByIdsAsync(keyPrefix, [id], LoadStale, ConfigureCache);
+
+            // Second read for the same id: without the opt-in, the token is (again) minted only inside
+            // configureCache, AFTER this load already ran below — so the entry from the first read is
+            // never evicted and this loader must NOT run.
+            Task<IList<StaleCacheProbeModel>> LoadFresh(IList<string> ids)
+            {
+                secondLoadCalls++;
+
+                IList<StaleCacheProbeModel> items = [new StaleCacheProbeModel { Id = id, Version = 2 }];
+                return Task.FromResult(items);
+            }
+
+            var second = await sut.GetOrLoadByIdsAsync(keyPrefix, [id], LoadFresh, ConfigureCache);
+
+            Assert.Equal(0, secondLoadCalls);
+            Assert.Equal(1, second.Single().Version);
+        }
+    }
+}

--- a/tests/VirtoCommerce.Platform.Tests/GenericCrud/CrudServiceCacheTokenGateTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/GenericCrud/CrudServiceCacheTokenGateTests.cs
@@ -1,0 +1,200 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Caching.Memory;
+using Moq;
+using VirtoCommerce.Platform.Caching;
+using VirtoCommerce.Platform.Core.Caching;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Domain;
+using VirtoCommerce.Platform.Core.Events;
+using VirtoCommerce.Platform.Data.GenericCrud;
+using VirtoCommerce.Platform.Tests.Common;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Tests.GenericCrud
+{
+    // Pins the pairing gate in CrudService.GetAsync. Capturing the invalidation token before the load
+    // (VCST-5303) is only meaningful for a service that still owns BOTH halves of the token pairing: the
+    // mint side (CreateCacheToken, reached through the default ConfigureCache) and the expire side
+    // (ClearCache). CreateCacheToken memoizes into CancellableCacheRegion<T>'s process-static key-token
+    // dictionary, whose only removal path is an explicit expire — so handing it to the cache helper on
+    // behalf of a subclass that invalidates through a region of its own leaks one permanently-live
+    // CancellationTokenSource per id into a region nothing ever sweeps (vc-module-inventory
+    // InventoryServiceImpl is the real-world shape).
+    //
+    // Every probe type is generic over a marker so each test gets its own GenericCachingRegion<TModel>
+    // static state. Sharing a model type across tests — or with CrudServiceTests, which populates
+    // GenericCachingRegion<TestModel> — would let one test's tokens satisfy or break another's assertion.
+    public class CrudServiceCacheTokenGateTests
+    {
+        private const string ProbeId = "probe-1";
+
+        private sealed class OwnsPairing;
+        private sealed class OverridesPairing;
+        private sealed class OverridesPairingAndOptsBackIn;
+
+        [Fact]
+        public async Task GetAsync_ServiceOwnsThePairing_InvalidationDuringLoad_IsNotCached()
+        {
+            // The default shape: the gate is open, so the token is captured before the load and the
+            // mid-load invalidation cancels it. The stale value must not survive in the cache.
+            var service = new ProbeCrudService<OwnsPairing> { ExpireDuringLoad = true };
+
+            var first = await service.GetAsync([ProbeId]);
+            var second = await service.GetAsync([ProbeId]);
+
+            Assert.Equal(1, first.Single().Version);
+            Assert.Equal(2, service.LoadCalls);
+            Assert.Equal(2, second.Single().Version);
+        }
+
+        [Fact]
+        public async Task GetAsync_ServiceOverridesThePairing_DoesNotCreateTokensInTheDefaultRegion()
+        {
+            // ConfigureCache and ClearCache are both replaced, so this service invalidates through
+            // ProbeCacheRegion and gains nothing from the early capture. It must not pay for it either:
+            // GenericCachingRegion<TModel> stays untouched.
+            var service = new OverriddenPairingProbeCrudService<OverridesPairing>();
+
+            await service.GetAsync([ProbeId]);
+
+            Assert.Empty(GetDefaultRegionTokenKeys<ProbeModel<OverridesPairing>>());
+
+            // Proves the assertion above is not vacuous — the overridden ConfigureCache did run and did
+            // register the id in the region this service actually expires.
+            Assert.Contains(
+                ProbeCacheRegion<OverridesPairing>.GenerateRegionTokenKey(ProbeId),
+                GetRegionTokenKeys<ProbeCacheRegion<OverridesPairing>>());
+        }
+
+        [Fact]
+        public async Task GetAsync_ServiceOverridesThePairingButOptsBackIn_CreatesTokensInTheDefaultRegion()
+        {
+            // The escape hatch: a subclass that overrides the pairing but still calls base can restore the
+            // early capture with a one-line CaptureCacheTokenBeforeLoad override.
+            var service = new OptedInProbeCrudService<OverridesPairingAndOptsBackIn>();
+
+            await service.GetAsync([ProbeId]);
+
+            Assert.Contains(
+                GenericCachingRegion<ProbeModel<OverridesPairingAndOptsBackIn>>.GenerateRegionTokenKey(ProbeId),
+                GetDefaultRegionTokenKeys<ProbeModel<OverridesPairingAndOptsBackIn>>());
+        }
+
+        private static IReadOnlyCollection<string> GetDefaultRegionTokenKeys<TModel>()
+            where TModel : IEntity
+        {
+            return GetRegionTokenKeys<GenericCachingRegion<TModel>>();
+        }
+
+        // Reads CancellableCacheRegion<TRegion>'s private static _keyTokensDict. There is no public read
+        // surface for it, and the whole point of the gate is that entries never appear there — so the
+        // dictionary itself is what has to be asserted on.
+        private static IReadOnlyCollection<string> GetRegionTokenKeys<TRegion>()
+        {
+            var field = typeof(CancellableCacheRegion<TRegion>)
+                .GetField("_keyTokensDict", BindingFlags.NonPublic | BindingFlags.Static);
+
+            Assert.NotNull(field);
+
+            var tokens = (ConcurrentDictionary<string, CancellationTokenSource>)field.GetValue(null);
+
+            return tokens.Keys.ToList();
+        }
+
+        private sealed class ProbeModel<TMarker> : Entity, ICloneable
+        {
+            public int Version { get; set; }
+
+            public object Clone()
+            {
+                return MemberwiseClone();
+            }
+        }
+
+        private sealed class ProbeEntity<TMarker> : Entity, IDataEntity<ProbeEntity<TMarker>, ProbeModel<TMarker>>
+        {
+            public int Version { get; set; }
+
+            // GetAsync never converts in either direction here — ProcessModels is overridden so the probe
+            // needs no AbstractTypeFactory registration — and it never saves.
+            public ProbeModel<TMarker> ToModel(ProbeModel<TMarker> model) => throw new NotSupportedException();
+
+            public ProbeEntity<TMarker> FromModel(ProbeModel<TMarker> model, PrimaryKeyResolvingMap pkMap) => throw new NotSupportedException();
+
+            public void Patch(ProbeEntity<TMarker> target) => throw new NotSupportedException();
+        }
+
+        private sealed class ProbeChangingEvent<TMarker>(IEnumerable<GenericChangedEntry<ProbeModel<TMarker>>> changedEntries)
+            : GenericChangedEntryEvent<ProbeModel<TMarker>>(changedEntries);
+
+        private sealed class ProbeChangedEvent<TMarker>(IEnumerable<GenericChangedEntry<ProbeModel<TMarker>>> changedEntries)
+            : GenericChangedEntryEvent<ProbeModel<TMarker>>(changedEntries);
+
+        private sealed class ProbeCacheRegion<TMarker> : CancellableCacheRegion<ProbeCacheRegion<TMarker>>;
+
+        // Owns both halves of the pairing: neither ConfigureCache nor ClearCache is overridden.
+        private class ProbeCrudService<TMarker> : CrudService<ProbeModel<TMarker>, ProbeEntity<TMarker>, ProbeChangingEvent<TMarker>, ProbeChangedEvent<TMarker>>
+        {
+            public ProbeCrudService()
+                : base(() => new Mock<IRepository>().Object, MemoryCacheMockHelper.GetPlatformMemoryCache(), new Mock<IEventPublisher>().Object)
+            {
+            }
+
+            public int LoadCalls { get; private set; }
+
+            /// <summary>
+            /// Models a writer that commits and invalidates the key WHILE this load is in flight.
+            /// </summary>
+            public bool ExpireDuringLoad { get; set; }
+
+            protected override Task<IList<ProbeEntity<TMarker>>> LoadEntities(IRepository repository, IList<string> ids, string responseGroup)
+            {
+                LoadCalls++;
+
+                if (ExpireDuringLoad)
+                {
+                    GenericCachingRegion<ProbeModel<TMarker>>.ExpireTokenForKey(ProbeId);
+                }
+
+                IList<ProbeEntity<TMarker>> entities = ids
+                    .Select(x => new ProbeEntity<TMarker> { Id = x, Version = LoadCalls })
+                    .ToList();
+
+                return Task.FromResult(entities);
+            }
+
+            protected override IList<ProbeModel<TMarker>> ProcessModels(IList<ProbeEntity<TMarker>> entities, string responseGroup)
+            {
+                return entities
+                    .Select(x => new ProbeModel<TMarker> { Id = x.Id, Version = x.Version })
+                    .ToList();
+            }
+        }
+
+        // Mirrors vc-module-inventory InventoryServiceImpl: replaces both halves of the pairing with its own
+        // region and never calls base.
+        private class OverriddenPairingProbeCrudService<TMarker> : ProbeCrudService<TMarker>
+        {
+            protected override void ConfigureCache(MemoryCacheEntryOptions cacheOptions, string id, ProbeModel<TMarker> model)
+            {
+                cacheOptions.AddExpirationToken(ProbeCacheRegion<TMarker>.CreateChangeTokenForKey(id));
+            }
+
+            protected override void ClearCache(IList<ProbeModel<TMarker>> models)
+            {
+                ProbeCacheRegion<TMarker>.ExpireRegion();
+            }
+        }
+
+        private sealed class OptedInProbeCrudService<TMarker> : OverriddenPairingProbeCrudService<TMarker>
+        {
+            protected override bool CaptureCacheTokenBeforeLoad => true;
+        }
+    }
+}

--- a/tests/VirtoCommerce.Platform.Tests/GenericCrud/CrudServiceCacheTokenGateTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/GenericCrud/CrudServiceCacheTokenGateTests.cs
@@ -18,32 +18,39 @@ using Xunit;
 
 namespace VirtoCommerce.Platform.Tests.GenericCrud
 {
-    // Pins the pairing gate in CrudService.GetAsync. Capturing the invalidation token before the load
-    // (VCST-5303) is only meaningful for a service that still owns BOTH halves of the token pairing: the
-    // mint side (CreateCacheToken, reached through the default ConfigureCache) and the expire side
-    // (ClearCache). CreateCacheToken memoizes into CancellableCacheRegion<T>'s process-static key-token
-    // dictionary, whose only removal path is an explicit expire — so handing it to the cache helper on
-    // behalf of a subclass that invalidates through a region of its own leaks one permanently-live
-    // CancellationTokenSource per id into a region nothing ever sweeps (vc-module-inventory
-    // InventoryServiceImpl is the real-world shape).
+    // Pins the ConfigureCache gate in CrudService.GetAsync. Capturing the invalidation token before the load
+    // (VCST-5303) hands CreateCacheToken to the cache helper — and that is a WRITE, not a lookup:
+    // GenericCachingRegion<TModel>.CreateChangeTokenForKey does _keyTokensDict.GetOrAdd(...) into
+    // process-static state whose only removal path is an explicit expire.
     //
-    // Every probe type is generic over a marker so each test gets its own GenericCachingRegion<TModel>
-    // static state. Sharing a model type across tests — or with CrudServiceTests, which populates
+    // For a service that still mints through the default ConfigureCache the early capture is free: the same
+    // key set is minted either way, so GetOrAdd returns the source ConfigureCache would have created. For a
+    // service that overrides ConfigureCache and redirects the mint to its own region (vc-module-inventory
+    // InventoryServiceImpl), the early capture instead accumulates one permanently-live
+    // CancellationTokenSource per id in a region that service never expires.
+    //
+    // Overriding ClearCache does NOT move the mint, so it must not close the gate — vc-module-order
+    // CustomerOrderService overrides ClearCache to expire an extra key in the very same region, and it is the
+    // service whose stale cached reads VCST-5303 was measured on.
+    //
+    // Every probe type is generic over a marker so each test gets its own GenericCachingRegion<TModel> static
+    // state. Sharing a model type across tests — or with CrudServiceTests, which populates
     // GenericCachingRegion<TestModel> — would let one test's tokens satisfy or break another's assertion.
     public class CrudServiceCacheTokenGateTests
     {
         private const string ProbeId = "probe-1";
 
-        private sealed class OwnsPairing;
-        private sealed class OverridesPairing;
-        private sealed class OverridesPairingAndOptsBackIn;
+        private sealed class MintsThroughDefaultRegion;
+        private sealed class ExpiresExtraKeysInTheSameRegion;
+        private sealed class MintsThroughItsOwnRegion;
+        private sealed class MintsThroughItsOwnRegionAndOptsBackIn;
 
         [Fact]
-        public async Task GetAsync_ServiceOwnsThePairing_InvalidationDuringLoad_IsNotCached()
+        public async Task GetAsync_ServiceMintsThroughDefaultRegion_InvalidationDuringLoad_IsNotCached()
         {
-            // The default shape: the gate is open, so the token is captured before the load and the
-            // mid-load invalidation cancels it. The stale value must not survive in the cache.
-            var service = new ProbeCrudService<OwnsPairing> { ExpireDuringLoad = true };
+            // The default shape: the gate is open, the token is captured before the load, and the mid-load
+            // invalidation cancels it — so the stale value must not survive in the cache.
+            var service = new ProbeCrudService<MintsThroughDefaultRegion> { ExpireDuringLoad = true };
 
             var first = await service.GetAsync([ProbeId]);
             var second = await service.GetAsync([ProbeId]);
@@ -54,36 +61,50 @@ namespace VirtoCommerce.Platform.Tests.GenericCrud
         }
 
         [Fact]
-        public async Task GetAsync_ServiceOverridesThePairing_DoesNotCreateTokensInTheDefaultRegion()
+        public async Task GetAsync_ServiceOverridesOnlyClearCache_InvalidationDuringLoad_IsNotCached()
         {
-            // ConfigureCache and ClearCache are both replaced, so this service invalidates through
-            // ProbeCacheRegion and gains nothing from the early capture. It must not pay for it either:
-            // GenericCachingRegion<TModel> stays untouched.
-            var service = new OverriddenPairingProbeCrudService<OverridesPairing>();
+            // Regression guard for the CustomerOrderService shape: ClearCache is overridden (without calling
+            // base) but expires the same region the default ConfigureCache mints into. Conditioning the gate
+            // on ClearCache too would silently drop the fix here — the one place it was measured.
+            var service = new ClearCacheOnlyProbeCrudService<ExpiresExtraKeysInTheSameRegion> { ExpireDuringLoad = true };
+
+            await service.GetAsync([ProbeId]);
+            var second = await service.GetAsync([ProbeId]);
+
+            Assert.Equal(2, service.LoadCalls);
+            Assert.Equal(2, second.Single().Version);
+        }
+
+        [Fact]
+        public async Task GetAsync_ServiceOverridesConfigureCache_DoesNotCreateTokensInTheDefaultRegion()
+        {
+            // The mint is redirected to ProbeCacheRegion, so this service gains nothing from the early
+            // capture. It must not pay for it either: GenericCachingRegion<TModel> stays untouched.
+            var service = new OwnRegionProbeCrudService<MintsThroughItsOwnRegion>();
 
             await service.GetAsync([ProbeId]);
 
-            Assert.Empty(GetDefaultRegionTokenKeys<ProbeModel<OverridesPairing>>());
+            Assert.Empty(GetDefaultRegionTokenKeys<ProbeModel<MintsThroughItsOwnRegion>>());
 
             // Proves the assertion above is not vacuous — the overridden ConfigureCache did run and did
             // register the id in the region this service actually expires.
             Assert.Contains(
-                ProbeCacheRegion<OverridesPairing>.GenerateRegionTokenKey(ProbeId),
-                GetRegionTokenKeys<ProbeCacheRegion<OverridesPairing>>());
+                ProbeCacheRegion<MintsThroughItsOwnRegion>.GenerateRegionTokenKey(ProbeId),
+                GetRegionTokenKeys<ProbeCacheRegion<MintsThroughItsOwnRegion>>());
         }
 
         [Fact]
-        public async Task GetAsync_ServiceOverridesThePairingButOptsBackIn_CreatesTokensInTheDefaultRegion()
+        public async Task GetAsync_ServiceOverridesConfigureCacheButOptsBackIn_CreatesTokensInTheDefaultRegion()
         {
-            // The escape hatch: a subclass that overrides the pairing but still calls base can restore the
-            // early capture with a one-line CaptureCacheTokenBeforeLoad override.
-            var service = new OptedInProbeCrudService<OverridesPairingAndOptsBackIn>();
+            // The escape hatch: a subclass whose ConfigureCache override does call base restores the early
+            // capture with a one-line CaptureCacheTokenBeforeLoad override.
+            var service = new OptedInProbeCrudService<MintsThroughItsOwnRegionAndOptsBackIn>();
 
             await service.GetAsync([ProbeId]);
 
             Assert.Contains(
-                GenericCachingRegion<ProbeModel<OverridesPairingAndOptsBackIn>>.GenerateRegionTokenKey(ProbeId),
-                GetDefaultRegionTokenKeys<ProbeModel<OverridesPairingAndOptsBackIn>>());
+                GenericCachingRegion<ProbeModel<MintsThroughItsOwnRegionAndOptsBackIn>>.GenerateRegionTokenKey(ProbeId),
+                GetDefaultRegionTokenKeys<ProbeModel<MintsThroughItsOwnRegionAndOptsBackIn>>());
         }
 
         private static IReadOnlyCollection<string> GetDefaultRegionTokenKeys<TModel>()
@@ -138,7 +159,7 @@ namespace VirtoCommerce.Platform.Tests.GenericCrud
 
         private sealed class ProbeCacheRegion<TMarker> : CancellableCacheRegion<ProbeCacheRegion<TMarker>>;
 
-        // Owns both halves of the pairing: neither ConfigureCache nor ClearCache is overridden.
+        // Overrides nothing: mints and expires through GenericCachingRegion<TModel>.
         private class ProbeCrudService<TMarker> : CrudService<ProbeModel<TMarker>, ProbeEntity<TMarker>, ProbeChangingEvent<TMarker>, ProbeChangedEvent<TMarker>>
         {
             public ProbeCrudService()
@@ -177,9 +198,26 @@ namespace VirtoCommerce.Platform.Tests.GenericCrud
             }
         }
 
-        // Mirrors vc-module-inventory InventoryServiceImpl: replaces both halves of the pairing with its own
+        // Mirrors vc-module-order CustomerOrderService: overrides ClearCache without calling base, but expires
+        // the same region the default ConfigureCache mints into — it only adds a second key.
+        // The body is documentary — the gate reacts to the override EXISTING, and no test invokes ClearCache.
+        // Keep it anyway: emptying it would leave the probe no longer mirroring the shape it stands for.
+        private sealed class ClearCacheOnlyProbeCrudService<TMarker> : ProbeCrudService<TMarker>
+        {
+            protected override void ClearCache(IList<ProbeModel<TMarker>> models)
+            {
+                GenericSearchCachingRegion<ProbeModel<TMarker>>.ExpireRegion();
+
+                foreach (var model in models)
+                {
+                    GenericCachingRegion<ProbeModel<TMarker>>.ExpireTokenForKey(model.Id);
+                }
+            }
+        }
+
+        // Mirrors vc-module-inventory InventoryServiceImpl: redirects both the mint and the expire to its own
         // region and never calls base.
-        private class OverriddenPairingProbeCrudService<TMarker> : ProbeCrudService<TMarker>
+        private class OwnRegionProbeCrudService<TMarker> : ProbeCrudService<TMarker>
         {
             protected override void ConfigureCache(MemoryCacheEntryOptions cacheOptions, string id, ProbeModel<TMarker> model)
             {
@@ -192,7 +230,7 @@ namespace VirtoCommerce.Platform.Tests.GenericCrud
             }
         }
 
-        private sealed class OptedInProbeCrudService<TMarker> : OverriddenPairingProbeCrudService<TMarker>
+        private sealed class OptedInProbeCrudService<TMarker> : OwnRegionProbeCrudService<TMarker>
         {
             protected override bool CaptureCacheTokenBeforeLoad => true;
         }


### PR DESCRIPTION
## Problem

`MemoryCacheExtensions.GetOrLoadByIdsAsync` minted its invalidation change token **after** the load, inside the `configureCache` callback. That loses a write that lands while the load is in flight:

1. Reader misses the cache and calls `loadItems(missingIds)`.
2. A writer commits and invalidates the same key. `CancellableCacheRegion<T>.InnerExpireTokenForKey` cancels the key's token source **and removes it from the dictionary**.
3. The reader's load returns — carrying pre-write data.
4. Only now is the token minted. Because step 2 removed the old one, a **fresh, uncancelled** source is created.

The reader then caches the stale value against a live token. Nothing will evict it: the invalidation that should have killed it already happened and left no trace. The stale entry is served until the sliding TTL expires.

## Fix

Capture the token for every missing id **before** `await loadItems(...)`, and attach it in the create callback:

```csharp
var preCapturedTokens = createExpirationToken is null
    ? null
    : missingIds.ToDictionary(x => x, createExpirationToken, _ignoreCase);

var items = await loadItems(missingIds) ?? Array.Empty<TItem>();
```

A token captured before the load is the same source the writer will cancel, so an invalidation racing the load now evicts the entry it made stale.

`CrudService.GetAsync` passes its existing `CreateCacheToken`, so every consumer of the platform CRUD read path gets the fix without changing its own code.

## Known limitations — this reduces the symptom, it does not eliminate it

Stated explicitly so an acceptance criterion isn't written against the wrong claim:

- **Only the id-keyed primary token is pre-captured.** A `configureCache` override may key tokens off fields of the *loaded model* — `SupplierShippingMethodService` adds a token for `model.SupplierId`, for instance. That key is unknowable before the load, so those secondary tokens are still minted afterwards and remain open to the same race.
- **The reader that loses the race still returns the stale value once.** `GetOrCreateExclusive` hands back the factory's return value regardless of whether the entry survived; the cancelled token suppresses *caching*, not that one return. So a caller re-arming a concurrency check from that model can still fail. The expected outcome is a sharp drop in stale reads, not zero.
- **Under sustained writes to a hot key this trades "serve stale" for "cache nothing".** The miss path holds `AsyncLock.GetLockByKey(normalizedPrefix)`, keyed per service + response group rather than per id, so repeated invalidation of one id can funnel readers of the whole prefix through that lock and into the database. The only benchmark in the repo (`GetOrLoadByIdsBenchmarks`) measures the all-hit path, so this is unmeasured here.

## The pre-capture is gated on the mint seam

`CreateChangeTokenForKey` is not a pure read — `_keyTokensDict.GetOrAdd(...)` writes into a static dictionary whose entries are removed only by an explicit expire. Passing `CreateCacheToken` on behalf of every subclass therefore means a subclass that redirects the mint accumulates one `CancellationTokenSource` per distinct id read, in a region it never expires, and gets nothing in return — its real token is still minted late. `vc-module-inventory`'s `InventoryServiceImpl` is exactly that shape.

So `GetAsync` hands over the factory only while the service still mints through the default `ConfigureCache`, detected by reflection and surfaced as `protected virtual bool CaptureCacheTokenBeforeLoad` so an override that does call base can opt back in with one line. The opt-out sits where the factory is passed, not inside it: `GetOrLoadByIdsCoreAsync` never invokes a null factory, so no token source is created at all and the opted-out path executes exactly the pre-fix instruction sequence.

**The condition covers `ConfigureCache` only, and that is deliberate.** The first attempt also required `ClearCache` not to be overridden — "the service still owns both halves of the mint/expire pairing". Measured on a probe service mirroring the `CustomerOrderService` shape (overrides `ClearCache` without calling base, expires the same region), with the gate forced open versus closed:

| | gate open | gate closed |
|---|---|---|
| token sources after reading 3 ids | 3 | 3 — the same keys |
| writer invalidates mid-load | reloads, serves fresh | caches the stale value |

Identical cost, lost benefit. `GetOrLoadByIdsCoreAsync` runs `configureCache` for every missing id, so the default `ConfigureCache` mints that same key set anyway and `GetOrAdd` returns the source the pre-capture already created. Only an overridden `ConfigureCache` can move the mint elsewhere, and only then is new state created. Requiring `ClearCache` too would have dropped this fix for `CustomerOrderService`, `ShipmentService`, `PaymentService` and `PropertyGroupService` — all of which expire the very `GenericCachingRegion<TModel>` that the default `ConfigureCache` mints into, and the first of which is the service the defect was measured on.

**One shipped service opts out unnecessarily, and the remedy belongs in its own repo rather than here.** `vc-module-catalog`'s `PropertyDictionaryItemService.ConfigureCache` calls base, so its pairing is intact — but reflection cannot see a base call, so the gate closes on it. One line restores it: `protected override bool CaptureCacheTokenBeforeLoad => true;`. The other two `ConfigureCache` overrides in shipped modules, `ItemService` and `InventoryServiceImpl`, do not call base, so the gate is right for them.

## The probe is cached, and shared with the platform's other consumer

Every CRUD service in the shipped modules is registered `AddTransient`, so the constructor runs on every DI resolve, and probing by reflection there charges each resolve for an answer that is fixed at type load. Measured per resolve, both probes, .NET 10 Release, 1e6 iterations:

| | ns | bytes |
|---|---|---|
| uncached probe | 170 | 208 |
| cached on `(Type, MethodInfo)` | 98 | 0 |

The cache lives in a new `ReflectionUtility.IsMethodOverridden(this Type, MethodInfo)` rather than on `CrudService`, matching how this repo already caches type-keyed reflection — `ValueObject`, `ChangesDetector`, `PolymorphJsonConverter`, `TypeExtensions` and `ReflectionUtility` each keep such a cache on a **non-generic** class. A static on the generic `CrudService` is duplicated per closed generic: 54 subclasses at 1064 B per `ConcurrentDictionary` is roughly 57 KB, against 47 B for the two `MethodInfo` statics that remain there. Rejected alternatives, measured rather than argued: a `(Type, Type, string)` key costs 117 ns because the string is hashed by content on every lookup, and `params ReadOnlySpan<Type>` with the arity in the key costs 118 ns and cannot tell apart overloads of equal arity.

The helper takes the base `MethodInfo` rather than a method name, because a name is ambiguous between overloads — `ToModel` has two — and it answers by comparing `GetBaseDefinition()` slots instead of re-resolving by name and parameter types.

`ValueObject` carried the same probe privately and now uses the shared one. That corrects both call sites: a member hidden with `new` rather than overridden was previously reported as overridden, although a virtual call still reaches the base implementation, which is what both callers actually care about. No shipped type hides any of the four probed members.

## API shape: four explicit overloads, not an optional parameter

The obvious edit — add `Func<string, IChangeToken> createExpirationToken = null` to the existing methods — would be a **binary break**, even though it compiles and reads as source-compatible.

C# binds optional arguments at the **call site**: the compiler emits a call to the method's full parameter list and fills defaults in. An assembly compiled against the old signature therefore references an arity that no longer exists. Platform assemblies ship as NuGet and modules load as plugins, rebuilt on their own schedule — so this surfaces as a runtime `MissingMethodException` in modules whose build and tests are green.

`GetOrLoadByIdsAsync` has external callers in at least `vc-module-catalog` (`CategoryService`, `ItemService`, `CategoryTreeService`), `vc-module-cart` (`WishlistService`) and `vc-module-order` (`PurchasedProductsService`), so the exposure is real rather than theoretical. Every previously published signature is left byte-identical and the new capability arrives as separate overloads delegating to a private core.

Overload resolution is unambiguous despite two overloads sharing a caller-visible arity: they discriminate by delegate shape — `Action<MemoryCacheEntryOptions, string, TItem>` (three parameters) versus `Func<string, IChangeToken>` (one).

## Tests

`GetOrLoadByIdsStaleCacheTests` covers the interleaving directly: it invalidates the key while the load is in flight and asserts the next read does **not** observe the pre-write value, alongside a characterization test pinning the opt-in boundary for callers that pass no token factory.

`CrudServiceCacheTokenGateTests` pins the gate on four subclass shapes — mints through the default region, overrides `ClearCache` only (the `CustomerOrderService` shape, the regression guard: restoring the `ClearCache` conjunct makes it fail with one load instead of two), redirects the mint to its own region, and redirects it but opts back in.

Solution build 0 warnings / 0 errors. `VirtoCommerce.Platform.Caching.Tests` 65/65, `VirtoCommerce.Platform.Core.Tests` 154/154, `VirtoCommerce.Platform.Tests` 337 passed — its one failure, `FileManagerIntegrationTests.SafeDelete_CreateAndSafeDeleteDirectory`, is pre-existing and environmental: the test hardcodes a Windows path separator, so on Linux the nested directory is a single name containing a backslash.

## Why still draft

The numbers that motivated the fix are being re-measured: the stand's baseline shifted when this branch merged current `dev`, so the earlier before/after arms are not comparable and a fresh baseline is required before any latency or failure-rate claim.

Also unaddressed by choice, listed so it reads as a scope decision rather than an oversight: `SettingsManager` is the platform's other in-repo caller of this primitive and has the identical late-mint shape, so a setting saved while a settings read is in flight caches the stale value for up to the sliding window. Not made worse here, not fixed here.

Related: VCST-5627 — the defect this PR fixes, filed on its own issue because VCST-5303 is a
benchmark-harness story (Done); this is a correctness bug in a platform cache primitive that the
harness surfaced.

Image tag:
ghcr.io/VirtoCommerce/platform:3.1053.0-pr-3091-5d76-vcst-5303-cache-token-before-load-5d76469d
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5303

