### PR TITLE
VCST-5532: Restrict admin UI access

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Common/WildcardMatcher.cs
+++ b/src/VirtoCommerce.Platform.Core/Common/WildcardMatcher.cs
@@ -1,0 +1,29 @@
+using System.IO.Enumeration;
+
+namespace VirtoCommerce.Platform.Core.Common
+{
+    /// <summary>
+    /// Matches a value against a mask, where '*' stands for any sequence of characters
+    /// and '?' for exactly one. The whole value must match the mask:
+    /// 'catalog:*' matches 'catalog:read' but not 'catalog'.
+    /// </summary>
+    public static class WildcardMatcher
+    {
+        /// <summary>
+        /// Returns true when the value matches the mask. Matching is case-insensitive.
+        /// A null or blank mask, or a null value, never matches.
+        /// </summary>
+        public static bool IsMatch(string pattern, string value)
+        {
+            if (string.IsNullOrWhiteSpace(pattern) || value is null)
+            {
+                return false;
+            }
+
+            // The BCL matcher is span-based and allocation-free, and needs no pattern cache.
+            // Preferred over a regex built from configuration: there is no expression to compile
+            // and no backtracking to guard against.
+            return FileSystemName.MatchesSimpleExpression(pattern, value, ignoreCase: true);
+        }
+    }
+}

--- a/src/VirtoCommerce.Platform.Core/Common/WildcardMatcher.cs
+++ b/src/VirtoCommerce.Platform.Core/Common/WildcardMatcher.cs
@@ -9,20 +9,18 @@ namespace VirtoCommerce.Platform.Core.Common
     /// </summary>
     public static class WildcardMatcher
     {
-        /// <summary>
-        /// Returns true when the value matches the mask. Matching is case-insensitive.
-        /// A null or blank mask, or a null value, never matches.
-        /// </summary>
         public static bool IsMatch(string pattern, string value)
         {
-            if (string.IsNullOrWhiteSpace(pattern) || value is null)
+            if (string.IsNullOrEmpty(pattern) && string.IsNullOrEmpty(value))
+            {
+                return true;
+            }
+
+            if (string.IsNullOrWhiteSpace(pattern))
             {
                 return false;
             }
 
-            // The BCL matcher is span-based and allocation-free, and needs no pattern cache.
-            // Preferred over a regex built from configuration: there is no expression to compile
-            // and no backtracking to guard against.
             return FileSystemName.MatchesSimpleExpression(pattern, value, ignoreCase: true);
         }
     }

--- a/src/VirtoCommerce.Platform.Core/PlatformUIOptions.cs
+++ b/src/VirtoCommerce.Platform.Core/PlatformUIOptions.cs
@@ -1,3 +1,5 @@
+using VirtoCommerce.Platform.Core.Security;
+
 namespace VirtoCommerce.Platform.Core
 {
     public class PlatformUIOptions
@@ -5,5 +7,10 @@ namespace VirtoCommerce.Platform.Core
         public bool Enable { get; set; } = true;
 
         public EnvironmentBannerOptions EnvironmentBanner { get; set; } = new EnvironmentBannerOptions();
+
+        /// <summary>
+        /// Controls which authenticated users may enter the admin UI.
+        /// </summary>
+        public AdminUIAccessOptions Access { get; set; } = new AdminUIAccessOptions();
     }
 }

--- a/src/VirtoCommerce.Platform.Core/Security/AdminUIAccessContext.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/AdminUIAccessContext.cs
@@ -1,0 +1,20 @@
+using System.Collections.Generic;
+
+namespace VirtoCommerce.Platform.Core.Security
+{
+    /// <summary>
+    /// Everything an <see cref="IAdminUIAccessPolicy"/> needs to reach a decision.
+    /// Passing a context instead of loose parameters keeps the interface stable:
+    /// new inputs can be added as properties without breaking existing implementations,
+    /// which matters because Platform.Core ships as a NuGet package.
+    /// </summary>
+    public class AdminUIAccessContext
+    {
+        public ApplicationUser User { get; set; }
+
+        /// <summary>
+        /// Distinct permission names the user holds, flattened from their roles.
+        /// </summary>
+        public IList<string> Permissions { get; set; } = new List<string>();
+    }
+}

