### PR TITLE
VCST-5686: Add on-demand job cancellation

### DIFF
--- a/src/VirtoCommerce.Platform.Core/Jobs/BackgroundJob.cs
+++ b/src/VirtoCommerce.Platform.Core/Jobs/BackgroundJob.cs
@@ -48,4 +48,37 @@ public static class BackgroundJob
         var backgroundJob = scope.ServiceProvider.GetRequiredService<IBackgroundJob>();
         return await backgroundJob.Enqueue<THandler>(payload, options, cancellationToken);
     }
+
+    /// <summary>
+    /// Static counterpart of <see cref="IBackgroundJob.Cancel"/>: request cancellation of a job by id. Resolves the
+    /// scoped facade through a short-lived scope and delegates. Prefer checking <see cref="SupportsCancellation"/>
+    /// first so a caller can tell "not supported" apart from "nothing to cancel".
+    /// </summary>
+    public static async Task<bool> Cancel(string jobId, CancellationToken cancellationToken = default)
+    {
+        var provider = _rootServiceProvider
+            ?? throw new InvalidOperationException(
+                "BackgroundJob static facade is not initialized. Install the VirtoCommerce.BackgroundJobs module " +
+                "(it calls BackgroundJob.Initialize during startup), or inject IBackgroundJob instead.");
+
+        using var scope = provider.CreateScope();
+        var backgroundJob = scope.ServiceProvider.GetRequiredService<IBackgroundJob>();
+        return await backgroundJob.Cancel(jobId, cancellationToken);
+    }
+
+    /// <summary>Whether the active engine supports on-demand cancellation; <c>false</c> when uninitialized.</summary>
+    public static bool SupportsCancellation
+    {
+        get
+        {
+            var provider = _rootServiceProvider;
+            if (provider is null)
+            {
+                return false;
+            }
+
+            using var scope = provider.CreateScope();
+            return scope.ServiceProvider.GetRequiredService<IBackgroundJob>().SupportsCancellation;
+        }
+    }
 }

--- a/src/VirtoCommerce.Platform.Core/Jobs/IBackgroundJob.cs
+++ b/src/VirtoCommerce.Platform.Core/Jobs/IBackgroundJob.cs
@@ -6,20 +6,77 @@ using System.Threading.Tasks;
 namespace VirtoCommerce.Platform.Core.Jobs;
 
 /// <summary>
