### PR TITLE
VCST-5637: add a streaming JSON content hash for cache keys

### DIFF
--- a/benchmarks/VirtoCommerce.Platform.Benchmark/Caching/JsonHashBenchmarks.cs
+++ b/benchmarks/VirtoCommerce.Platform.Benchmark/Caching/JsonHashBenchmarks.cs
@@ -13,16 +13,13 @@ namespace VirtoCommerce.Platform.Benchmark.Caching;
 // on every call, so on a request that never hits it is pure overhead — which is the number a caller needs
 // before deciding the cache is free.
 //
-// Streamed is the shipped path. Materialized is the same digest computed the obvious way, via an
-// intermediate JSON string; the gap between them is what the pooled streaming writer buys.
-//
 // The payload is a synthetic polymorphic tree rather than a real search request: Platform.Core cannot
 // reference a search module, and the property that matters here is shape and size, not domain meaning —
 // an interface-typed tree with string leaves, sized by NodeCount to bracket a few-KB request.
 [MemoryDiagnoser]
 public class JsonHashBenchmarks
 {
-    //The shipped settings, so the two arms serialize identically and the comparison stays honest.
+    // The shipped settings, so the two arms serialize identically and the comparison stays honest.
     private static readonly JsonSerializerSettings _settings = JsonHashExtensions.CreateCacheKeySettings();
 
     [Params(8, 64, 256)]
@@ -44,14 +41,14 @@ public class JsonHashBenchmarks
         };
     }
 
-    //Materialized is the baseline: it is the obvious implementation this one replaces, so the ratio column
-    //reads as "what the streaming writer bought".
+    // Materialized is the baseline: it is the obvious implementation the streaming writer replaces, so the
+    // ratio column reads as "what the streaming writer bought".
     [Benchmark(Baseline = true)]
     public string Materialized()
     {
-        //Omit the declared root type and this arm writes no root $type, so the two arms hash DIFFERENT
-        //payloads: the ratio charges Streamed for bytes the baseline never wrote, worst at the smallest
-        //NodeCount. Nothing catches that - it compiles, it runs, and no test asserts the arms agree.
+        // Omit the declared root type and this arm writes no root $type, so the two arms hash DIFFERENT
+        // payloads: the ratio charges Streamed for bytes the baseline never wrote, worst at the smallest
+        // NodeCount. Nothing catches that - it compiles, it runs, and no test asserts the arms agree.
         var json = JsonConvert.SerializeObject(_payload, typeof(object), _settings);
 
         return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(json)));

--- a/benchmarks/VirtoCommerce.Platform.Benchmark/Caching/JsonHashBenchmarks.cs
+++ b/benchmarks/VirtoCommerce.Platform.Benchmark/Caching/JsonHashBenchmarks.cs
@@ -49,7 +49,10 @@ public class JsonHashBenchmarks
     [Benchmark(Baseline = true)]
     public string Materialized()
     {
-        var json = JsonConvert.SerializeObject(_payload, _settings);
+        //Omit the declared root type and this arm writes no root $type, so the two arms hash DIFFERENT
+        //payloads: the ratio charges Streamed for bytes the baseline never wrote, worst at the smallest
+        //NodeCount. Nothing catches that - it compiles, it runs, and no test asserts the arms agree.
+        var json = JsonConvert.SerializeObject(_payload, typeof(object), _settings);
 
         return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(json)));
     }

--- a/benchmarks/VirtoCommerce.Platform.Benchmark/Caching/JsonHashBenchmarks.cs
+++ b/benchmarks/VirtoCommerce.Platform.Benchmark/Caching/JsonHashBenchmarks.cs
@@ -1,0 +1,78 @@
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Security.Cryptography;
+using System.Text;
+using BenchmarkDotNet.Attributes;
+using Newtonsoft.Json;
+using VirtoCommerce.Platform.Core.Caching;
+
+namespace VirtoCommerce.Platform.Benchmark.Caching;
+
+// What a cache MISS pays to build its key: serialize the argument graph and hash it. That cost is charged
+// on every call, so on a request that never hits it is pure overhead — which is the number a caller needs
+// before deciding the cache is free.
+//
+// Streamed is the shipped path. Materialized is the same digest computed the obvious way, via an
+// intermediate JSON string; the gap between them is what the pooled streaming writer buys.
+//
+// The payload is a synthetic polymorphic tree rather than a real search request: Platform.Core cannot
+// reference a search module, and the property that matters here is shape and size, not domain meaning —
+// an interface-typed tree with string leaves, sized by NodeCount to bracket a few-KB request.
+[MemoryDiagnoser]
+public class JsonHashBenchmarks
+{
+    //The shipped settings, so the two arms serialize identically and the comparison stays honest.
+    private static readonly JsonSerializerSettings _settings = JsonHashExtensions.CreateCacheKeySettings();
+
+    [Params(8, 64, 256)]
+    public int NodeCount { get; set; }
+
+    private Holder _payload;
+
+    [GlobalSetup]
+    public void Setup()
+    {
+        _payload = new Holder
+        {
+            Root = new AndNode
+            {
+                Children = Enumerable.Range(0, NodeCount)
+                    .Select(i => (INode)new Leaf { Value = $"field-{i}:{new string('v', 24)}" })
+                    .ToList(),
+            },
+        };
+    }
+
+    //Materialized is the baseline: it is the obvious implementation this one replaces, so the ratio column
+    //reads as "what the streaming writer bought".
+    [Benchmark(Baseline = true)]
+    public string Materialized()
+    {
+        var json = JsonConvert.SerializeObject(_payload, _settings);
+
+        return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(json)));
+    }
+
+    [Benchmark]
+    public string Streamed() => _payload.GetJsonSha256Hex();
+
+    public class Holder
+    {
+        public INode Root { get; set; }
+    }
+
+    public interface INode
+    {
+    }
+
+    public class AndNode : INode
+    {
+        public IList<INode> Children { get; set; }
+    }
+
+    public class Leaf : INode
+    {
+        public string Value { get; set; }
+    }
+}

--- a/src/VirtoCommerce.Platform.Core/Caching/JsonHashExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/JsonHashExtensions.cs
@@ -10,11 +10,18 @@ namespace VirtoCommerce.Platform.Core.Caching;
 /// <summary>
 /// Stable content hash of an object graph, for use as a cache key.
 /// </summary>