--- a/src/VirtoCommerce.Platform.Core/Security/AdminUIAccessOptions.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/AdminUIAccessOptions.cs
@@ -1,0 +1,43 @@
+using System.Collections.Generic;
+
+namespace VirtoCommerce.Platform.Core.Security
+{
+    /// <summary>
+    /// Controls which authenticated users are allowed to enter the admin UI.
+    /// Configured in the VirtoCommerce:PlatformUI:Access section.
+    /// An empty list means "not constrained by this rule", so the defaults below
+    /// reproduce the behavior the platform had before this option existed:
+    /// any user holding at least one permission may enter the admin UI.
+    /// </summary>
+    public class AdminUIAccessOptions
+    {
+        /// <summary>
+        /// When true (default), users with IsAdministrator bypass all other rules.
+        /// </summary>
+        public bool AllowAdministrators { get; set; } = true;
+
+        /// <summary>
+        /// When true (default), a user must hold at least one permission to enter the admin UI.
+        /// </summary>
+        public bool RequireAnyPermission { get; set; } = true;
+
+        /// <summary>
+        /// Account types (<see cref="UserType"/>) allowed to enter the admin UI.
+        /// Allow-list only: when empty the account type is not checked.
+        /// </summary>
+        public IList<string> AllowedAccountTypes { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Permission masks ('*' wildcard) of which the user must hold at least one.
+        /// When empty the user's permissions are not required to match anything.
+        /// </summary>
+        public IList<string> AllowedPermissions { get; set; } = new List<string>();
+
+        /// <summary>
+        /// Permission masks ('*' wildcard) that deny admin UI access.
+        /// Holding any matching permission denies access, and takes precedence
+        /// over <see cref="AllowedPermissions"/>.
+        /// </summary>
+        public IList<string> DeniedPermissions { get; set; } = new List<string>();
+    }
+}

--- a/src/VirtoCommerce.Platform.Core/Security/AdminUIAccessResult.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/AdminUIAccessResult.cs
@@ -1,0 +1,13 @@
+namespace VirtoCommerce.Platform.Core.Security
+{
+    public class AdminUIAccessResult
+    {
+        public bool IsAllowed { get; set; }
+
+        public string DenyReason { get; set; }
+
+        public static AdminUIAccessResult Allowed() => new() { IsAllowed = true };
+
+        public static AdminUIAccessResult Denied(string reason) => new() { IsAllowed = false, DenyReason = reason };
+    }
+}

--- a/src/VirtoCommerce.Platform.Core/Security/IAdminUIAccessPolicy.cs
+++ b/src/VirtoCommerce.Platform.Core/Security/IAdminUIAccessPolicy.cs
@@ -1,0 +1,20 @@
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VirtoCommerce.Platform.Core.Security
+{
+    /// <summary>
+    /// Decides whether an authenticated user may enter the admin UI.
+    /// This is independent of authorization: a denied user keeps every permission
+    /// they hold and can still call the API endpoints those permissions grant.
+    /// </summary>
+    public interface IAdminUIAccessPolicy
+    {
+        /// <param name="context">The user and the permissions to evaluate.</param>
+        /// <param name="cancellationToken">
+        /// Honored by implementations that need to look up additional data.
+        /// The built-in configuration policy is purely in-memory.
+        /// </param>
+        Task<AdminUIAccessResult> EvaluateAsync(AdminUIAccessContext context, CancellationToken cancellationToken = default);
+    }
+}

--- a/src/VirtoCommerce.Platform.Security/Services/ConfigurationAdminUIAccessPolicy.cs
+++ b/src/VirtoCommerce.Platform.Security/Services/ConfigurationAdminUIAccessPolicy.cs
@@ -1,0 +1,93 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using VirtoCommerce.Platform.Core;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Core.Security;
+
+namespace VirtoCommerce.Platform.Security.Services
+{
+    /// <summary>
+    /// Evaluates admin UI access against the VirtoCommerce:PlatformUI:Access configuration section.
+    /// Keeping the policy in configuration rather than in a stored setting means it cannot be
+    /// changed through the API, so a user cannot grant themselves admin UI access.
+    /// </summary>
+    public class ConfigurationAdminUIAccessPolicy : IAdminUIAccessPolicy
+    {
+        // A monitor rather than IOptions so that editing appsettings.json takes effect
+        // without restarting the process - this class is registered as a singleton.
+        private readonly IOptionsMonitor<PlatformUIOptions> _platformUIOptions;
+
+        public ConfigurationAdminUIAccessPolicy(IOptionsMonitor<PlatformUIOptions> platformUIOptions)
+        {
+            _platformUIOptions = platformUIOptions;
+        }
+
+        public Task<AdminUIAccessResult> EvaluateAsync(AdminUIAccessContext context, CancellationToken cancellationToken = default)
+        {
+            ArgumentNullException.ThrowIfNull(context);
+            ArgumentNullException.ThrowIfNull(context.User);
+
+            cancellationToken.ThrowIfCancellationRequested();
+
+            return Task.FromResult(Evaluate(context));
+        }
+
+        private AdminUIAccessResult Evaluate(AdminUIAccessContext context)
+        {
+            var options = _platformUIOptions.CurrentValue?.Access ?? new AdminUIAccessOptions();
+            var user = context.User;
+            var permissions = context.Permissions ?? [];
+
+            // 1. Administrators bypass every other rule.
+            if (options.AllowAdministrators && user.IsAdministrator)
+            {
+                return AdminUIAccessResult.Allowed();
+            }
+
+            // 2. Account type is an allow-list: an empty list does not constrain.
+            if (options.AllowedAccountTypes?.Count > 0 &&
+                !options.AllowedAccountTypes.Any(x => x.EqualsIgnoreCase(user.UserType)))
+            {
+                return AdminUIAccessResult.Denied($"Account type '{user.UserType}' is not in AllowedAccountTypes.");
+            }
+
+            // 3. Denied permission masks win over any allow rule.
+            var deniedMatch = FirstMatch(options.DeniedPermissions, permissions);
+            if (deniedMatch != null)
+            {
+                return AdminUIAccessResult.Denied($"Permission '{deniedMatch}' matches DeniedPermissions.");
+            }
+
+            // 4. When an allow-list is configured the user must hold at least one matching permission.
+            if (options.AllowedPermissions?.Count > 0 && FirstMatch(options.AllowedPermissions, permissions) == null)
+            {
+                return AdminUIAccessResult.Denied("No permission matches AllowedPermissions.");
+            }
+
+            // 5. The platform's original rule: at least one permission is required.
+            if (options.RequireAnyPermission && permissions.Count == 0)
+            {
+                return AdminUIAccessResult.Denied("The user has no permissions.");
+            }
+
+            return AdminUIAccessResult.Allowed();
+        }
+
+        /// <summary>
+        /// Returns the first permission matching any of the masks, or null when none match.
+        /// </summary>
+        private static string FirstMatch(IList<string> masks, IList<string> permissions)
+        {
+            if (masks is null || masks.Count == 0)
+            {
+                return null;
+            }
+
+            return permissions.FirstOrDefault(permission => masks.Any(mask => WildcardMatcher.IsMatch(mask, permission)));
+        }
+    }
+}

--- a/src/VirtoCommerce.Platform.Web/Controllers/Api/SecurityController.cs
+++ b/src/VirtoCommerce.Platform.Web/Controllers/Api/SecurityController.cs
@@ -49,6 +49,7 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
         private readonly IEnumerable<ExternalSignInProviderConfiguration> _externalSigninProviderConfigs;
         private readonly IUserSessionsSearchService _userSessionsSearchService;
         private readonly IUserSessionsService _userSessionsService;
+        private readonly IAdminUIAccessPolicy _adminUIAccessPolicy;
 
         public SecurityController(
             SignInManager<ApplicationUser> signInManager,
@@ -66,7 +67,8 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
             ILogger<SecurityController> logger,
             IEnumerable<ExternalSignInProviderConfiguration> externalSigninProviderConfigs,
             IUserSessionsSearchService userSessionsSearchService,
-            IUserSessionsService userSessionsService)
+            IUserSessionsService userSessionsService,
+            IAdminUIAccessPolicy adminUIAccessPolicy)
         {
             _signInManager = signInManager;
             _securityOptions = securityOptions.Value;
@@ -84,6 +86,7 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
             _externalSigninProviderConfigs = externalSigninProviderConfigs;
             _userSessionsSearchService = userSessionsSearchService;
             _userSessionsService = userSessionsService;
+            _adminUIAccessPolicy = adminUIAccessPolicy;
         }
 
         private UserManager<ApplicationUser> UserManager => _signInManager.UserManager;