-/// Developer-facing facade to enqueue background work (engine-agnostic).
+/// Developer-facing facade to enqueue background work (engine-agnostic). The active implementation is provided by
+/// an installed background-job engine module (e.g. <c>VirtoCommerce.BackgroundJobs</c>). When no engine is
+/// installed, a fallback is registered that throws <see cref="BackgroundJobEngineNotInstalledException"/> with
+/// actionable installation instructions.
+/// <para>
+/// Inject this to enqueue work; implement <see cref="IBackgroundJobHandler{TPayload}"/> to handle a payload.
+/// </para>
 /// </summary>
 public interface IBackgroundJob
 {
+    /// <summary>
+    /// Enqueue a message-based job: <typeparamref name="THandler"/> processes the supplied <paramref name="payload"/>
+    /// on the active engine (Hangfire, RabbitMQ, …), with or without progress (see
+    /// <see cref="EnqueueOptions.ReportProgress"/>). Naming the handler makes the enqueue self-documenting and lets
+    /// several handlers share one payload type. The payload is validated against the handler at enqueue time:
+    /// <typeparamref name="THandler"/> must implement <see cref="IBackgroundJobHandler{TPayload}"/> for the payload's
+    /// runtime type, otherwise this throws.
+    /// </summary>
+    /// <typeparam name="THandler">The handler that will run the payload.</typeparam>
+    /// <param name="payload">The serializable payload instance; its runtime type selects the handler's payload contract.</param>
+    /// <param name="options">Per-enqueue options (queue, title, progress, retries, unique key).</param>
+    /// <param name="cancellationToken">Cancels the enqueue operation.</param>
+    /// <returns>The engine-specific job id.</returns>
     Task<string> Enqueue<THandler>(object payload, EnqueueOptions? options = null,
         CancellationToken cancellationToken = default)
         where THandler : class;
 
+    /// <summary>
+    /// Non-generic overload of <see cref="Enqueue{THandler}"/> for callers that only have the handler
+    /// <see cref="Type"/> at runtime — e.g. a REST "run by name" endpoint that resolved a registered
+    /// <see cref="BackgroundJobDescriptor"/>. <paramref name="handlerType"/> must be a concrete class implementing
+    /// <see cref="IBackgroundJobHandler{TPayload}"/> for the payload's runtime type, otherwise this throws.
+    /// </summary>
+    /// <param name="handlerType">The concrete handler type that will run the payload.</param>
+    /// <param name="payload">The serializable payload instance; its runtime type selects the handler's payload contract.</param>
+    /// <param name="options">Per-enqueue options (queue, title, progress, retries, unique key).</param>
+    /// <param name="cancellationToken">Cancels the enqueue operation.</param>
+    /// <returns>The engine-specific job id.</returns>
+    /// <remarks>
+    /// A default (throwing) implementation is provided so this member can be added without breaking existing external
+    /// implementers of <see cref="IBackgroundJob"/>; the platform's facade overrides it with the real behavior.
+    /// </remarks>
     Task<string> Enqueue(Type handlerType, object payload, EnqueueOptions? options = null,
         CancellationToken cancellationToken = default)
         => throw new NotSupportedException(
             $"This {nameof(IBackgroundJob)} implementation does not support the non-generic Enqueue(Type, ...) overload.");
 
+    /// <summary>
+    /// Request cancellation of a previously enqueued job. Best-effort and engine-dependent: an engine with a job store
+    /// (Hangfire) removes a job that has not started and aborts a running one, while a queue engine that cannot recall
+    /// a published message (RabbitMQ) records the request so the worker discards the message on dequeue, or trips the
+    /// running handler's <see cref="CancellationToken"/>. Either way the handler must honor the token it is given —
+    /// cancellation asks work to stop, it does not kill a thread.
+    /// </summary>
+    /// <param name="jobId">The engine-specific job id returned by one of the <c>Enqueue</c> overloads.</param>
+    /// <param name="cancellationToken">Cancels the cancel request itself, not the job.</param>
+    /// <returns>
+    /// <c>true</c> when the request was accepted, <c>false</c> when there was nothing to cancel. Check
+    /// <see cref="SupportsCancellation"/> first to tell "nothing to cancel" apart from "this engine cannot cancel".
+    /// </returns>
+    /// <remarks>
+    /// A default implementation returning <c>false</c> is provided so this member can be added without breaking
+    /// existing external implementers of <see cref="IBackgroundJob"/>.
+    /// </remarks>
     Task<bool> Cancel(string jobId, CancellationToken cancellationToken = default) => Task.FromResult(false);
 
+    /// <summary>
+    /// Whether the active engine can cancel a job on demand. <c>false</c> when no engine is installed, or when the
+    /// installed one has no way to stop work already handed to a worker. Probe this before offering cancellation in a
+    /// UI or an API, so an engine that cannot cancel degrades visibly (a disabled button, a <c>501</c>) instead of
+    /// answering a cancel request that does nothing.
+    /// </summary>
     bool SupportsCancellation => false;
 }

--- a/src/VirtoCommerce.Platform.Core/Jobs/IBackgroundJob.cs
+++ b/src/VirtoCommerce.Platform.Core/Jobs/IBackgroundJob.cs
@@ -52,4 +52,22 @@ public interface IBackgroundJob
         CancellationToken cancellationToken = default)
         => throw new NotSupportedException(
             $"This {nameof(IBackgroundJob)} implementation does not support the non-generic Enqueue(Type, ...) overload.");
