### PR TITLE
VCST-5618: API returns 302 redirect to login page instead of 401

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Security/Authentication/ApiCookieRedirectHandler.cs
+++ b/src/VirtoCommerce.Platform.Web/Security/Authentication/ApiCookieRedirectHandler.cs
@@ -3,45 +3,43 @@ using System.Threading.Tasks;
 using Microsoft.AspNetCore.Authentication;
 using Microsoft.AspNetCore.Authentication.Cookies;
 using Microsoft.AspNetCore.Http;
-using Microsoft.Net.Http.Headers;
 
-namespace VirtoCommerce.Platform.Web.Security.Authentication
+namespace VirtoCommerce.Platform.Web.Security.Authentication;
+
+/// <summary>
+/// Handles cookie authentication challenges.
+/// API requests get a status code, so that API clients (including the admin SPA) can detect an expired
+/// session instead of transparently following the redirect and receiving the login page HTML with 200 OK.
+/// Browser navigation keeps redirecting to the login page, which the OpenID Connect authorization
+/// endpoint (/connect/authorize) relies on.
+/// </summary>
+public static class ApiCookieRedirectHandler
 {
-    /// <summary>
-    /// Handles cookie authentication challenges.
-    /// API requests get a status code, so that API clients (including the admin SPA) can detect an expired
-    /// session instead of transparently following the redirect and receiving the login page HTML with 200 OK.
-    /// Browser navigation keeps redirecting to the login page, which the OpenID Connect authorization
-    /// endpoint (/connect/authorize) relies on.
-    /// </summary>
-    public static class ApiCookieRedirectHandler
+    public const string ApiPathPrefix = "/api";
+    private const string XmlHttpRequest = "XMLHttpRequest";
+
+    public static Task HandleAsync(RedirectContext<CookieAuthenticationOptions> context, int statusCode)
     {
-        public const string ApiPathPrefix = "/api";
-        private const string XmlHttpRequest = "XMLHttpRequest";
-
-        public static Task HandleAsync(RedirectContext<CookieAuthenticationOptions> context, int statusCode)
+        if (IsApiRequest(context.Request))
         {
-            if (IsApiRequest(context.Request))
-            {
-                context.Response.StatusCode = statusCode;
-            }
-            else
-            {
-                context.Response.Redirect(context.RedirectUri);
-            }
-
-            return Task.CompletedTask;
+            context.Response.StatusCode = statusCode;
+        }
+        else
+        {
+            context.Response.Redirect(context.RedirectUri);
         }
 
-        /// <summary>
-        /// A request is treated as an API request when it targets the API path prefix, or when the client marks it
-        /// as an AJAX request. The latter preserves the behavior of the replaced built-in handler, which SignalR
-        /// hub negotiation depends on.
-        /// </summary>
-        public static bool IsApiRequest(HttpRequest request)
-        {
-            return request.Path.StartsWithSegments(ApiPathPrefix, StringComparison.OrdinalIgnoreCase) ||
-                   request.Headers[HeaderNames.XRequestedWith] == XmlHttpRequest;
-        }
+        return Task.CompletedTask;
+    }
+
+    /// <summary>
+    /// A request is treated as an API request when it targets the API path prefix, or when the client marks it
+    /// as an AJAX request. The latter preserves the behavior of the replaced built-in handler, which SignalR
+    /// hub negotiation depends on.
+    /// </summary>
+    public static bool IsApiRequest(HttpRequest request)
+    {
+        return request.Path.StartsWithSegments(ApiPathPrefix, StringComparison.OrdinalIgnoreCase) ||
+               request.Headers.XRequestedWith == XmlHttpRequest;
     }
 }