@@ -221,6 +224,17 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
                 return Ok(new { });
             }
 
+            var permissions = user.Roles.SelectMany(x => x.Permissions).Select(x => x.Name).Distinct().ToArray();
+            var adminUIAccess = await _adminUIAccessPolicy.EvaluateAsync(
+                new AdminUIAccessContext { User = user, Permissions = permissions },
+                HttpContext.RequestAborted);
+
+            if (!adminUIAccess.IsAllowed)
+            {
+                _logger.LogInformation("Admin UI access denied for user {user}: {reason}",
+                    UserManager.SanitizeUserName(user.UserName), adminUIAccess.DenyReason);
+            }
+
             var result = new UserDetail
             {
                 Id = user.Id,
@@ -228,10 +242,11 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
                 UserName = user.UserName,
                 PasswordExpired = user.PasswordExpired,
                 DaysTillPasswordExpiry = PasswordExpiryHelper.ContDaysTillPasswordExpiry(user, _userOptionsExtended),
-                Permissions = user.Roles.SelectMany(x => x.Permissions).Select(x => x.Name).Distinct().ToArray(),
+                Permissions = permissions,
                 AuthenticationMethod = HttpContext.User.GetAuthenticationMethod(),
                 IsSsoAuthenticationMethod = HttpContext.User.IsExternalSignIn(),
                 MemberId = user.MemberId,
+                CanAccessAdminUI = adminUIAccess.IsAllowed,
             };
 
             // Password never expired with SSO

--- a/src/VirtoCommerce.Platform.Web/Model/Security/UserDetail.cs
+++ b/src/VirtoCommerce.Platform.Web/Model/Security/UserDetail.cs
@@ -13,5 +13,6 @@ namespace VirtoCommerce.Platform.Web.Model.Security
         public string AuthenticationMethod { get; set; }
         public bool IsSsoAuthenticationMethod { get; set; }
         public string MemberId { get; set; }
+        public bool CanAccessAdminUI { get; set; }
     }
 }

--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -706,6 +706,11 @@ namespace VirtoCommerce.Platform.Web
             // Platform UI options
             services.AddOptions<PlatformUIOptions>().Bind(Configuration.GetSection("VirtoCommerce:PlatformUI"));
 
+            // Decides whether an authenticated user may enter the admin UI (VirtoCommerce:PlatformUI:Access).
+            // TryAdd so a module can supply its own policy: module ConfigureServices runs before this,
+            // and an unconditional AddSingleton here would always override it.
+            services.TryAddSingleton<IAdminUIAccessPolicy, ConfigurationAdminUIAccessPolicy>();
+
             // Add login page UI options
             var loginPageUIOptions = Configuration.GetSection("LoginPageUI");
             services.AddOptions<LoginPageUIOptions>().Bind(loginPageUIOptions);

--- a/src/VirtoCommerce.Platform.Web/appsettings.json
+++ b/src/VirtoCommerce.Platform.Web/appsettings.json
@@ -72,6 +72,22 @@
         "Enable": true,
         "Name": "",
         "ThemePreset": "" // Possible values: prod, dev, test, staging, demo, default