+
+    /// <summary>
+    /// Request cancellation of a previously enqueued job by id. Best-effort and engine-dependent: a not-yet-started
+    /// job is prevented from running; a running job is asked to stop via its <see cref="CancellationToken"/>.
+    /// Returns <c>true</c> if the active engine accepted the request. Check <see cref="SupportsCancellation"/> first to
+    /// tell "not supported" apart from "nothing to cancel".
+    /// </summary>
+    /// <param name="jobId">The engine-specific job id returned by <see cref="Enqueue{THandler}"/>.</param>
+    /// <param name="cancellationToken">Cancels the cancellation request operation itself.</param>
+    /// <returns><c>true</c> if the active engine accepted the cancellation request.</returns>
+    /// <remarks>
+    /// A default no-op implementation is provided so this member can be added without breaking existing external
+    /// implementers of <see cref="IBackgroundJob"/>; the platform's facade overrides it with the real behavior.
+    /// </remarks>
+    Task<bool> Cancel(string jobId, CancellationToken cancellationToken = default) => Task.FromResult(false);
+
+    /// <summary>Whether the active engine supports on-demand cancellation (see <see cref="Cancel"/>).</summary>
+    bool SupportsCancellation => false;
 }

--- a/src/VirtoCommerce.Platform.Core/Jobs/IBackgroundJob.cs
+++ b/src/VirtoCommerce.Platform.Core/Jobs/IBackgroundJob.cs
@@ -6,68 +6,20 @@ using System.Threading.Tasks;
 namespace VirtoCommerce.Platform.Core.Jobs;
 
 /// <summary>
-/// Developer-facing facade to enqueue background work (engine-agnostic). The active implementation is provided by
-/// an installed background-job engine module (e.g. <c>VirtoCommerce.BackgroundJobs</c>). When no engine is
-/// installed, a fallback is registered that throws <see cref="BackgroundJobEngineNotInstalledException"/> with
-/// actionable installation instructions.
-/// <para>
-/// Inject this to enqueue work; implement <see cref="IBackgroundJobHandler{TPayload}"/> to handle a payload.
-/// </para>
+/// Developer-facing facade to enqueue background work (engine-agnostic).
 /// </summary>
 public interface IBackgroundJob
 {
-    /// <summary>
-    /// Enqueue a message-based job: <typeparamref name="THandler"/> processes the supplied <paramref name="payload"/>
-    /// on the active engine (Hangfire, RabbitMQ, …), with or without progress (see
-    /// <see cref="EnqueueOptions.ReportProgress"/>). Naming the handler makes the enqueue self-documenting and lets
-    /// several handlers share one payload type. The payload is validated against the handler at enqueue time:
-    /// <typeparamref name="THandler"/> must implement <see cref="IBackgroundJobHandler{TPayload}"/> for the payload's
-    /// runtime type, otherwise this throws.
-    /// </summary>
-    /// <typeparam name="THandler">The handler that will run the payload.</typeparam>
-    /// <param name="payload">The serializable payload instance; its runtime type selects the handler's payload contract.</param>
-    /// <param name="options">Per-enqueue options (queue, title, progress, retries, unique key).</param>
-    /// <param name="cancellationToken">Cancels the enqueue operation.</param>
-    /// <returns>The engine-specific job id.</returns>
     Task<string> Enqueue<THandler>(object payload, EnqueueOptions? options = null,
         CancellationToken cancellationToken = default)
         where THandler : class;
 
-    /// <summary>
-    /// Non-generic overload of <see cref="Enqueue{THandler}"/> for callers that only have the handler
-    /// <see cref="Type"/> at runtime — e.g. a REST "run by name" endpoint that resolved a registered
-    /// <see cref="BackgroundJobDescriptor"/>. <paramref name="handlerType"/> must be a concrete class implementing
-    /// <see cref="IBackgroundJobHandler{TPayload}"/> for the payload's runtime type, otherwise this throws.
-    /// </summary>
-    /// <param name="handlerType">The concrete handler type that will run the payload.</param>
-    /// <param name="payload">The serializable payload instance; its runtime type selects the handler's payload contract.</param>
-    /// <param name="options">Per-enqueue options (queue, title, progress, retries, unique key).</param>
-    /// <param name="cancellationToken">Cancels the enqueue operation.</param>
-    /// <returns>The engine-specific job id.</returns>
-    /// <remarks>
-    /// A default (throwing) implementation is provided so this member can be added without breaking existing external
-    /// implementers of <see cref="IBackgroundJob"/>; the platform's facade overrides it with the real behavior.
-    /// </remarks>
     Task<string> Enqueue(Type handlerType, object payload, EnqueueOptions? options = null,
         CancellationToken cancellationToken = default)
         => throw new NotSupportedException(
             $"This {nameof(IBackgroundJob)} implementation does not support the non-generic Enqueue(Type, ...) overload.");
 
-    /// <summary>
-    /// Request cancellation of a previously enqueued job by id. Best-effort and engine-dependent: a not-yet-started
-    /// job is prevented from running; a running job is asked to stop via its <see cref="CancellationToken"/>.
-    /// Returns <c>true</c> if the active engine accepted the request. Check <see cref="SupportsCancellation"/> first to
-    /// tell "not supported" apart from "nothing to cancel".
-    /// </summary>
-    /// <param name="jobId">The engine-specific job id returned by <see cref="Enqueue{THandler}"/>.</param>
-    /// <param name="cancellationToken">Cancels the cancellation request operation itself.</param>
-    /// <returns><c>true</c> if the active engine accepted the cancellation request.</returns>
-    /// <remarks>
-    /// A default no-op implementation is provided so this member can be added without breaking existing external
-    /// implementers of <see cref="IBackgroundJob"/>; the platform's facade overrides it with the real behavior.
-    /// </remarks>
     Task<bool> Cancel(string jobId, CancellationToken cancellationToken = default) => Task.FromResult(false);
 
-    /// <summary>Whether the active engine supports on-demand cancellation (see <see cref="Cancel"/>).</summary>
     bool SupportsCancellation => false;
 }