--- a/src/VirtoCommerce.Platform.Web/Security/Authentication/ApiCookieRedirectHandler.cs
+++ b/src/VirtoCommerce.Platform.Web/Security/Authentication/ApiCookieRedirectHandler.cs
@@ -1,0 +1,47 @@
+using System;
+using System.Threading.Tasks;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
+using Microsoft.Net.Http.Headers;
+
+namespace VirtoCommerce.Platform.Web.Security.Authentication
+{
+    /// <summary>
+    /// Handles cookie authentication challenges.
+    /// API requests get a status code, so that API clients (including the admin SPA) can detect an expired
+    /// session instead of transparently following the redirect and receiving the login page HTML with 200 OK.
+    /// Browser navigation keeps redirecting to the login page, which the OpenID Connect authorization
+    /// endpoint (/connect/authorize) relies on.
+    /// </summary>
+    public static class ApiCookieRedirectHandler
+    {
+        public const string ApiPathPrefix = "/api";
+        private const string XmlHttpRequest = "XMLHttpRequest";
+
+        public static Task HandleAsync(RedirectContext<CookieAuthenticationOptions> context, int statusCode)
+        {
+            if (IsApiRequest(context.Request))
+            {
+                context.Response.StatusCode = statusCode;
+            }
+            else
+            {
+                context.Response.Redirect(context.RedirectUri);
+            }
+
+            return Task.CompletedTask;
+        }
+
+        /// <summary>
+        /// A request is treated as an API request when it targets the API path prefix, or when the client marks it
+        /// as an AJAX request. The latter preserves the behavior of the replaced built-in handler, which SignalR
+        /// hub negotiation depends on.
+        /// </summary>
+        public static bool IsApiRequest(HttpRequest request)
+        {
+            return request.Path.StartsWithSegments(ApiPathPrefix, StringComparison.OrdinalIgnoreCase) ||
+                   request.Headers[HeaderNames.XRequestedWith] == XmlHttpRequest;
+        }
+    }
+}

--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -565,7 +565,6 @@ namespace VirtoCommerce.Platform.Web
             services.Configure<DataProtectionTokenProviderOptions>(Configuration.GetSection("IdentityOptions:DataProtection"));
             services.Configure<FixedSettings>(Configuration.GetSection("PlatformSettings"));
 