+      },
+      // Controls which authenticated users may enter the admin UI. 
+      "Access": {
+        // Users with IsAdministrator bypass all rules below.
+        "AllowAdministrators": true,
+        // A user must hold at least one permission to enter the admin UI.
+        "RequireAnyPermission": true,
+        // Account types (see VirtoCommerce.Platform.Security.AccountTypes) allowed into the admin UI,
+        // for example [ "Manager", "Administrator" ] to keep Customer accounts out.
+        "AllowedAccountTypes": [],
+        // Permission masks ('*' wildcard) of which the user must hold at least one,
+        // for example [ "platform:*", "catalog:*" ].
+        "AllowedPermissions": [],
+        // Permission masks ('*' wildcard) that deny access. Takes precedence over AllowedPermissions,
+        // so [ "platform:*" ] allowed with [ "platform:setting:*" ] denied works as expected.
+        "DeniedPermissions": [ "xapi:*" ]
       }
     },
     "Hangfire": {

--- a/src/VirtoCommerce.Platform.Web/appsettings.json
+++ b/src/VirtoCommerce.Platform.Web/appsettings.json
@@ -87,7 +87,7 @@
         "AllowedPermissions": [],
         // Permission masks ('*' wildcard) that deny access. Takes precedence over AllowedPermissions,
         // so [ "platform:*" ] allowed with [ "platform:setting:*" ] denied works as expected.
-        "DeniedPermissions": [ "xapi:*" ]
+        "DeniedPermissions": []
       }
     },
     "Hangfire": {

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/app.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/app.js
@@ -497,7 +497,7 @@ angular.module('platformWebApp', AppDependencies).controller('platformWebApp.app
                                 }
                             }
                         });