+/// <remarks>
+/// Prefer this over a key assembled from selected fields: a hand-written projection silently becomes
+/// under-inclusive - and starts serving the wrong data - the day a field is added to the hashed type.
+/// Hash a request or criteria object, not a materialized entity (serialization walks every readable property,
+/// so a lazily-loaded one issues queries) and not a graph carrying secrets (the pooled buffers go back to
+/// <see cref="ArrayPool{T}.Shared"/> uncleared, readable by whoever rents them next).
+/// </remarks>
 public static class JsonHashExtensions
 {
-    //4096 chars keeps a typical (~2 KB) payload to a single drain, and both pooled buffers - this one and
-    //the byte buffer derived from it (12291 requested, 16384 returned) - under the 85 KB large-object-heap
-    //threshold.
+    // 4096 chars keeps a typical (~2 KB) payload to a single drain, and both pooled buffers - this one and
+    // the byte buffer derived from it (12291 requested, 16384 returned) - under the 85 KB large-object-heap
+    // threshold.
     private const int CharBufferSize = 4096;
 
     private static readonly JsonSerializerSettings _cacheKeySerializerSettings = CreateCacheKeySettings();
@@ -24,27 +31,22 @@ public static class JsonHashExtensions
     /// may adjust - add a converter, say - before passing it to the overload that takes settings.
     /// </summary>
     /// <remarks>
-    /// <see cref="TypeNameHandling.Auto"/> is required, not stylistic. Two sibling types that declare the
-    /// same members serialize identically, so without a type discriminator their graphs hash alike and a
-    /// cache keyed on the digest serves one caller another's result. It is safe here only because this JSON
-    /// is exclusively hashed and never deserialized - do NOT reuse these settings for reading a payload back.
-    /// <br/><br/>
-    /// These settings are only HALF the protection, and the missing half is invisible: <c>Auto</c> emits the
-    /// discriminator where the runtime type differs from the DECLARED one, and the root of a serialization
-    /// has no declared type unless the caller supplies it. Taking these settings to
-    /// <c>JsonConvert.SerializeObject(value, settings)</c> therefore leaves the hashed object itself
-    /// undiscriminated - pass the root type too, as <see cref="GetJsonSha256Hex(object, JsonSerializerSettings)"/>
-    /// does: <c>JsonConvert.SerializeObject(value, typeof(object), settings)</c>.
-    /// <br/><br/>
-    /// <see cref="ReferenceLoopHandling.Ignore"/> makes a cyclic graph yield a truncated but stable key
-    /// rather than throwing, on a path whose only job is to produce a string.
+    /// Two obligations come with them. Serialize the root as <c>typeof(object)</c>, the way
+    /// <see cref="GetJsonSha256Hex(object, JsonSerializerSettings)"/> does - <c>Auto</c> discriminates against
+    /// the DECLARED type, which a root does not have. And do not read a payload back with them: emitting type
+    /// names is safe only because this JSON is exclusively hashed.
     /// </remarks>
     public static JsonSerializerSettings CreateCacheKeySettings()
     {
         return new JsonSerializerSettings
         {
             Formatting = Formatting.None,
+            // A cyclic graph should yield a truncated but stable key, not an exception, on a path whose only
+            // job is to produce a string.
             ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+            // Load-bearing: two sibling types that declare the same members serialize identically, so
+            // without a discriminator their graphs hash alike and a cache keyed on the digest serves one
+            // caller another's result.
             TypeNameHandling = TypeNameHandling.Auto,
         };
     }
@@ -52,48 +54,33 @@ public static class JsonHashExtensions
     /// <summary>
     /// SHA-256 of the object's JSON form, lowercase hex, using settings vetted for cache keys.
     /// </summary>
-    /// <param name="value">Graph to hash. <c>null</c> is legal and hashes as the JSON literal <c>null</c>.</param>
+    /// <param name="value">
+    /// Graph to hash, and not one carrying secrets - see the remarks on this type for why. <c>null</c> is
+    /// legal and hashes as the JSON literal <c>null</c>.
+    /// </param>
     /// <returns>64 lowercase hex characters.</returns>
-    /// <remarks>
-    /// Prefer this over assembling a key from selected fields: an over-inclusive key costs one extra miss,
-    /// an under-inclusive one serves the wrong data, and a hand-written projection silently becomes
-    /// under-inclusive the day a field is added to the hashed type.
-    /// <br/><br/>
-    /// Serializing walks every readable property on the graph, so pointing this at an entity with lazy
-    /// loading will issue queries. Hash the request or criteria object, not a materialized entity.
-    /// <br/><br/>
-    /// The pooled buffers are returned to <see cref="ArrayPool{T}.Shared"/> without being cleared, so
-    /// fragments of the serialized graph remain readable by whoever rents them next. That is fine for
-    /// search criteria and the like; do not hash a graph carrying secrets.
-    /// </remarks>
     public static string GetJsonSha256Hex(this object value)
     {
         return value.GetJsonSha256Hex(_cacheKeySerializerSettings);
     }
 
     /// <summary>
-    /// SHA-256 of the object's JSON form, lowercase hex. Streamed into the hash because the intermediate
-    /// string is never read: materializing it would copy a multi-KB payload twice per call.
+    /// SHA-256 of the object's JSON form, lowercase hex, using caller-supplied settings.
     /// </summary>
     /// <param name="value">
     /// Graph to hash. <c>null</c> is legal and hashes as the JSON literal <c>null</c>. A root that
     /// serializes to a bare JSON scalar carries no type discriminator - two enums sharing a numeric value,
-    /// or an <c>int</c> and a <c>long</c> of equal value, hash alike. Hash a request or criteria OBJECT.
+    /// or an <c>int</c> and a <c>long</c> of equal value, hash alike.
     /// </param>
     /// <param name="settings">
-    /// Must make the JSON DISCRIMINATING, not merely valid - see <see cref="CreateCacheKeySettings"/>, which
-    /// is the intended starting point. Passing settings without a type discriminator over a polymorphic
-    /// graph produces a plausible digest that collides across types.
+    /// Must make the JSON DISCRIMINATING, not merely valid - see <see cref="CreateCacheKeySettings"/>.
+    /// Settings without a type discriminator produce a plausible digest that collides across types.
     /// </param>
     /// <returns>64 lowercase hex characters.</returns>
     /// <exception cref="ArgumentNullException"><paramref name="settings"/> is null.</exception>
     /// <remarks>
-    /// The result is UTF8-based and independent of the host: the writer pins its newline, so a caller who
-    /// asks for indented formatting still gets the same digest on every platform.
-    /// <br/><br/>
-    /// Without <c>[JsonDerivedType]</c> on every participating type, <c>System.Text.Json</c> serializes by
-    /// DECLARED type and emits an empty object for an interface-typed member - which is why this path uses
-    /// Newtonsoft.
+    /// The digest is UTF8-based and does not depend on the host platform, whatever <see cref="Formatting"/>
+    /// the settings ask for.
     /// </remarks>
     public static string GetJsonSha256Hex(this object value, JsonSerializerSettings settings)
     {
@@ -102,37 +89,38 @@ public static class JsonHashExtensions
         using var incremental = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
         using (var textWriter = new Utf8HashingTextWriter(incremental))
         {
-            //CloseOutput=false: this writer owns its pooled buffers and returns them in its own Dispose.
+            // CloseOutput=false: this writer owns its pooled buffers and returns them in its own Dispose.
             using var jsonWriter = new JsonTextWriter(textWriter) { CloseOutput = false };
-            //typeof(object) is load-bearing, not a filler argument. TypeNameHandling.Auto emits $type only
-            //where the runtime type differs from the DECLARED one, and the overload without a type leaves
-            //the root with no declared type to differ from - so nothing is written for the hashed object
-            //itself, the very thing the key is taken over, and two sibling roots collide. Nested members
-            //are unaffected: a property always has a declared type.
+            // typeof(object) is load-bearing, not a filler argument: TypeNameHandling.Auto emits $type only
+            // where the runtime type differs from the DECLARED one, and the overload without a type leaves
+            // the root with none to differ from - so nothing is written for the hashed object itself, the
+            // very thing the key is taken over, and two sibling roots collide.
             JsonSerializer.Create(settings).Serialize(jsonWriter, value, typeof(object));
         }
 
         Span<byte> digest = stackalloc byte[SHA256.HashSizeInBytes];
         incremental.GetCurrentHash(digest);
 
-        //Lowercase, not ToHexString: CacheKey.Normalize returns the same instance for an already-lowercase
-        //key and allocates a lowered copy otherwise, and PlatformMemoryCache normalizes on every get, set
-        //and remove - an uppercase digest would pay that copy for the lifetime of the key.
+        // Lowercase, not ToHexString: CacheKey.Normalize returns the same instance for an already-lowercase
+        // key and allocates a lowered copy otherwise, and PlatformMemoryCache normalizes on every get, set
+        // and remove - an uppercase digest would pay that copy for the lifetime of the key.
         return Convert.ToHexStringLower(digest);
     }
 
     /// <summary>
     /// <see cref="TextWriter"/> that UTF8-encodes into a pooled buffer and feeds an
-    /// <see cref="IncrementalHash"/>, so no JSON string or byte array is ever materialized.
+    /// <see cref="IncrementalHash"/>, so no JSON string or byte array is ever materialized. Collapsing it
+    /// back into serialize-then-hash produces the SAME digest, so no test fails - the only casualty is the
+    /// allocation win, which <c>JsonHashBenchmarks</c> quantifies.
     /// </summary>
     private sealed class Utf8HashingTextWriter : TextWriter
     {
         private readonly IncrementalHash _hash;
-        //A stateful Encoder, not Encoding.GetBytes: a surrogate pair can straddle two drains, and only the
-        //encoder carries the high surrogate across the boundary instead of emitting a replacement char.
+        // A stateful Encoder, not Encoding.GetBytes: a surrogate pair can straddle two drains, and only the
+        // encoder carries the high surrogate across the boundary instead of emitting a replacement char.
         private readonly Encoder _encoder = Encoding.UTF8.GetEncoder();
-        //ArrayPool may return a LARGER array than requested, so the working capacity is this field rather
-        //than _chars.Length - the byte buffer is sized from it, and the two must not drift apart.
+        // ArrayPool may return a LARGER array than requested, so the working capacity is this field rather
+        // than _chars.Length - the byte buffer is sized from it, and the two must not drift apart.
         private readonly int _capacity = CharBufferSize;
         private char[] _chars = ArrayPool<char>.Shared.Rent(CharBufferSize);
         private byte[] _bytes = ArrayPool<byte>.Shared.Rent(Encoding.UTF8.GetMaxByteCount(CharBufferSize));
@@ -142,8 +130,8 @@ public static class JsonHashExtensions
         public Utf8HashingTextWriter(IncrementalHash hash)
         {
             _hash = hash;
-            //Pinned, so a caller asking for indented formatting cannot make the digest depend on
-            //Environment.NewLine: JsonTextWriter routes indentation through this property.
+            // Pinned, so a caller asking for indented formatting cannot make the digest depend on
+            // Environment.NewLine: JsonTextWriter routes indentation through this property.
             NewLine = "\n";
         }
 
@@ -197,21 +185,20 @@ public static class JsonHashExtensions
             _pending = 0;
         }
 
-        //Must be idempotent: returning the same rented arrays twice corrupts ArrayPool.Shared process-wide,
-        //surfacing as unrelated code receiving an aliased buffer.
+        // Must be idempotent: returning the same rented arrays twice corrupts ArrayPool.Shared process-wide,
+        // surfacing as unrelated code receiving an aliased buffer.
         protected override void Dispose(bool disposing)
         {
             if (disposing && !_disposed)
             {
                 try
                 {
-                    //Drain BEFORE setting the flag - Drain() bails out on it, which would truncate the hash.
-                    //flush: true so a trailing high surrogate is emitted rather than dropped.
+                    // Drain BEFORE setting the flag - Drain() bails out on it, which would truncate the hash.
+                    // flush: true so a trailing high surrogate is emitted rather than dropped.
                     Drain(flush: true);
                 }
                 finally
                 {
-                    //In a finally so a throwing drain still returns the arrays rather than leaking them.
                     _disposed = true;
                     ArrayPool<char>.Shared.Return(_chars);
                     ArrayPool<byte>.Shared.Return(_bytes);

--- a/src/VirtoCommerce.Platform.Core/Caching/JsonHashExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/JsonHashExtensions.cs
@@ -1,0 +1,210 @@
+using System;
+using System.Buffers;
+using System.IO;
+using System.Security.Cryptography;
+using System.Text;
+using Newtonsoft.Json;
+
+namespace VirtoCommerce.Platform.Core.Caching;
+
+/// <summary>
+/// Stable content hash of an object graph, for use as a cache key.
+/// </summary>
+public static class JsonHashExtensions
+{
+    //4096 chars keeps a typical (~2 KB) payload to a single drain, and both pooled buffers - this one and
+    //the byte buffer derived from it (12291 requested, 16384 returned) - under the 85 KB large-object-heap
+    //threshold.
+    private const int CharBufferSize = 4096;
+
+    private static readonly JsonSerializerSettings _cacheKeySerializerSettings = CreateCacheKeySettings();
+
+    /// <summary>
+    /// The serializer settings <see cref="GetJsonSha256Hex(object)"/> uses, as a fresh instance the caller
+    /// may adjust - add a converter, say - before passing it to the overload that takes settings.
+    /// </summary>
+    /// <remarks>
+    /// <see cref="TypeNameHandling.Auto"/> is required, not stylistic. Two sibling types that declare the
+    /// same members serialize identically, so without a type discriminator their graphs hash alike and a
+    /// cache keyed on the digest serves one caller another's result. It is safe here only because this JSON
+    /// is exclusively hashed and never deserialized - do NOT reuse these settings for reading a payload back.
+    /// <br/><br/>
+    /// <see cref="ReferenceLoopHandling.Ignore"/> makes a cyclic graph yield a truncated but stable key
+    /// rather than throwing, on a path whose only job is to produce a string.
+    /// </remarks>
+    public static JsonSerializerSettings CreateCacheKeySettings()
+    {
+        return new JsonSerializerSettings
+        {
+            Formatting = Formatting.None,
+            ReferenceLoopHandling = ReferenceLoopHandling.Ignore,
+            TypeNameHandling = TypeNameHandling.Auto,
+        };
+    }
+
+    /// <summary>
+    /// SHA-256 of the object's JSON form, lowercase hex, using settings vetted for cache keys.
+    /// </summary>
+    /// <param name="value">Graph to hash. <c>null</c> is legal and hashes as the JSON literal <c>null</c>.</param>
+    /// <returns>64 lowercase hex characters.</returns>
+    /// <remarks>
+    /// Prefer this over assembling a key from selected fields: an over-inclusive key costs one extra miss,
+    /// an under-inclusive one serves the wrong data, and a hand-written projection silently becomes
+    /// under-inclusive the day a field is added to the hashed type.
+    /// <br/><br/>
+    /// Serializing walks every readable property on the graph, so pointing this at an entity with lazy
+    /// loading will issue queries. Hash the request or criteria object, not a materialized entity.
+    /// <br/><br/>
+    /// The pooled buffers are returned to <see cref="ArrayPool{T}.Shared"/> without being cleared, so
+    /// fragments of the serialized graph remain readable by whoever rents them next. That is fine for
+    /// search criteria and the like; do not hash a graph carrying secrets.
+    /// </remarks>
+    public static string GetJsonSha256Hex(this object value)
+    {
+        return value.GetJsonSha256Hex(_cacheKeySerializerSettings);
+    }
+
+    /// <summary>
+    /// SHA-256 of the object's JSON form, lowercase hex. Streamed into the hash because the intermediate
+    /// string is never read: materializing it would copy a multi-KB payload twice per call.
+    /// </summary>
+    /// <param name="value">Graph to hash. <c>null</c> is legal and hashes as the JSON literal <c>null</c>.</param>
+    /// <param name="settings">
+    /// Must make the JSON DISCRIMINATING, not merely valid - see <see cref="CreateCacheKeySettings"/>, which
+    /// is the intended starting point. Passing settings without a type discriminator over a polymorphic
+    /// graph produces a plausible digest that collides across types.
+    /// </param>
+    /// <returns>64 lowercase hex characters.</returns>
+    /// <exception cref="ArgumentNullException"><paramref name="settings"/> is null.</exception>
+    /// <remarks>
+    /// The result is UTF8-based and independent of the host: the writer pins its newline, so a caller who
+    /// asks for indented formatting still gets the same digest on every platform.
+    /// <br/><br/>
+    /// Without <c>[JsonDerivedType]</c> on every participating type, <c>System.Text.Json</c> serializes by
+    /// DECLARED type and emits an empty object for an interface-typed member - which is why this path uses
+    /// Newtonsoft.
+    /// </remarks>
+    public static string GetJsonSha256Hex(this object value, JsonSerializerSettings settings)
+    {
+        ArgumentNullException.ThrowIfNull(settings);
+
+        using var incremental = IncrementalHash.CreateHash(HashAlgorithmName.SHA256);
+        using (var textWriter = new Utf8HashingTextWriter(incremental))
+        {
+            //CloseOutput=false: this writer owns its pooled buffers and returns them in its own Dispose.
+            using var jsonWriter = new JsonTextWriter(textWriter) { CloseOutput = false };
+            JsonSerializer.Create(settings).Serialize(jsonWriter, value);
+        }
+
+        Span<byte> digest = stackalloc byte[SHA256.HashSizeInBytes];
+        incremental.GetCurrentHash(digest);
+
+        //Lowercase, not ToHexString: CacheKey.Normalize returns the same instance for an already-lowercase
+        //key and allocates a lowered copy otherwise, and PlatformMemoryCache normalizes on every get, set
+        //and remove - an uppercase digest would pay that copy for the lifetime of the key.
+        return Convert.ToHexStringLower(digest);
+    }
+
+    /// <summary>
+    /// <see cref="TextWriter"/> that UTF8-encodes into a pooled buffer and feeds an
+    /// <see cref="IncrementalHash"/>, so no JSON string or byte array is ever materialized.
+    /// </summary>
+    private sealed class Utf8HashingTextWriter : TextWriter
+    {
+        private readonly IncrementalHash _hash;
+        //A stateful Encoder, not Encoding.GetBytes: a surrogate pair can straddle two drains, and only the
+        //encoder carries the high surrogate across the boundary instead of emitting a replacement char.
+        private readonly Encoder _encoder = Encoding.UTF8.GetEncoder();
+        //ArrayPool may return a LARGER array than requested, so the working capacity is this field rather
+        //than _chars.Length - the byte buffer is sized from it, and the two must not drift apart.
+        private readonly int _capacity = CharBufferSize;
+        private char[] _chars = ArrayPool<char>.Shared.Rent(CharBufferSize);
+        private byte[] _bytes = ArrayPool<byte>.Shared.Rent(Encoding.UTF8.GetMaxByteCount(CharBufferSize));
+        private int _pending;
+        private bool _disposed;
+
+        public Utf8HashingTextWriter(IncrementalHash hash)
+        {
+            _hash = hash;
+            //Pinned, so a caller asking for indented formatting cannot make the digest depend on
+            //Environment.NewLine: JsonTextWriter routes indentation through this property.
+            NewLine = "\n";
+        }
+
+        public override Encoding Encoding => Encoding.UTF8;
+
+        public override void Write(char value)
+        {
+            if (_pending == _capacity)
+            {
+                Drain(flush: false);
+            }
+
+            _chars[_pending++] = value;
+        }
+
+        public override void Write(char[] buffer, int index, int count) => Write(buffer.AsSpan(index, count));
+
+        public override void Write(string value) => Write(value.AsSpan());
+
+        public override void Write(ReadOnlySpan<char> buffer)
+        {
+            while (!buffer.IsEmpty)
+            {
+                if (_pending == _capacity)
+                {
+                    Drain(flush: false);
+                }
+
+                var take = Math.Min(buffer.Length, _capacity - _pending);
+                buffer[..take].CopyTo(_chars.AsSpan(_pending));
+                _pending += take;
+                buffer = buffer[take..];
+            }
+        }
+
+        public override void Flush() => Drain(flush: false);
+
+        private void Drain(bool flush)
+        {
+            if (_disposed || (_pending == 0 && !flush))
+            {
+                return;
+            }
+
+            var written = _encoder.GetBytes(_chars.AsSpan(0, _pending), _bytes, flush);
+            if (written > 0)
+            {
+                _hash.AppendData(_bytes.AsSpan(0, written));
+            }
+
+            _pending = 0;
+        }
+
+        //Must be idempotent: returning the same rented arrays twice corrupts ArrayPool.Shared process-wide,
+        //surfacing as unrelated code receiving an aliased buffer.
+        protected override void Dispose(bool disposing)
+        {
+            if (disposing && !_disposed)
+            {
+                try
+                {
+                    //Drain BEFORE setting the flag - Drain() bails out on it, which would truncate the hash.
+                    //flush: true so a trailing high surrogate is emitted rather than dropped.
+                    Drain(flush: true);
+                }
+                finally
+                {
+                    //In a finally so a throwing drain still returns the arrays rather than leaking them.
+                    _disposed = true;
+                    ArrayPool<char>.Shared.Return(_chars);
+                    ArrayPool<byte>.Shared.Return(_bytes);
+                    _chars = null;
+                    _bytes = null;
+                }
+            }
+
+            base.Dispose(disposing);
+        }
+    }
+}

--- a/src/VirtoCommerce.Platform.Core/Caching/JsonHashExtensions.cs
+++ b/src/VirtoCommerce.Platform.Core/Caching/JsonHashExtensions.cs
@@ -29,6 +29,13 @@ public static class JsonHashExtensions
     /// cache keyed on the digest serves one caller another's result. It is safe here only because this JSON
     /// is exclusively hashed and never deserialized - do NOT reuse these settings for reading a payload back.
     /// <br/><br/>
+    /// These settings are only HALF the protection, and the missing half is invisible: <c>Auto</c> emits the
+    /// discriminator where the runtime type differs from the DECLARED one, and the root of a serialization
+    /// has no declared type unless the caller supplies it. Taking these settings to
+    /// <c>JsonConvert.SerializeObject(value, settings)</c> therefore leaves the hashed object itself
+    /// undiscriminated - pass the root type too, as <see cref="GetJsonSha256Hex(object, JsonSerializerSettings)"/>
+    /// does: <c>JsonConvert.SerializeObject(value, typeof(object), settings)</c>.
+    /// <br/><br/>
     /// <see cref="ReferenceLoopHandling.Ignore"/> makes a cyclic graph yield a truncated but stable key
     /// rather than throwing, on a path whose only job is to produce a string.
     /// </remarks>
@@ -68,7 +75,11 @@ public static class JsonHashExtensions
     /// SHA-256 of the object's JSON form, lowercase hex. Streamed into the hash because the intermediate
     /// string is never read: materializing it would copy a multi-KB payload twice per call.
     /// </summary>
-    /// <param name="value">Graph to hash. <c>null</c> is legal and hashes as the JSON literal <c>null</c>.</param>
+    /// <param name="value">
+    /// Graph to hash. <c>null</c> is legal and hashes as the JSON literal <c>null</c>. A root that
+    /// serializes to a bare JSON scalar carries no type discriminator - two enums sharing a numeric value,
+    /// or an <c>int</c> and a <c>long</c> of equal value, hash alike. Hash a request or criteria OBJECT.
+    /// </param>
     /// <param name="settings">
     /// Must make the JSON DISCRIMINATING, not merely valid - see <see cref="CreateCacheKeySettings"/>, which
     /// is the intended starting point. Passing settings without a type discriminator over a polymorphic
@@ -93,7 +104,12 @@ public static class JsonHashExtensions
         {
             //CloseOutput=false: this writer owns its pooled buffers and returns them in its own Dispose.
             using var jsonWriter = new JsonTextWriter(textWriter) { CloseOutput = false };
-            JsonSerializer.Create(settings).Serialize(jsonWriter, value);
+            //typeof(object) is load-bearing, not a filler argument. TypeNameHandling.Auto emits $type only
+            //where the runtime type differs from the DECLARED one, and the overload without a type leaves
+            //the root with no declared type to differ from - so nothing is written for the hashed object
+            //itself, the very thing the key is taken over, and two sibling roots collide. Nested members
+            //are unaffected: a property always has a declared type.
+            JsonSerializer.Create(settings).Serialize(jsonWriter, value, typeof(object));
         }
 
         Span<byte> digest = stackalloc byte[SHA256.HashSizeInBytes];

--- a/tests/VirtoCommerce.Platform.Core.Tests/Caching/JsonHashExtensionsTests.cs
+++ b/tests/VirtoCommerce.Platform.Core.Tests/Caching/JsonHashExtensionsTests.cs
@@ -1,0 +1,211 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using System.Security.Cryptography;
+using System.Text;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Newtonsoft.Json;
+using VirtoCommerce.Platform.Core.Caching;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Core.Tests.Caching
+{
+    public class JsonHashExtensionsTests
+    {
+        // Mirrors the writer's internal buffer; the tests below derive drain boundaries from it rather than
+        // hard-coding payload lengths, because the JSON around the payload shifts where the seam lands.
+        private const int BufferSize = 4096;
+
+        [Fact]
+        public void GetJsonSha256Hex_EqualGraphsBuiltSeparately_ProduceEqualHashes()
+        {
+            // Arrange — two graphs with no shared instance
+            var first = BuildTree(new AndNode(), "alpha", "beta");
+            var second = BuildTree(new AndNode(), "alpha", "beta");
+
+            // Act & Assert
+            first.GetJsonSha256Hex().Should().Be(second.GetJsonSha256Hex());
+        }
+
+        [Fact]
+        public void GetJsonSha256Hex_GraphsDifferingOnlyInLeafValue_ProduceDifferentHashes()
+        {
+            var first = BuildTree(new AndNode(), "alpha", "beta");
+            var second = BuildTree(new AndNode(), "alpha", "gamma");
+
+            first.GetJsonSha256Hex().Should().NotBe(second.GetJsonSha256Hex());
+        }
+
+        [Fact]
+        public void GetJsonSha256Hex_GraphsDifferingOnlyInPolymorphicRuntimeType_ProduceDifferentHashes()
+        {
+            // THIS is the test that pins TypeNameHandling in the shipped settings: drop the discriminator
+            // from CreateCacheKeySettings and this fails. AndNode and OrNode are structurally identical —
+            // each declares exactly one member of the same type — so nothing else can tell them apart.
+            var and = BuildTree(new AndNode(), "alpha", "beta");
+            var or = BuildTree(new OrNode(), "alpha", "beta");
+
+            and.GetJsonSha256Hex().Should().NotBe(or.GetJsonSha256Hex());
+        }
+
+        [Fact]
+        public void GetJsonSha256Hex_WithoutTypeNameHandling_CollidesOnPolymorphicRuntimeType()
+        {
+            // Validates the FIXTURE of the test above rather than the shipped settings: it proves AndNode
+            // and OrNode really are indistinguishable without a discriminator, so that test's pass is
+            // evidence about the discriminator and not about some incidental difference between the types.
+            var withoutDiscriminator = JsonHashExtensions.CreateCacheKeySettings();
+            withoutDiscriminator.TypeNameHandling = TypeNameHandling.None;
+
+            var and = BuildTree(new AndNode(), "alpha", "beta");
+            var or = BuildTree(new OrNode(), "alpha", "beta");
+
+            and.GetJsonSha256Hex(withoutDiscriminator).Should().Be(or.GetJsonSha256Hex(withoutDiscriminator));
+        }
+
+        [Fact]
+        public void GetJsonSha256Hex_NullSettings_Throws()
+        {
+            // Newtonsoft treats null settings as "defaults", which emits no $type — i.e. silently produces
+            // the collision this class exists to prevent, and returns a plausible digest while doing it.
+            var act = () => BuildTree(new AndNode(), "alpha").GetJsonSha256Hex(null);
+
+            act.Should().Throw<ArgumentNullException>();
+        }
+
+        [Fact]
+        public void GetJsonSha256Hex_NullValue_HashesTheJsonNullLiteral()
+        {
+            object value = null;
+
+            value.GetJsonSha256Hex().Should().Be(NonStreamingHash(null));
+        }
+
+        [Theory]
+        [InlineData(0)]
+        [InlineData(16)]
+        [InlineData(BufferSize * 3)]
+        public void GetJsonSha256Hex_PayloadOfVariousSizes_MatchesNonStreamingHash(int payloadLength)
+        {
+            var value = LeafOf(new string('x', payloadLength));
+
+            value.GetJsonSha256Hex().Should().Be(NonStreamingHash(value));
+        }
+
+        [Fact]
+        public void GetJsonSha256Hex_PayloadEndingOnADrainBoundary_MatchesNonStreamingHash()
+        {
+            // The seam is not at a round payload length: the JSON ahead of the payload — property names and
+            // the assembly-qualified $type of every node — pushes it. Measure the overhead and derive the
+            // exact padding, so this keeps testing the boundary after any rename to the fixture types.
+            var overhead = SerializedLength(LeafOf(string.Empty));
+            var atSeam = BufferSize - overhead;
+
+            atSeam.Should().BeGreaterThan(0, "the fixture's JSON overhead must be smaller than one buffer");
+
+            foreach (var padding in new[] { atSeam - 1, atSeam, atSeam + 1 })
+            {
+                var value = LeafOf(new string('x', padding));
+
+                value.GetJsonSha256Hex().Should().Be(NonStreamingHash(value),
+                    "the digest must not depend on where the buffer happens to drain (padding {0})", padding);
+            }
+        }
+
+        [Fact]
+        public void GetJsonSha256Hex_SurrogatePairStraddlingADrainBoundary_MatchesNonStreamingHash()
+        {
+            // A surrogate pair is two chars, and the writer drains every BufferSize chars. When the pair is
+            // split across a drain, only a STATEFUL encoder carries the high half over; a stateless one
+            // emits a replacement character for each half and the digest diverges.
+            //
+            // Sweep a whole buffer's worth of alignments rather than picking offsets: an earlier version of
+            // this test hand-picked five and passed against a deliberately broken encoder, i.e. proved
+            // nothing. The same mistake is why the boundary test above computes its seam.
+            for (var padding = BufferSize; padding < BufferSize * 2 + 8; padding++)
+            {
+                var value = LeafOf(new string('x', padding) + "\U0001F600tail");
+
+                value.GetJsonSha256Hex().Should().Be(NonStreamingHash(value),
+                    "the surrogate pair must survive a drain boundary (padding {0})", padding);
+            }
+        }
+
+        [Fact]
+        public void GetJsonSha256Hex_ConcurrentCalls_AllMatchTheReferenceHash()
+        {
+            // Concurrency is the only way a pooled-buffer bug shows itself: a double return, or an array
+            // handed out while another writer still holds it, aliases two callers onto one buffer. A
+            // sequential loop cannot surface that. Comparing against the reference — not merely against the
+            // first result — is what makes a uniformly wrong digest fail rather than pass.
+            var value = LeafOf(new string('y', BufferSize * 2 + 137));
+            var expected = NonStreamingHash(value);
+            var results = new ConcurrentBag<string>();
+
+            Parallel.For(0, 64, _ => results.Add(value.GetJsonSha256Hex()));
+
+            results.Should().HaveCount(64).And.OnlyContain(x => x == expected);
+        }
+
+        // Reference implementation: serialize to a string, then hash its UTF8 bytes. The streaming writer
+        // exists to avoid materializing that string; it must produce the same digest as if it had not.
+        // Uses the shipped settings factory so the two sides cannot drift apart silently.
+        private static string NonStreamingHash(object value)
+        {
+            var json = JsonConvert.SerializeObject(value, JsonHashExtensions.CreateCacheKeySettings());
+
+            return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(json)));
+        }
+
+        private static int SerializedLength(object value)
+        {
+            return JsonConvert.SerializeObject(value, JsonHashExtensions.CreateCacheKeySettings()).Length;
+        }
+
+        private static Holder LeafOf(string value)
+        {
+            return new Holder { Root = new AndNode { Children = [new Leaf { Value = value }] } };
+        }
+
+        private static Holder BuildTree(NodeBase root, params string[] leafValues)
+        {
+            root.Children = [];
+
+            foreach (var leafValue in leafValues)
+            {
+                root.Children.Add(new Leaf { Value = leafValue });
+            }
+
+            return new Holder { Root = root };
+        }
+
+        private sealed class Holder
+        {
+            public INode Root { get; set; }
+        }
+
+        private interface INode
+        {
+        }
+
+        private abstract class NodeBase : INode
+        {
+            public IList<INode> Children { get; set; }
+        }
+
+        // Structurally identical siblings — the shape a content hash cannot tell apart without a type name.
+        private sealed class AndNode : NodeBase
+        {
+        }
+
+        private sealed class OrNode : NodeBase
+        {
+        }
+
+        private sealed class Leaf : INode
+        {
+            public string Value { get; set; }
+        }
+    }
+}

--- a/tests/VirtoCommerce.Platform.Core.Tests/Caching/JsonHashExtensionsTests.cs
+++ b/tests/VirtoCommerce.Platform.Core.Tests/Caching/JsonHashExtensionsTests.cs
@@ -20,11 +20,9 @@ namespace VirtoCommerce.Platform.Core.Tests.Caching
         [Fact]
         public void GetJsonSha256Hex_EqualGraphsBuiltSeparately_ProduceEqualHashes()
         {
-            // Arrange — two graphs with no shared instance
             var first = BuildTree(new AndNode(), "alpha", "beta");
             var second = BuildTree(new AndNode(), "alpha", "beta");
 
-            // Act & Assert
             first.GetJsonSha256Hex().Should().Be(second.GetJsonSha256Hex());
         }
 
@@ -66,9 +64,9 @@ namespace VirtoCommerce.Platform.Core.Tests.Caching
         [Fact]
         public void GetJsonSha256Hex_WithoutTypeNameHandling_CollidesOnPolymorphicRootRuntimeType()
         {
-            // Fixture check for the test above, mirroring the nested one below: with the discriminator off,
-            // the two roots must be indistinguishable — otherwise that test could pass on some incidental
-            // difference between AndNode and OrNode rather than on the root $type.
+            // Fixture check, not a check of the shipped settings: with the discriminator off the two roots
+            // must be indistinguishable, or the test above could be passing on some incidental difference
+            // between AndNode and OrNode rather than on the root $type.
             var withoutDiscriminator = JsonHashExtensions.CreateCacheKeySettings();
             withoutDiscriminator.TypeNameHandling = TypeNameHandling.None;
 
@@ -81,9 +79,7 @@ namespace VirtoCommerce.Platform.Core.Tests.Caching
         [Fact]
         public void GetJsonSha256Hex_WithoutTypeNameHandling_CollidesOnPolymorphicRuntimeType()
         {
-            // Validates the FIXTURE of the test above rather than the shipped settings: it proves AndNode
-            // and OrNode really are indistinguishable without a discriminator, so that test's pass is
-            // evidence about the discriminator and not about some incidental difference between the types.
+            // The same fixture check for the nested shape.
             var withoutDiscriminator = JsonHashExtensions.CreateCacheKeySettings();
             withoutDiscriminator.TypeNameHandling = TypeNameHandling.None;
 

--- a/tests/VirtoCommerce.Platform.Core.Tests/Caching/JsonHashExtensionsTests.cs
+++ b/tests/VirtoCommerce.Platform.Core.Tests/Caching/JsonHashExtensionsTests.cs
@@ -50,6 +50,35 @@ namespace VirtoCommerce.Platform.Core.Tests.Caching
         }
 
         [Fact]
+        public void GetJsonSha256Hex_RootsDifferingOnlyInRuntimeType_ProduceDifferentHashes()
+        {
+            // The test above hashes a Holder, so its polymorphic node is a MEMBER — and a member always has
+            // a declared type for TypeNameHandling.Auto to compare against. Here the polymorphic object is
+            // the root itself, which is the shape a cache key actually takes: hash the request, not a
+            // wrapper around it. Serializing without declaring the root as object emits no $type for it and
+            // these two collide, with no error and a plausible-looking digest.
+            var and = BuildTree(new AndNode(), "alpha", "beta").Root;
+            var or = BuildTree(new OrNode(), "alpha", "beta").Root;
+
+            and.GetJsonSha256Hex().Should().NotBe(or.GetJsonSha256Hex());
+        }
+
+        [Fact]
+        public void GetJsonSha256Hex_WithoutTypeNameHandling_CollidesOnPolymorphicRootRuntimeType()
+        {
+            // Fixture check for the test above, mirroring the nested one below: with the discriminator off,
+            // the two roots must be indistinguishable — otherwise that test could pass on some incidental
+            // difference between AndNode and OrNode rather than on the root $type.
+            var withoutDiscriminator = JsonHashExtensions.CreateCacheKeySettings();
+            withoutDiscriminator.TypeNameHandling = TypeNameHandling.None;
+
+            var and = BuildTree(new AndNode(), "alpha", "beta").Root;
+            var or = BuildTree(new OrNode(), "alpha", "beta").Root;
+
+            and.GetJsonSha256Hex(withoutDiscriminator).Should().Be(or.GetJsonSha256Hex(withoutDiscriminator));
+        }
+
+        [Fact]
         public void GetJsonSha256Hex_WithoutTypeNameHandling_CollidesOnPolymorphicRuntimeType()
         {
             // Validates the FIXTURE of the test above rather than the shipped settings: it proves AndNode
@@ -153,14 +182,24 @@ namespace VirtoCommerce.Platform.Core.Tests.Caching
         // Uses the shipped settings factory so the two sides cannot drift apart silently.
         private static string NonStreamingHash(object value)
         {
-            var json = JsonConvert.SerializeObject(value, JsonHashExtensions.CreateCacheKeySettings());
+            var json = ReferenceJson(value);
 
             return Convert.ToHexStringLower(SHA256.HashData(Encoding.UTF8.GetBytes(json)));
         }
 
+        // The seam the boundary test derives is measured on this JSON, so it must be byte-for-byte what the
+        // streaming path writes — the root $type included, or the seam lands short by its length.
         private static int SerializedLength(object value)
         {
-            return JsonConvert.SerializeObject(value, JsonHashExtensions.CreateCacheKeySettings()).Length;
+            return ReferenceJson(value).Length;
+        }
+
+        // typeof(object) mirrors the declared root type the implementation passes; dropping it here would
+        // make the reference omit the root discriminator and every parity assertion above would compare the
+        // streaming path against a DIFFERENT payload.
+        private static string ReferenceJson(object value)
+        {
+            return JsonConvert.SerializeObject(value, typeof(object), JsonHashExtensions.CreateCacheKeySettings());
         }
 
         private static Holder LeafOf(string value)


### PR DESCRIPTION
## Summary

Adds `JsonHashExtensions.GetJsonSha256Hex` to `VirtoCommerce.Platform.Core.Caching`: a stable content hash of an object graph, for building a cache key over an argument that is too structured to key by hand.

The motivating case is a cache over a call whose argument is a recursive, polymorphic request object. Such a key cannot be assembled from selected fields — an over-inclusive key costs one extra miss, an under-inclusive one serves the wrong data, and a hand-written projection silently becomes under-inclusive the day a field is added to the hashed type. Hashing the whole argument is complete by construction.

## Why not the existing object-hash helpers

`ObjectExtension.GetHash` / `GetMD5Hash` / `GetSHA1Hash` serialize through `XmlSerializer`, which cannot serialize an interface-typed member at all — so they cannot express a key over a polymorphic graph. The naming here follows that family; the `Hex` suffix marks the encoding difference (they return base64).

## Two things the naive version gets wrong

**A missing type discriminator silently collides.** Two sibling types that declare the same members serialize identically, so their graphs hash alike and a cache keyed on the digest serves one caller another's result. Hence `TypeNameHandling.Auto`, which is normally a red flag and is safe here only because this JSON is exclusively hashed and never deserialized — stated in the doc-comment, and pinned by a test that fails if the setting is removed.

That setting is only half of it, and the other half is easy to miss. `Auto` emits the discriminator where a runtime type differs from the **declared** one — a property always has a declared type, but the root of a serialization does not unless the caller supplies it. Serializing through the overload that takes no type therefore leaves the hashed object *itself* undiscriminated, which is precisely the object a cache key is taken over. The root type is declared explicitly (`Serialize(writer, value, typeof(object))`), and `CreateCacheKeySettings` says so, because a caller who takes those settings to a plain `JsonConvert.SerializeObject(value, settings)` reintroduces the collision with nothing to warn them.

`System.Text.Json` cannot express this key without `[JsonDerivedType]` on every participating type: it serializes by declared type and emits an empty object for an interface-typed member.

**Materializing the JSON copies a multi-KB payload twice per call.** The serializer writes straight into an `IncrementalHash` through a pooled-buffer `TextWriter`, so no JSON string and no byte array is ever built.

Measured (`JsonHashBenchmarks`, short job, streamed against serialize-then-hash; `NodeCount` is the benchmark's payload parameter):

| NodeCount | time | allocated |
|---|---|---|
| 8 | 5.2 vs 5.4 us | 14.1 vs 22.6 KB |
| 64 | 29.7 vs 30.5 us | 85.8 vs 147.6 KB |
| 256 | 110.9 vs 118.2 us | 331.9 vs 528.3 KB |

The win is 37-42% of the allocations. Wall time differs by a few percent at most, and a short job's confidence intervals overlap there — so allocation is the effect worth claiming. Worth saying plainly, because the obvious pitch for a streaming writer is speed and that is not what this buys.

Both arms declare the same root type. They have to: the baseline re-derives the payload independently, and if it omitted the root `$type` the ratio would charge the streamed arm for bytes the baseline never wrote — a wrong number that compiles, runs, and is asserted by nothing.

## Details worth a reviewer's eye

- **Lowercase hex, deliberately.** `CacheKey.Normalize` returns the same instance for an already-lowercase key, and `PlatformMemoryCache` normalizes on every get, set and remove. An uppercase digest would pay a string copy for the lifetime of every key built from it.
- **The writer pins `NewLine`.** `JsonTextWriter` routes indentation through it, so without pinning, a caller passing `Formatting.Indented` would get a different digest on Linux and Windows — and the class promises a stable hash.
- **`settings: null` throws.** Newtonsoft reads null as "defaults", which emits no `$type` — i.e. it would silently produce exactly the collision above while returning a plausible digest.
- **A bare scalar root is out of contract.** Newtonsoft writes a primitive token without consulting the declared root type, so two enums sharing a numeric value hash alike. Documented on the parameter; it does not affect hashing a request or criteria object.
- **The vetted settings are exposed** as `CreateCacheKeySettings()` rather than kept private, so a caller needing one extra converter can start from them, and so the tests and the benchmark cannot drift from the shipped configuration by hand-copying the literal.
- **Buffers are returned to the shared pool uncleared** — documented, with the consequence: do not hash a graph carrying secrets.

## Test plan

- [x] `VirtoCommerce.Platform.Core.Tests` 168/168; solution builds with 0 warnings.
- [x] Equal graphs hash equal; graphs differing in a leaf value differ.
- [x] Graphs differing only in a polymorphic runtime type differ — **verified discriminating**: removing `TypeNameHandling` from the shipped settings fails this test and only this test.
- [x] The same for a polymorphic **root**, not merely a polymorphic member — **verified discriminating**: reverting the declared root type fails this test and only this test. Every other fixture wraps its polymorphic node in a monomorphic holder, so without this one the root case is untested.
- [x] A surrogate pair straddling a buffer drain survives — **verified discriminating**: replacing the stateful `Encoder` with a stateless one fails this test and only this test. The test sweeps a whole buffer's worth of alignments rather than picking offsets, because the JSON ahead of the payload shifts where the seam lands.
- [x] The drain boundary is computed from the fixture's own serialized overhead, so it keeps testing the boundary after any rename — and that overhead is measured on the same payload the streaming path writes, root `$type` included.
- [x] 64 concurrent calls all match the reference hash — the only shape in which a pooled-buffer fault can surface.
- [x] Null settings throw; a null receiver hashes the JSON `null` literal.

Image tag:
ghcr.io/VirtoCommerce/platform:3.1057.0-pr-3095-3abb-vcst-5637-json-hash-extensions-3abbc5bb
Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5637

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Wrong cache keys from misused settings or polymorphic collisions could serve incorrect cached data; the API is new and not yet wired into production cache paths in this diff.
> 
> **Overview**
> Introduces **`JsonHashExtensions`** in Platform.Core.Caching so callers can derive **stable SHA-256 cache keys** from whole request/criteria object graphs instead of hand-picked fields.
> 
> **`GetJsonSha256Hex`** serializes with **`CreateCacheKeySettings()`** (`TypeNameHandling.Auto`, no reference loops) and hashes via a **pooled `Utf8HashingTextWriter`** that streams UTF-8 into **`IncrementalHash`**—avoiding a full JSON string/byte array. Serialization uses **`typeof(object)`** at the root so polymorphic roots get `$type` discriminators and sibling types with identical shapes do not collide. Digests are **lowercase hex** to align with **`PlatformMemoryCache`** key normalization.
> 
> Adds **`JsonHashBenchmarks`** (materialized serialize-then-hash vs streamed) and **`JsonHashExtensionsTests`** covering parity with a reference hash, polymorphic root/member discrimination, buffer-drain boundaries, surrogate pairs, concurrency on pooled buffers, and null settings/value behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 3abbc5bb0708e03bc54c099cbd4b1c5f705831b8. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->