--- a/src/VirtoCommerce.Platform.Core/Jobs/IBackgroundJob.cs
+++ b/src/VirtoCommerce.Platform.Core/Jobs/IBackgroundJob.cs
@@ -6,77 +6,20 @@ using System.Threading.Tasks;
 namespace VirtoCommerce.Platform.Core.Jobs;
 
 /// <summary>
-/// Developer-facing facade to enqueue background work (engine-agnostic). The active implementation is provided by
-/// an installed background-job engine module (e.g. <c>VirtoCommerce.BackgroundJobs</c>). When no engine is
-/// installed, a fallback is registered that throws <see cref="BackgroundJobEngineNotInstalledException"/> with
-/// actionable installation instructions.
-/// <para>
-/// Inject this to enqueue work; implement <see cref="IBackgroundJobHandler{TPayload}"/> to handle a payload.
-/// </para>
+/// Developer-facing facade to enqueue background work (engine-agnostic).
 /// </summary>
 public interface IBackgroundJob
 {
-    /// <summary>
-    /// Enqueue a message-based job: <typeparamref name="THandler"/> processes the supplied <paramref name="payload"/>
-    /// on the active engine (Hangfire, RabbitMQ, …), with or without progress (see
-    /// <see cref="EnqueueOptions.ReportProgress"/>). Naming the handler makes the enqueue self-documenting and lets
-    /// several handlers share one payload type. The payload is validated against the handler at enqueue time:
-    /// <typeparamref name="THandler"/> must implement <see cref="IBackgroundJobHandler{TPayload}"/> for the payload's
-    /// runtime type, otherwise this throws.
-    /// </summary>
-    /// <typeparam name="THandler">The handler that will run the payload.</typeparam>
-    /// <param name="payload">The serializable payload instance; its runtime type selects the handler's payload contract.</param>
-    /// <param name="options">Per-enqueue options (queue, title, progress, retries, unique key).</param>
-    /// <param name="cancellationToken">Cancels the enqueue operation.</param>
-    /// <returns>The engine-specific job id.</returns>
     Task<string> Enqueue<THandler>(object payload, EnqueueOptions? options = null,
         CancellationToken cancellationToken = default)
         where THandler : class;
 
-    /// <summary>
-    /// Non-generic overload of <see cref="Enqueue{THandler}"/> for callers that only have the handler
-    /// <see cref="Type"/> at runtime — e.g. a REST "run by name" endpoint that resolved a registered
-    /// <see cref="BackgroundJobDescriptor"/>. <paramref name="handlerType"/> must be a concrete class implementing
-    /// <see cref="IBackgroundJobHandler{TPayload}"/> for the payload's runtime type, otherwise this throws.
-    /// </summary>
-    /// <param name="handlerType">The concrete handler type that will run the payload.</param>
-    /// <param name="payload">The serializable payload instance; its runtime type selects the handler's payload contract.</param>
-    /// <param name="options">Per-enqueue options (queue, title, progress, retries, unique key).</param>
-    /// <param name="cancellationToken">Cancels the enqueue operation.</param>
-    /// <returns>The engine-specific job id.</returns>
-    /// <remarks>
-    /// A default (throwing) implementation is provided so this member can be added without breaking existing external
-    /// implementers of <see cref="IBackgroundJob"/>; the platform's facade overrides it with the real behavior.
-    /// </remarks>
     Task<string> Enqueue(Type handlerType, object payload, EnqueueOptions? options = null,
         CancellationToken cancellationToken = default)
         => throw new NotSupportedException(
             $"This {nameof(IBackgroundJob)} implementation does not support the non-generic Enqueue(Type, ...) overload.");
 
-    /// <summary>
-    /// Request cancellation of a previously enqueued job. Best-effort and engine-dependent: an engine with a job store
-    /// (Hangfire) removes a job that has not started and aborts a running one, while a queue engine that cannot recall
-    /// a published message (RabbitMQ) records the request so the worker discards the message on dequeue, or trips the
-    /// running handler's <see cref="CancellationToken"/>. Either way the handler must honor the token it is given —
-    /// cancellation asks work to stop, it does not kill a thread.
-    /// </summary>
-    /// <param name="jobId">The engine-specific job id returned by one of the <c>Enqueue</c> overloads.</param>
-    /// <param name="cancellationToken">Cancels the cancel request itself, not the job.</param>
-    /// <returns>
-    /// <c>true</c> when the request was accepted, <c>false</c> when there was nothing to cancel. Check
-    /// <see cref="SupportsCancellation"/> first to tell "nothing to cancel" apart from "this engine cannot cancel".
-    /// </returns>
-    /// <remarks>
-    /// A default implementation returning <c>false</c> is provided so this member can be added without breaking
-    /// existing external implementers of <see cref="IBackgroundJob"/>.
-    /// </remarks>
     Task<bool> Cancel(string jobId, CancellationToken cancellationToken = default) => Task.FromResult(false);
 
-    /// <summary>
-    /// Whether the active engine can cancel a job on demand. <c>false</c> when no engine is installed, or when the
-    /// installed one has no way to stop work already handed to a worker. Probe this before offering cancellation in a
-    /// UI or an API, so an engine that cannot cancel degrades visibly (a disabled button, a <c>501</c>) instead of
-    /// answering a cancel request that does nothing.
-    /// </summary>
     bool SupportsCancellation => false;
 }