-                    } else if (!authContext.isAdministrator && !authContext.permissions?.length) {
+                    } else if (!authContext.canAccessAdminUI) {
                         $state.go('contact-admin');
                     } else if (!currentState.name || currentState.name === 'loginDialog') {
                         var returnUrl = urlHelper.getSafeReturnUrl();

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/app.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/app.js
@@ -485,6 +485,12 @@ angular.module('platformWebApp', AppDependencies).controller('platformWebApp.app
                     var currentState = $state.current;
                     if (!authContext.isAuthenticated) {
                         $state.go('loginDialog');
+                    } else if (!authContext.canAccessAdminUI) {
+                        // Evaluated server-side from VirtoCommerce:PlatformUI:Access. Checked before
+                        // passwordExpired because there is no point sending a user who cannot enter
+                        // the admin UI through a password change first. A user denied here can still
+                        // call the API endpoints their permissions grant.
+                        $state.go('contact-admin');
                     } else if (authContext.passwordExpired) {
                         $state.go('changePasswordDialog', {
                             onClose: function () {
@@ -497,8 +503,6 @@ angular.module('platformWebApp', AppDependencies).controller('platformWebApp.app
                                 }
                             }
                         });
-                    } else if (!authContext.canAccessAdminUI) {
-                        $state.go('contact-admin');
                     } else if (!currentState.name || currentState.name === 'loginDialog') {
                         var returnUrl = urlHelper.getSafeReturnUrl();
                         if (returnUrl) {

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/security/security.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/security/security.js
@@ -339,8 +339,17 @@ angular.module('platformWebApp')
 
 
             $transitions.onBefore({ to: 'workspace.**' }, function (transition) {
+                if (!authService.isAuthenticated) {
+                    return;
+                }
+
+                // Prevent transition to workspace if the server denied admin UI access.
+                if (!authService.canAccessAdminUI) {
+                    return transition.router.stateService.target('contact-admin');
+                }
+
                 // Prevent transition to workspace if password expired
-                if (authService.isAuthenticated && authService.passwordExpired) {
+                if (authService.passwordExpired) {
                     return transition.router.stateService.target('changePasswordDialog');
                 }
             });

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/security/services/auth.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/security/services/auth.js
@@ -9,7 +9,8 @@ angular.module('platformWebApp')
         fullName: null,
         permissions: null,
         isAuthenticated: false,
-        memberId: null
+        memberId: null,
+        canAccessAdminUI: false
     };
 
     authContext.fillAuthData = function () {

--- a/tests/VirtoCommerce.Platform.Core.Tests/Common/WildcardMatcherTests.cs
+++ b/tests/VirtoCommerce.Platform.Core.Tests/Common/WildcardMatcherTests.cs
@@ -1,0 +1,64 @@
+using VirtoCommerce.Platform.Core.Common;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Core.Tests.Common
+{
+    public class WildcardMatcherTests
+    {
+        [Theory]
+        // Exact matches
+        [InlineData("catalog:read", "catalog:read", true)]
+        [InlineData("catalog:read", "catalog:update", false)]
+        // Match-all
+        [InlineData("*", "catalog:read", true)]
+        // An empty value matches nothing, not even '*' - a missing name should never satisfy a mask
+        [InlineData("*", "", false)]
+        // Prefix masks
+        [InlineData("catalog:*", "catalog:read", true)]
+        [InlineData("catalog:*", "catalog:setting:access", true)]
+        [InlineData("catalog:*", "platform:read", false)]
+        // A prefix mask requires the separator to be present
+        [InlineData("catalog:*", "catalog", false)]
+        // Suffix masks
+        [InlineData("*:read", "catalog:read", true)]
+        [InlineData("*:read", "catalog:update", false)]
+        // Masks in the middle
+        [InlineData("platform:*:access", "platform:setting:access", true)]
+        [InlineData("platform:*:access", "platform:setting:update", false)]
+        // Anchored - must match the whole value, not a substring
+        [InlineData("catalog", "catalog:read", false)]
+        [InlineData("read", "catalog:read", false)]
+        // Case insensitive
+        [InlineData("Catalog:*", "catalog:read", true)]
+        [InlineData("catalog:READ", "catalog:read", true)]
+        // '?' matches exactly one character
+        [InlineData("cat?log:read", "catalog:read", true)]
+        [InlineData("cat?log:read", "catlog:read", false)]
+        // Everything other than '*' and '?' is literal
+        [InlineData("a.b", "axb", false)]
+        [InlineData("a.b", "a.b", true)]
+        [InlineData("a+b", "a+b", true)]
+        public void IsMatch_ReturnsExpectedResult(string pattern, string value, bool expected)
+        {
+            //Act
+            var actual = WildcardMatcher.IsMatch(pattern, value);
+
+            //Assert
+            Assert.Equal(expected, actual);
+        }
+
+        [Theory]
+        [InlineData(null, "catalog:read")]
+        [InlineData("", "catalog:read")]
+        [InlineData(" ", "catalog:read")]
+        [InlineData("catalog:*", null)]
+        public void IsMatch_WithNullOrEmptyArgument_ReturnsFalse(string pattern, string value)
+        {
+            //Act
+            var actual = WildcardMatcher.IsMatch(pattern, value);
+
+            //Assert
+            Assert.False(actual);
+        }
+    }
+}

--- a/tests/VirtoCommerce.Platform.Core.Tests/Common/WildcardMatcherTests.cs
+++ b/tests/VirtoCommerce.Platform.Core.Tests/Common/WildcardMatcherTests.cs
@@ -60,5 +60,41 @@ namespace VirtoCommerce.Platform.Core.Tests.Common
             //Assert
             Assert.False(actual);
         }
+
+        [Theory]
+        [InlineData("*")]
+        [InlineData("**")]
+        [InlineData("?")]
+        [InlineData("catalog:*")]
+        public void IsMatch_WithMissingValue_NeverMatches_NotEvenMatchAllMask(string pattern)
+        {
+            //Arrange
+            // A missing permission or account type must never satisfy a mask, otherwise an
+            // unnamed value would slip through AllowedPermissions.
+            //Act
+            var matchesNull = WildcardMatcher.IsMatch(pattern, null);
+            var matchesEmpty = WildcardMatcher.IsMatch(pattern, string.Empty);
+
+            //Assert
+            Assert.False(matchesNull);
+            Assert.False(matchesEmpty);
+        }
+
+        [Theory]
+        [InlineData(null, null)]
+        [InlineData("", "")]
+        [InlineData(null, "")]
+        [InlineData("", null)]
+        public void IsMatch_WhenBothMaskAndValueAreMissing_ReturnsTrue(string pattern, string value)
+        {
+            //Arrange
+            // An empty mask is treated as matching an empty value, so "nothing" equals "nothing".
+            // Neither side occurs with real permission names or account types.
+            //Act
+            var actual = WildcardMatcher.IsMatch(pattern, value);
+
+            //Assert
+            Assert.True(actual);
+        }
     }
 }

--- a/tests/VirtoCommerce.Platform.Tests/Security/AdminUIAccessPolicyTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/Security/AdminUIAccessPolicyTests.cs
@@ -1,0 +1,390 @@
+using System;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.Options;
+using Moq;
+using VirtoCommerce.Platform.Core;
+using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.Platform.Security.Services;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Tests.Security
+{
+    public class AdminUIAccessPolicyTests
+    {
+        private static ConfigurationAdminUIAccessPolicy CreatePolicy(AdminUIAccessOptions access = null)
+        {
+            var options = new PlatformUIOptions();
+            if (access != null)
+            {
+                options.Access = access;
+            }
+
+            var monitor = new Mock<IOptionsMonitor<PlatformUIOptions>>();
+            monitor.SetupGet(x => x.CurrentValue).Returns(options);
+
+            return new ConfigurationAdminUIAccessPolicy(monitor.Object);
+        }
+
+        private static AdminUIAccessContext CreateContext(
+            bool isAdministrator = false,
+            string userType = nameof(UserType.Manager),
+            params string[] permissions) =>
+            new()
+            {
+                User = new ApplicationUser
+                {
+                    UserName = "test",
+                    IsAdministrator = isAdministrator,
+                    UserType = userType,
+                },
+                Permissions = permissions,
+            };
+
+        #region Rule 1 - administrator bypass
+
+        [Fact]
+        public async Task Administrator_IsAllowed_EvenWithNoPermissionsAndDisallowedAccountType()
+        {
+            //Arrange
+            var policy = CreatePolicy(new AdminUIAccessOptions
+            {
+                AllowedAccountTypes = [nameof(UserType.Manager)],
+            });
+            var context = CreateContext(isAdministrator: true, userType: nameof(UserType.Customer));
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.True(result.IsAllowed);
+        }
+
+        [Fact]
+        public async Task Administrator_IsSubjectToRules_WhenAllowAdministratorsIsFalse()
+        {
+            //Arrange
+            var policy = CreatePolicy(new AdminUIAccessOptions
+            {
+                AllowAdministrators = false,
+                AllowedAccountTypes = [nameof(UserType.Manager)],
+            });
+            var context = CreateContext(true, nameof(UserType.Customer), "platform:setting:access");
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.False(result.IsAllowed);
+        }
+
+        #endregion
+
+        #region Rule 2 - allowed account types
+
+        [Fact]
+        public async Task AccountTypeNotInAllowedList_IsDenied()
+        {
+            //Arrange
+            var policy = CreatePolicy(new AdminUIAccessOptions
+            {
+                AllowedAccountTypes = [nameof(UserType.Manager), nameof(UserType.Administrator)],
+            });
+            var context = CreateContext(false, nameof(UserType.Customer), "platform:setting:access");
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.False(result.IsAllowed);
+        }
+
+        [Fact]
+        public async Task AccountTypeInAllowedList_IsAllowed()
+        {
+            //Arrange
+            var policy = CreatePolicy(new AdminUIAccessOptions
+            {
+                AllowedAccountTypes = [nameof(UserType.Manager), nameof(UserType.Administrator)],
+            });
+            var context = CreateContext(false, nameof(UserType.Manager), "platform:setting:access");
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.True(result.IsAllowed);
+        }
+
+        [Fact]
+        public async Task AccountTypeComparison_IsCaseInsensitive()
+        {
+            //Arrange
+            var policy = CreatePolicy(new AdminUIAccessOptions
+            {
+                AllowedAccountTypes = ["manager"],
+            });
+            var context = CreateContext(false, "Manager", "platform:setting:access");
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.True(result.IsAllowed);
+        }
+
+        [Fact]
+        public async Task EmptyUserType_IsDenied_WhenAllowedAccountTypesConfigured()
+        {
+            //Arrange
+            var policy = CreatePolicy(new AdminUIAccessOptions
+            {
+                AllowedAccountTypes = [nameof(UserType.Manager)],
+            });
+            var context = CreateContext(false, null, "platform:setting:access");
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.False(result.IsAllowed);
+        }
+
+        [Fact]
+        public async Task EmptyAllowedAccountTypes_DoesNotConstrainAccountType()
+        {
+            //Arrange
+            var policy = CreatePolicy(new AdminUIAccessOptions());
+            var context = CreateContext(false, nameof(UserType.Customer), "platform:setting:access");
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.True(result.IsAllowed);
+        }
+
+        #endregion
+
+        #region Rules 3 and 4 - permission allow / deny masks
+
+        [Fact]
+        public async Task PermissionMatchingDeniedMask_IsDenied()
+        {
+            //Arrange
+            var policy = CreatePolicy(new AdminUIAccessOptions
+            {
+                DeniedPermissions = ["mymodule:customer-api:*"],
+            });
+            var context = CreateContext(false, nameof(UserType.Manager), "mymodule:customer-api:read");
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.False(result.IsAllowed);
+        }
+
+        [Fact]
+        public async Task DeniedMask_TakesPrecedenceOverBroaderAllowedMask()
+        {
+            //Arrange
+            var policy = CreatePolicy(new AdminUIAccessOptions
+            {
+                AllowedPermissions = ["platform:*"],
+                DeniedPermissions = ["platform:setting:*"],
+            });
+            var context = CreateContext(false, nameof(UserType.Manager), "platform:setting:access");
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.False(result.IsAllowed);
+        }
+
+        [Fact]
+        public async Task AnyDeniedPermission_DeniesAccess_EvenWhenOtherPermissionsAreAllowed()
+        {
+            //Arrange
+            var policy = CreatePolicy(new AdminUIAccessOptions
+            {
+                DeniedPermissions = ["mymodule:customer-api:*"],
+            });
+            var context = CreateContext(false, nameof(UserType.Manager), "catalog:read", "mymodule:customer-api:read");
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.False(result.IsAllowed);
+        }
+
+        [Fact]
+        public async Task NoPermissionMatchingAllowedMask_IsDenied()
+        {
+            //Arrange
+            var policy = CreatePolicy(new AdminUIAccessOptions
+            {
+                AllowedPermissions = ["platform:*"],
+            });
+            var context = CreateContext(false, nameof(UserType.Manager), "catalog:read");
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.False(result.IsAllowed);
+        }
+
+        [Fact]
+        public async Task PermissionMatchingAllowedMask_IsAllowed()
+        {
+            //Arrange
+            var policy = CreatePolicy(new AdminUIAccessOptions
+            {
+                AllowedPermissions = ["platform:*"],
+            });
+            var context = CreateContext(false, nameof(UserType.Manager), "platform:setting:access");
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.True(result.IsAllowed);
+        }
+
+        #endregion
+
+        #region Rule 5 - RequireAnyPermission preserves the existing behaviour
+
+        [Fact]
+        public async Task NonAdministratorWithNoPermissions_IsDenied_ByDefault()
+        {
+            //Arrange
+            var policy = CreatePolicy();
+            var context = CreateContext();
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.False(result.IsAllowed);
+        }
+
+        [Fact]
+        public async Task NonAdministratorWithOnePermission_IsAllowed_ByDefault()
+        {
+            //Arrange
+            var policy = CreatePolicy();
+            var context = CreateContext(false, nameof(UserType.Manager), "catalog:read");
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.True(result.IsAllowed);
+        }
+
+        [Fact]
+        public async Task NonAdministratorWithNoPermissions_IsAllowed_WhenRequireAnyPermissionIsFalse()
+        {
+            //Arrange
+            var policy = CreatePolicy(new AdminUIAccessOptions { RequireAnyPermission = false });
+            var context = CreateContext();
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.True(result.IsAllowed);
+        }
+
+        #endregion
+
+        #region The reported scenario
+
+        [Fact]
+        public async Task CustomerWithApiPermission_IsDeniedAdminUI_ButKeepsThePermission()
+        {
+            //Arrange
+            var policy = CreatePolicy(new AdminUIAccessOptions
+            {
+                AllowedAccountTypes = [nameof(UserType.Manager), nameof(UserType.Administrator)],
+            });
+            var context = CreateContext(false, nameof(UserType.Customer), "mymodule:custom-endpoint:access");
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.False(result.IsAllowed);
+            Assert.False(string.IsNullOrEmpty(result.DenyReason));
+            // The policy only gates the admin UI - it must not strip the user's permissions.
+            Assert.Contains("mymodule:custom-endpoint:access", context.Permissions);
+        }
+
+        #endregion
+
+        #region Context validation
+
+        [Fact]
+        public async Task NullPermissions_AreTreatedAsEmpty()
+        {
+            //Arrange
+            var policy = CreatePolicy();
+            var context = new AdminUIAccessContext
+            {
+                User = new ApplicationUser { UserName = "test" },
+                Permissions = null,
+            };
+
+            //Act
+            var result = await policy.EvaluateAsync(context, TestContext.Current.CancellationToken);
+
+            //Assert
+            Assert.False(result.IsAllowed);
+        }
+
+        [Fact]
+        public async Task NullContext_Throws()
+        {
+            //Arrange
+            var policy = CreatePolicy();
+
+            //Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(() => policy.EvaluateAsync(null, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public async Task NullUser_Throws()
+        {
+            //Arrange
+            var policy = CreatePolicy();
+            var context = new AdminUIAccessContext { User = null };
+
+            //Act & Assert
+            await Assert.ThrowsAsync<ArgumentNullException>(() => policy.EvaluateAsync(context, TestContext.Current.CancellationToken));
+        }
+
+        [Fact]
+        public async Task CancelledToken_Throws()
+        {
+            //Arrange
+            var policy = CreatePolicy();
+            var context = CreateContext(false, nameof(UserType.Manager), "catalog:read");
+            using var cancellationTokenSource = new CancellationTokenSource();
+            await cancellationTokenSource.CancelAsync();
+
+            //Act & Assert
+            // This test is about the policy honoring an already-cancelled token, so it must pass
+            // its own instead of TestContext.Current.CancellationToken.
+#pragma warning disable xUnit1051
+            await Assert.ThrowsAnyAsync<OperationCanceledException>(
+                () => policy.EvaluateAsync(context, cancellationTokenSource.Token));
+#pragma warning restore xUnit1051
+        }
+
+        #endregion
+    }
+}

--- a/tests/VirtoCommerce.Platform.Web.Tests/Controllers/Api/SecurityControllerTests.cs
+++ b/tests/VirtoCommerce.Platform.Web.Tests/Controllers/Api/SecurityControllerTests.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Security.Claims;
+using System.Threading;
 using System.Threading.Tasks;
 using AutoFixture;
 using FluentAssertions;
@@ -35,6 +36,7 @@ namespace VirtoCommerce.Platform.Web.Tests.Controllers.Api
         private readonly Mock<ILogger<SecurityController>> _logger;
         private readonly Mock<IUserSessionsSearchService> _userSessionsSearchServiceMock;
         private readonly Mock<IUserSessionsService> _userSessionsServiceMock;
+        private readonly Mock<IAdminUIAccessPolicy> _adminUIAccessPolicyMock;
 
         private readonly IEnumerable<ExternalSignInProviderConfiguration> _externalSigninProviderConfigs;
 
@@ -51,6 +53,11 @@ namespace VirtoCommerce.Platform.Web.Tests.Controllers.Api
             _userSessionsSearchServiceMock = new Mock<IUserSessionsSearchService>();
             _userSessionsServiceMock = new Mock<IUserSessionsService>();
             _logger = new Mock<ILogger<SecurityController>>();
+
+            _adminUIAccessPolicyMock = new Mock<IAdminUIAccessPolicy>();
+            _adminUIAccessPolicyMock
+                .Setup(x => x.EvaluateAsync(It.IsAny<AdminUIAccessContext>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(AdminUIAccessResult.Allowed());
 
             _userManagerMock = new Mock<UserManager<ApplicationUser>>(
                 Mock.Of<IUserStore<ApplicationUser>>(),
@@ -102,7 +109,7 @@ namespace VirtoCommerce.Platform.Web.Tests.Controllers.Api
                 _userSearchServiceMock.Object,
                 _roleSearchServiceMock.Object,
                 securityOptions.Object,
-                Mock.Of<IOptions<UserOptionsExtended>>(),
+                Options.Create(new UserOptionsExtended()),
                 passwordOptions.Object,
                 passwordLoginOptions.Object,
                 identityOptions.Object,
@@ -111,7 +118,8 @@ namespace VirtoCommerce.Platform.Web.Tests.Controllers.Api
                 _logger.Object,
                 _externalSigninProviderConfigs,
                 _userSessionsSearchServiceMock.Object,
-                _userSessionsServiceMock.Object);
+                _userSessionsServiceMock.Object,
+                _adminUIAccessPolicyMock.Object);
 
             controller.ControllerContext.HttpContext = new DefaultHttpContext();
             controller.ControllerContext.HttpContext.User = new ClaimsPrincipal(new ClaimsIdentity());
@@ -631,6 +639,84 @@ namespace VirtoCommerce.Platform.Web.Tests.Controllers.Api
             var result = actual.ExtractFromOkResult();
             result.Succeeded.Should().BeFalse();
         }
+
+        #endregion
+
+        #region GetCurrentUser
+
+        [Theory]
+        [InlineData(true)]
+        [InlineData(false)]
+        public async Task GetCurrentUser_ReturnsCanAccessAdminUI_FromThePolicy(bool isAllowed)
+        {
+            // Arrange
+            var user = CreateUserWithPermission("catalog:read");
+            SetCurrentUser(user);
+
+            _adminUIAccessPolicyMock
+                .Setup(x => x.EvaluateAsync(It.IsAny<AdminUIAccessContext>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(isAllowed ? AdminUIAccessResult.Allowed() : AdminUIAccessResult.Denied("nope"));
+
+            // Act
+            var actual = await _controller.GetCurrentUser();
+
+            // Assert
+            var result = actual.Result as Microsoft.AspNetCore.Mvc.OkObjectResult;
+            var userDetail = result.Value as UserDetail;
+            userDetail.CanAccessAdminUI.Should().Be(isAllowed);
+        }
+
+        [Fact]
+        public async Task GetCurrentUser_KeepsPermissions_WhenAdminUIAccessIsDenied()
+        {
+            // Arrange
+            var user = CreateUserWithPermission("mymodule:custom-endpoint:access");
+            SetCurrentUser(user);
+
+            _adminUIAccessPolicyMock
+                .Setup(x => x.EvaluateAsync(It.IsAny<AdminUIAccessContext>(), It.IsAny<CancellationToken>()))
+                .ReturnsAsync(AdminUIAccessResult.Denied("account type not allowed"));
+
+            // Act
+            var actual = await _controller.GetCurrentUser();
+
+            // Assert
+            var result = actual.Result as Microsoft.AspNetCore.Mvc.OkObjectResult;
+            var userDetail = result.Value as UserDetail;
+            userDetail.CanAccessAdminUI.Should().BeFalse();
+            // Denying the admin UI must not strip the permissions the user needs for the API.
+            userDetail.Permissions.Should().Contain("mymodule:custom-endpoint:access");
+        }
+
+        [Fact]
+        public async Task GetCurrentUser_PassesTheUsersPermissionsToThePolicy()
+        {
+            // Arrange
+            var user = CreateUserWithPermission("catalog:read");
+            SetCurrentUser(user);
+
+            // Act
+            await _controller.GetCurrentUser();
+
+            // Assert
+            _adminUIAccessPolicyMock.Verify(x => x.EvaluateAsync(
+                It.Is<AdminUIAccessContext>(c =>
+                    c.User.UserName == user.UserName &&
+                    c.Permissions.Contains("catalog:read")),
+                It.IsAny<CancellationToken>()), Times.Once);
+        }
+
+        private ApplicationUser CreateUserWithPermission(string permission) =>
+            new()
+            {
+                Id = "user-id",
+                UserName = "test-user",
+                UserType = nameof(UserType.Customer),
+                Roles =
+                [
+                    new Role { Permissions = [new Permission { Name = permission }] }
+                ],
+            };
 
         #endregion
     }


### PR DESCRIPTION
## Description

Restrict admin UI access by permission masks and account types via PlatformUI configuration

Introduce a configuration-driven admin UI access policy under the existing VirtoCommerce:PlatformUI section. The decision is evaluated server-side and delivered to the SPA as a computed canAccessAdminUI flag on GET /api/platform/security/currentuser, so the client never needs access to the policy itself.

```json
"PlatformUI": {
  "Access": {
    "AllowAdministrators": true,     // administrators bypass all rules
    "RequireAnyPermission": true,    // the pre-existing rule
    "AllowedAccountTypes": [],       // e.g. [ "Manager", "Administrator" ]
    "AllowedPermissions": [],        // masks: [ "platform:*", "catalog:*" ]
    "DeniedPermissions": []          // masks; wins over AllowedPermissions
  }
}
```

<img width="674" height="584" alt="image" src="https://github.com/user-attachments/assets/987ca25f-2bb0-4ea0-939d-f62a17892884" />


## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5532
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes login and navigation behavior for authenticated users and introduces security-adjacent configuration; defaults preserve prior “any permission” behavior, but misconfigured allow/deny or account-type lists could lock out legitimate admins (except when `AllowAdministrators` applies).
> 
> **Overview**
> Adds a **configuration-driven gate** for who may use the admin SPA, separate from API permission checks. Rules live under `VirtoCommerce:PlatformUI:Access` (admin bypass, required permissions, account-type allow list, permission allow/deny masks with `*` wildcards). Policy is evaluated on the server in `GET currentuser` and exposed as **`canAccessAdminUI`**; denied users keep their permissions for API calls.
> 
> The default **`ConfigurationAdminUIAccessPolicy`** is registered with `TryAddSingleton` so modules can replace it. **`WildcardMatcher`** supports mask matching for allow/deny lists.
> 
> The Angular app **replaces** the old client rule (non-admin with zero permissions → contact-admin) with the server flag, routing to **contact-admin** before password-expiry flows and blocking **`workspace.**` transitions when access is denied.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 6fab9b5cf5fb2f34fe832d079b45a41434eb1441. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1054.0-pr-3092-6fab-vcst-5532-6fab9b5c