-            //always  return 401 instead of 302 for unauthorized  requests
             services.ConfigureApplicationCookie(options =>
             {
                 options.Cookie.Name = platformOptions.ApplicationCookieName;
@@ -575,6 +574,14 @@ namespace VirtoCommerce.Platform.Web
                 options.ExpireTimeSpan = authorizationOptions?.CookieExpireTimeSpan ?? TimeSpan.FromMinutes(60);
                 options.SlidingExpiration = authorizationOptions?.CookieSlidingExpiration ?? true;
                 options.LoginPath = "/";
+
+                // Return 401/403 for API requests instead of redirecting them to the login page.
+                // The mixed authentication scheme forwards anonymous requests to the cookie handler, so without this
+                // an expired session makes the API answer with a 302 to the login page instead of a status code.
+                // Assign the delegates instead of replacing options.Events: the instance created by AddIdentity
+                // carries OnValidatePrincipal, which runs the security stamp validation.
+                options.Events.OnRedirectToLogin = context => ApiCookieRedirectHandler.HandleAsync(context, StatusCodes.Status401Unauthorized);
+                options.Events.OnRedirectToAccessDenied = context => ApiCookieRedirectHandler.HandleAsync(context, StatusCodes.Status403Forbidden);
             });
 
             services.AddAuthorization(options =>

--- a/tests/VirtoCommerce.Platform.Web.Tests/Security/ApiCookieRedirectHandlerTests.cs
+++ b/tests/VirtoCommerce.Platform.Web.Tests/Security/ApiCookieRedirectHandlerTests.cs
@@ -1,0 +1,88 @@
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Authentication;
+using Microsoft.AspNetCore.Authentication.Cookies;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Identity;
+using VirtoCommerce.Platform.Web.Security.Authentication;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Web.Tests.Security
+{
+    public class ApiCookieRedirectHandlerTests
+    {
+        private const string LoginUri = "https://localhost:5001/?ReturnUrl=%2Fapi%2Fplatform%2Fsettings";
+
+        [Theory]
+        // The regression: API calls from the admin SPA must not be redirected to the login page.
+        [InlineData("/api/platform/settings/VirtoCommerce.Platform.Security.AccountTypes")]
+        [InlineData("/api/platform/security/users/search")]
+        // Path matching is case-insensitive.
+        [InlineData("/API/platform/settings")]
+        // The prefix itself is an API request.
+        [InlineData("/api")]
+        public async Task HandleAsync_ApiPath_SetsStatusCodeAndDoesNotRedirect(string path)
+        {
+            var context = CreateContext(path);
+
+            await ApiCookieRedirectHandler.HandleAsync(context, StatusCodes.Status401Unauthorized);
+
+            context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+            context.Response.Headers.Location.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task HandleAsync_ApiPath_AccessDenied_SetsForbidden()
+        {
+            var context = CreateContext("/api/platform/security/users/search");
+
+            await ApiCookieRedirectHandler.HandleAsync(context, StatusCodes.Status403Forbidden);
+
+            context.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+            context.Response.Headers.Location.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task HandleAsync_AjaxRequestOutsideApiPath_SetsStatusCode()
+        {
+            // SignalR marks hub negotiation as an AJAX request. It relied on the framework's built-in
+            // AJAX special case, which this handler replaces - the 401 must be preserved.
+            var context = CreateContext("/pushNotificationHub/negotiate", isAjax: true);
+
+            await ApiCookieRedirectHandler.HandleAsync(context, StatusCodes.Status401Unauthorized);
+
+            context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        }
+
+        [Theory]
+        // Browser navigation must keep redirecting, the OpenID Connect authorization flow depends on it.
+        [InlineData("/connect/authorize")]
+        [InlineData("/")]
+        // "apiary" is not the "/api" segment.
+        [InlineData("/apiary/docs")]
+        public async Task HandleAsync_NonApiPath_RedirectsToLoginPage(string path)
+        {
+            var context = CreateContext(path);
+
+            await ApiCookieRedirectHandler.HandleAsync(context, StatusCodes.Status401Unauthorized);
+
+            context.Response.StatusCode.Should().Be(StatusCodes.Status302Found);
+            context.Response.Headers.Location.ToString().Should().Be(LoginUri);
+        }
+
+        private static RedirectContext<CookieAuthenticationOptions> CreateContext(string path, bool isAjax = false)
+        {
+            var httpContext = new DefaultHttpContext();
+            httpContext.Request.Path = path;
+
+            if (isAjax)
+            {
+                httpContext.Request.Headers["X-Requested-With"] = "XMLHttpRequest";
+            }
+
+            var scheme = new AuthenticationScheme(IdentityConstants.ApplicationScheme, displayName: null, typeof(CookieAuthenticationHandler));
+
+            return new RedirectContext<CookieAuthenticationOptions>(httpContext, scheme, new CookieAuthenticationOptions(), new AuthenticationProperties(), LoginUri);
+        }
+    }
+}

--- a/tests/VirtoCommerce.Platform.Web.Tests/Security/ApiCookieRedirectHandlerTests.cs
+++ b/tests/VirtoCommerce.Platform.Web.Tests/Security/ApiCookieRedirectHandlerTests.cs
@@ -7,82 +7,81 @@ using Microsoft.AspNetCore.Identity;
 using VirtoCommerce.Platform.Web.Security.Authentication;
 using Xunit;
 
-namespace VirtoCommerce.Platform.Web.Tests.Security
+namespace VirtoCommerce.Platform.Web.Tests.Security;
+
+public class ApiCookieRedirectHandlerTests
 {
-    public class ApiCookieRedirectHandlerTests
+    private const string LoginUri = "https://localhost:5001/?ReturnUrl=%2Fapi%2Fplatform%2Fsettings";
+
+    [Theory]
+    // The regression: API calls from the admin SPA must not be redirected to the login page.
+    [InlineData("/api/platform/settings/VirtoCommerce.Platform.Security.AccountTypes")]
+    [InlineData("/api/platform/security/users/search")]
+    // Path matching is case-insensitive.
+    [InlineData("/API/platform/settings")]
+    // The prefix itself is an API request.
+    [InlineData("/api")]
+    public async Task HandleAsync_ApiPath_SetsStatusCodeAndDoesNotRedirect(string path)
     {
-        private const string LoginUri = "https://localhost:5001/?ReturnUrl=%2Fapi%2Fplatform%2Fsettings";
+        var context = CreateContext(path);
 
-        [Theory]
-        // The regression: API calls from the admin SPA must not be redirected to the login page.
-        [InlineData("/api/platform/settings/VirtoCommerce.Platform.Security.AccountTypes")]
-        [InlineData("/api/platform/security/users/search")]
-        // Path matching is case-insensitive.
-        [InlineData("/API/platform/settings")]
-        // The prefix itself is an API request.
-        [InlineData("/api")]
-        public async Task HandleAsync_ApiPath_SetsStatusCodeAndDoesNotRedirect(string path)
+        await ApiCookieRedirectHandler.HandleAsync(context, StatusCodes.Status401Unauthorized);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+        context.Response.Headers.Location.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_ApiPath_AccessDenied_SetsForbidden()
+    {
+        var context = CreateContext("/api/platform/security/users/search");
+
+        await ApiCookieRedirectHandler.HandleAsync(context, StatusCodes.Status403Forbidden);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
+        context.Response.Headers.Location.Should().BeEmpty();
+    }
+
+    [Fact]
+    public async Task HandleAsync_AjaxRequestOutsideApiPath_SetsStatusCode()
+    {
+        // SignalR marks hub negotiation as an AJAX request. It relied on the framework's built-in
+        // AJAX special case, which this handler replaces - the 401 must be preserved.
+        var context = CreateContext("/pushNotificationHub/negotiate", isAjax: true);
+
+        await ApiCookieRedirectHandler.HandleAsync(context, StatusCodes.Status401Unauthorized);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
+    }
+
+    [Theory]
+    // Browser navigation must keep redirecting, the OpenID Connect authorization flow depends on it.
+    [InlineData("/connect/authorize")]
+    [InlineData("/")]
+    // "apiary" is not the "/api" segment.
+    [InlineData("/apiary/docs")]
+    public async Task HandleAsync_NonApiPath_RedirectsToLoginPage(string path)
+    {
+        var context = CreateContext(path);
+
+        await ApiCookieRedirectHandler.HandleAsync(context, StatusCodes.Status401Unauthorized);
+
+        context.Response.StatusCode.Should().Be(StatusCodes.Status302Found);
+        context.Response.Headers.Location.ToString().Should().Be(LoginUri);
+    }
+
+    private static RedirectContext<CookieAuthenticationOptions> CreateContext(string path, bool isAjax = false)
+    {
+        var httpContext = new DefaultHttpContext();
+        httpContext.Request.Path = path;
+
+        if (isAjax)
         {
-            var context = CreateContext(path);
-
-            await ApiCookieRedirectHandler.HandleAsync(context, StatusCodes.Status401Unauthorized);
-
-            context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
-            context.Response.Headers.Location.Should().BeEmpty();
+            httpContext.Request.Headers.XRequestedWith = "XMLHttpRequest";
         }
 
-        [Fact]
-        public async Task HandleAsync_ApiPath_AccessDenied_SetsForbidden()
-        {
-            var context = CreateContext("/api/platform/security/users/search");
+        var scheme = new AuthenticationScheme(IdentityConstants.ApplicationScheme, displayName: null, typeof(CookieAuthenticationHandler));
 
-            await ApiCookieRedirectHandler.HandleAsync(context, StatusCodes.Status403Forbidden);
-
-            context.Response.StatusCode.Should().Be(StatusCodes.Status403Forbidden);
-            context.Response.Headers.Location.Should().BeEmpty();
-        }
-
-        [Fact]
-        public async Task HandleAsync_AjaxRequestOutsideApiPath_SetsStatusCode()
-        {
-            // SignalR marks hub negotiation as an AJAX request. It relied on the framework's built-in
-            // AJAX special case, which this handler replaces - the 401 must be preserved.
-            var context = CreateContext("/pushNotificationHub/negotiate", isAjax: true);
-
-            await ApiCookieRedirectHandler.HandleAsync(context, StatusCodes.Status401Unauthorized);
-
-            context.Response.StatusCode.Should().Be(StatusCodes.Status401Unauthorized);
-        }
-
-        [Theory]
-        // Browser navigation must keep redirecting, the OpenID Connect authorization flow depends on it.
-        [InlineData("/connect/authorize")]
-        [InlineData("/")]
-        // "apiary" is not the "/api" segment.
-        [InlineData("/apiary/docs")]
-        public async Task HandleAsync_NonApiPath_RedirectsToLoginPage(string path)
-        {
-            var context = CreateContext(path);
-
-            await ApiCookieRedirectHandler.HandleAsync(context, StatusCodes.Status401Unauthorized);
-
-            context.Response.StatusCode.Should().Be(StatusCodes.Status302Found);
-            context.Response.Headers.Location.ToString().Should().Be(LoginUri);
-        }
-
-        private static RedirectContext<CookieAuthenticationOptions> CreateContext(string path, bool isAjax = false)
-        {
-            var httpContext = new DefaultHttpContext();
-            httpContext.Request.Path = path;
-
-            if (isAjax)
-            {
-                httpContext.Request.Headers["X-Requested-With"] = "XMLHttpRequest";
-            }
-
-            var scheme = new AuthenticationScheme(IdentityConstants.ApplicationScheme, displayName: null, typeof(CookieAuthenticationHandler));
-
-            return new RedirectContext<CookieAuthenticationOptions>(httpContext, scheme, new CookieAuthenticationOptions(), new AuthenticationProperties(), LoginUri);
-        }
+        return new RedirectContext<CookieAuthenticationOptions>(httpContext, scheme, new CookieAuthenticationOptions(), new AuthenticationProperties(), LoginUri);
     }
 }


### PR DESCRIPTION
## Description
API returns 302 redirect to login page instead of 401 Unauthorized when the session expires since 3.1027.0.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5618
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes cookie authentication challenge behavior for all unauthenticated/forbidden requests, but scope is narrow (status vs redirect) and covered by targeted tests; incorrect path detection could still break OIDC redirects or API clients.
> 
> **Overview**
> Fixes **VCST-5618**: when a cookie session expires, unauthenticated `/api` calls were getting a **302 to the login page** (often followed as HTML with 200) instead of a proper **401**, which broke the admin SPA’s session handling.
> 
> Cookie **`OnRedirectToLogin`** and **`OnRedirectToAccessDenied`** now delegate to **`ApiCookieRedirectHandler`**, which returns **401/403** for requests under **`/api`** (case-insensitive) or with **`X-Requested-With: XMLHttpRequest`** (SignalR negotiate). Ordinary browser navigation still **redirects** to login so **`/connect/authorize`** and similar flows keep working. Event handlers are **assigned** on the existing cookie events object so **`OnValidatePrincipal`** / security stamp validation from **`AddIdentity`** is preserved.
> 
> Unit tests cover API paths, forbidden responses, AJAX/SignalR paths, and non-API redirects (including paths like `/apiary` that must not match `/api`).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit e27ac905f0016bedf7c373066bba8b29b9dd386e. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1053.0-pr-3093-e27a-vcst-5618-e27ac905