--- a/src/VirtoCommerce.Platform.Core/Jobs/IRecurringJobScheduleBuilder.cs
+++ b/src/VirtoCommerce.Platform.Core/Jobs/IRecurringJobScheduleBuilder.cs
@@ -26,6 +26,13 @@ public interface IRecurringJobScheduleBuilder
     /// <summary>Target queue for the enqueued payload (falls back to the configured default queue when unset).</summary>
     IRecurringJobScheduleBuilder WithQueue(string queue);
 
+    /// <summary>
+    /// Maximum automatic retry attempts for each occurrence (falls back to the engine-wide default when unset).
+    /// Pass <c>0</c> for a job that must not be retried — a scheduled run that failed is superseded by the next
+    /// occurrence anyway, and retrying it only duplicates work.
+    /// </summary>
+    IRecurringJobScheduleBuilder WithMaxRetryAttempts(int maxRetryAttempts);
+
     /// <summary>Time zone the cron expression is evaluated in (defaults to UTC).</summary>
     IRecurringJobScheduleBuilder WithTimeZone(TimeZoneInfo timeZone);
 

--- a/src/VirtoCommerce.Platform.Core/Jobs/RecurringJobScheduleBuilder.cs
+++ b/src/VirtoCommerce.Platform.Core/Jobs/RecurringJobScheduleBuilder.cs
@@ -14,6 +14,7 @@ internal sealed class RecurringJobScheduleBuilder : IRecurringJobScheduleBuilder
     private SettingDescriptor? _enablerSetting;
     private SettingDescriptor? _cronSetting;
     private string? _queue;
+    private int? _maxRetryAttempts;
     private TimeZoneInfo _timeZone = TimeZoneInfo.Utc;
     private bool _enabled = true;
 
@@ -39,6 +40,14 @@ internal sealed class RecurringJobScheduleBuilder : IRecurringJobScheduleBuilder
     public IRecurringJobScheduleBuilder WithQueue(string queue)
     {
         _queue = queue;
+        return this;
+    }
+
+    public IRecurringJobScheduleBuilder WithMaxRetryAttempts(int maxRetryAttempts)
+    {
+        ArgumentOutOfRangeException.ThrowIfNegative(maxRetryAttempts);
+
+        _maxRetryAttempts = maxRetryAttempts;
         return this;
     }
 
@@ -78,7 +87,9 @@ internal sealed class RecurringJobScheduleBuilder : IRecurringJobScheduleBuilder
                 $"Recurring job '{_id}' must use either WithCron(...) or FromSettings(...), not both — they are mutually exclusive.");
         }
 
-        var options = _queue is null ? null : new EnqueueOptions { Queue = _queue };
+        var options = _queue is null && _maxRetryAttempts is null
+            ? null
+            : new EnqueueOptions { Queue = _queue, MaxRetryAttempts = _maxRetryAttempts };
 
         return new RecurringJobRegistration
         {

--- a/tests/VirtoCommerce.Platform.Core.Tests/Jobs/RecurringJobScheduleBuilderTests.cs
+++ b/tests/VirtoCommerce.Platform.Core.Tests/Jobs/RecurringJobScheduleBuilderTests.cs
@@ -1,0 +1,107 @@
+#nullable enable
+using System;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.Extensions.DependencyInjection;
+using VirtoCommerce.Platform.Core.Jobs;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Core.Tests.Jobs;
+
+/// <summary>
+/// Exercises the recurring-schedule builder through its public surface: what a schedule declares must reach the
+/// <see cref="EnqueueOptions"/> the registration passes to <see cref="IBackgroundJob"/> on each occurrence.
+/// </summary>
+public class RecurringJobScheduleBuilderTests
+{
+    private class TestPayload
+    {
+    }
+
+    private sealed class TestHandler : IBackgroundJobHandler<TestPayload>
+    {
+        public Task Execute(TestPayload payload, IJobExecutionContext context, CancellationToken cancellationToken = default)
+            => Task.CompletedTask;
+    }
+
+    /// <summary>Records the options a triggered occurrence enqueues with.</summary>
+    private sealed class RecordingBackgroundJob : IBackgroundJob
+    {
+        public EnqueueOptions? Options { get; private set; }
+
+        public bool Enqueued { get; private set; }
+
+        public Task<string> Enqueue<THandler>(object payload, EnqueueOptions? options = null,
+            CancellationToken cancellationToken = default)
+            where THandler : class
+        {
+            Options = options;
+            Enqueued = true;
+            return Task.FromResult("job-1");
+        }
+    }
+
+    private static async Task<RecordingBackgroundJob> TriggerOnce(Action<IRecurringJobScheduleBuilder> configure)
+    {
+        var services = new ServiceCollection();
+        services.AddRecurringJob<TestHandler, TestPayload>(configure);
+
+        using var provider = services.BuildServiceProvider();
+        var registration = provider.GetServices<RecurringJobRegistration>().Single();
+
+        var jobs = new RecordingBackgroundJob();
+        await registration.Trigger(jobs, TestContext.Current.CancellationToken);
+
+        return jobs;
+    }
+
+    [Fact]
+    public async Task WithMaxRetryAttempts_Reaches_The_Enqueue_Options()
+    {
+        var jobs = await TriggerOnce(schedule => schedule
+            .WithId("test-job")
+            .WithCron("0 * * * *")
+            .WithMaxRetryAttempts(0));
+
+        Assert.True(jobs.Enqueued);
+        Assert.Equal(0, jobs.Options?.MaxRetryAttempts);
+    }
+
+    [Fact]
+    public async Task WithMaxRetryAttempts_Combines_With_WithQueue()
+    {
+        var jobs = await TriggerOnce(schedule => schedule
+            .WithId("test-job")
+            .WithCron("0 * * * *")
+            .WithQueue("low")
+            .WithMaxRetryAttempts(2));
+
+        Assert.Equal("low", jobs.Options?.Queue);
+        Assert.Equal(2, jobs.Options?.MaxRetryAttempts);
+    }
+
+    [Fact]
+    public async Task Schedule_Without_Queue_Or_Retries_Enqueues_With_No_Options()
+    {
+        // Null, not an empty options object: the engine must apply its own defaults for both.
+        var jobs = await TriggerOnce(schedule => schedule
+            .WithId("test-job")
+            .WithCron("0 * * * *"));
+
+        Assert.True(jobs.Enqueued);
+        Assert.Null(jobs.Options);
+    }
+
+    [Fact]
+    public void WithMaxRetryAttempts_Rejects_A_Negative_Count()
+    {
+        var services = new ServiceCollection();
+
+        Assert.Throws<ArgumentOutOfRangeException>(() =>
+            services.AddRecurringJob<TestHandler, TestPayload>(schedule => schedule
+                .WithId("test-job")
+                .WithCron("0 * * * *")
+                .WithMaxRetryAttempts(-1)));
+    }
+}


### PR DESCRIPTION
Add on-demand job cancellation to the engine-agnostic background-jobs API.

Two default interface members on IBackgroundJob, plus the static BackgroundJob counterparts:

```cs
Task<bool> Cancel(string jobId, CancellationToken ct = default);  // default: false
bool SupportsCancellation { get; }
```

## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5686
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> New cancellation API is opt-in via default interface members, but callers may misread `false` from `Cancel` without checking `SupportsCancellation`; recurring retry limits change failure behavior for scheduled jobs.
> 
> **Overview**
> Extends the engine-agnostic background jobs surface so callers can **cancel a job by id** and discover whether the active engine supports that, without breaking engines that do not implement it yet.
> 
> `IBackgroundJob` gains default members `Cancel` (returns `false`) and `SupportsCancellation` (`false`); the static `BackgroundJob` facade adds matching `Cancel` and `SupportsCancellation` (uninitialized static facade reports no support). Interface XML on enqueue overloads is trimmed.
> 
> Recurring schedules can now set **per-occurrence max retry attempts** via `WithMaxRetryAttempts` on the schedule builder; values flow into `EnqueueOptions` (combined with queue, or `null` options when neither is set). Unit tests cover retry/queue wiring and negative retry counts.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 8dc132099b48546130a87db233303a5e0d446406. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1065.0-pr-3097-8dc1-vcst-5686-8dc13209