### PR TITLE
VCST-5450: Supported dictionary settings and tenant scope in settings v2 API

### DIFF
--- a/src/VirtoCommerce.Platform.Data/Settings/SettingsPropertyService.cs
+++ b/src/VirtoCommerce.Platform.Data/Settings/SettingsPropertyService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
 using System.Text.Json;
@@ -86,13 +87,36 @@ namespace VirtoCommerce.Platform.Data.Settings
                 descriptors = descriptors.Where(x => x.ModuleId == moduleId);
             }
 
-            var names = descriptors.Select(x => x.Name).ToArray();
+            var descriptorList = descriptors.ToList();
+            var names = descriptorList.Select(x => x.Name).ToArray();
+            var descriptorsByName = descriptorList.ToDictionary(x => x.Name, StringComparer.OrdinalIgnoreCase);
 
             var settings = await _settingsManager.GetObjectSettingsAsync(names, tenantType, tenantId);
             var result = new Dictionary<string, object>(StringComparer.OrdinalIgnoreCase);
 
             foreach (var setting in settings)
             {
+                if (setting.IsDictionary)
+                {
+                    var descriptorAllowedValues = descriptorsByName.TryGetValue(setting.Name, out var descriptor)
+                        ? descriptor.AllowedValues
+                        : null;
+
+                    if (modifiedOnly)
+                    {
+                        if (!ArrayValuesEqual(setting.AllowedValues, descriptorAllowedValues))
+                        {
+                            result[setting.Name] = setting.AllowedValues ?? [];
+                        }
+                    }
+                    else
+                    {
+                        result[setting.Name] = setting.AllowedValues ?? [];
+                    }
+
+                    continue;
+                }
+
                 var value = setting.Value ?? setting.DefaultValue;
 
                 if (modifiedOnly)
@@ -144,10 +168,18 @@ namespace VirtoCommerce.Platform.Data.Settings
 
                 var entry = new ObjectSettingEntry(descriptor)
                 {
-                    Value = ConvertValue(kvp.Value, descriptor.ValueType),
                     ObjectType = tenantType,
                     ObjectId = tenantId
                 };
+
+                if (descriptor.IsDictionary)
+                {
+                    entry.AllowedValues = ConvertArrayValue(kvp.Value, descriptor.ValueType);
+                }
+                else
+                {
+                    entry.Value = ConvertValue(kvp.Value, descriptor.ValueType);
+                }
 
                 settingsToSave.Add(entry);
             }
@@ -293,6 +325,47 @@ namespace VirtoCommerce.Platform.Data.Settings
                 SettingValueType.Decimal => Convert.ToDecimal(value),
                 _ => value.ToString()
             };
+        }
+
+        private static object[] ConvertArrayValue(object value, SettingValueType valueType)
+        {
+            if (value == null)
+            {
+                return [];
+            }
+
+            if (value is JArray jArray)
+            {
+                return jArray.Select(x => ConvertValue(x, valueType)).ToArray();
+            }
+
+            if (value is JsonElement { ValueKind: JsonValueKind.Array } jsonElement)
+            {
+                return jsonElement.EnumerateArray().Select(x => ConvertValue(x, valueType)).ToArray();
+            }
+
+            if (value is IEnumerable enumerable && value is not string)
+            {
+                return enumerable.Cast<object>().Select(x => ConvertValue(x, valueType)).ToArray();
+            }
+
+            return [ConvertValue(value, valueType)];
+        }
+
+        private static bool ArrayValuesEqual(object[] current, object[] defaultValues)
+        {
+            current ??= [];
+            defaultValues ??= [];
+
+            if (current.Length != defaultValues.Length)
+            {
+                return false;
+            }
+
+            var currentSorted = current.Select(x => x?.ToString()).OrderBy(x => x, StringComparer.Ordinal);
+            var defaultSorted = defaultValues.Select(x => x?.ToString()).OrderBy(x => x, StringComparer.Ordinal);
+
+            return currentSorted.SequenceEqual(defaultSorted, StringComparer.Ordinal);
         }
     }
 }

--- a/src/VirtoCommerce.Platform.Data/Settings/SettingsPropertyService.cs
+++ b/src/VirtoCommerce.Platform.Data/Settings/SettingsPropertyService.cs
@@ -96,44 +96,55 @@ namespace VirtoCommerce.Platform.Data.Settings
 
             foreach (var setting in settings)
             {
-                if (setting.IsDictionary)
-                {
-                    var descriptorAllowedValues = descriptorsByName.TryGetValue(setting.Name, out var descriptor)
-                        ? descriptor.AllowedValues
-                        : null;
+                descriptorsByName.TryGetValue(setting.Name, out var descriptor);
 
-                    if (modifiedOnly)
-                    {
-                        if (!ArrayValuesEqual(setting.AllowedValues, descriptorAllowedValues))
-                        {
-                            result[setting.Name] = setting.AllowedValues ?? [];
-                        }
-                    }
-                    else
-                    {
-                        result[setting.Name] = setting.AllowedValues ?? [];
-                    }
-
-                    continue;
-                }
-
-                var value = setting.Value ?? setting.DefaultValue;
-
-                if (modifiedOnly)
-                {
-                    // Only include if value differs from default
-                    if (!ValuesEqual(value, setting.DefaultValue))
-                    {
-                        result[setting.Name] = setting.Value;
-                    }
-                }
-                else
+                if (TryResolveValue(setting, descriptor, modifiedOnly, out var value))
                 {
                     result[setting.Name] = value;
                 }
             }
 
             return result;
+        }
+
+        private static bool TryResolveValue(ObjectSettingEntry setting, SettingDescriptor descriptor, bool modifiedOnly, out object value)
+        {
+            return setting.IsDictionary
+                ? TryResolveDictionaryValue(setting, descriptor, modifiedOnly, out value)
+                : TryResolveScalarValue(setting, modifiedOnly, out value);
+        }
+
+        private static bool TryResolveDictionaryValue(ObjectSettingEntry setting, SettingDescriptor descriptor, bool modifiedOnly, out object value)
+        {
+            if (modifiedOnly && ArrayValuesEqual(setting.AllowedValues, descriptor?.AllowedValues))
+            {
+                value = null;
+                return false;
+            }
+
+            value = setting.AllowedValues ?? [];
+            return true;
+        }
+
+        private static bool TryResolveScalarValue(ObjectSettingEntry setting, bool modifiedOnly, out object value)
+        {
+            var effectiveValue = setting.Value ?? setting.DefaultValue;
+
+            if (modifiedOnly)
+            {
+                // Only include if value differs from default
+                if (ValuesEqual(effectiveValue, setting.DefaultValue))
+                {
+                    value = null;
+                    return false;
+                }
+
+                value = setting.Value;
+                return true;
+            }
+
+            value = effectiveValue;
+            return true;
         }
 
         public async Task SaveValuesAsync(
@@ -148,60 +159,14 @@ namespace VirtoCommerce.Platform.Data.Settings
                 .ToDictionary(x => x.Name, x => x, StringComparer.OrdinalIgnoreCase);
 
             var typeAssignments = _settingsManager.GetSettingTypeAssignments();
-            var settingsToSave = new List<ObjectSettingEntry>();
+            var settingsToSave = values
+                .Select(kvp => BuildSettingEntry(kvp.Key, kvp.Value, allDescriptors, typeAssignments, tenantType, tenantId))
+                .ToList();
 
-            foreach (var kvp in values)
-            {
-                if (!allDescriptors.TryGetValue(kvp.Key, out var descriptor))
-                {
-                    throw new InvalidOperationException($"Unknown setting: '{kvp.Key}'");
-                }
-
-                // Validate scope: tenant-assigned settings should only be saved with a tenant scope,
-                // and global-only settings should not be saved with a tenant scope
-                var isAssignedToTenant = typeAssignments.ContainsKey(kvp.Key);
-                if (!string.IsNullOrEmpty(tenantType) && !isAssignedToTenant)
-                {
-                    throw new InvalidOperationException(
-                        $"Setting '{kvp.Key}' is not registered for tenant type '{tenantType}'");
-                }
-
-                var entry = new ObjectSettingEntry(descriptor)
-                {
-                    ObjectType = tenantType,
-                    ObjectId = tenantId
-                };
-
-                if (descriptor.IsDictionary)
-                {
-                    entry.AllowedValues = ConvertArrayValue(kvp.Value, descriptor.ValueType);
-                }
-                else
-                {
-                    entry.Value = ConvertValue(kvp.Value, descriptor.ValueType);
-                }
-
-                settingsToSave.Add(entry);
-            }
-
-            // replaceAll mode: the incoming dict is the complete set of desired modifications.
-            // Any currently-modified setting NOT in the dict should be reset to default (DB row deleted).
             if (replaceAll)
             {
-                var currentModified = await GetValuesAsync(tenantType, tenantId, modifiedOnly: true);
                 var incomingNames = new HashSet<string>(values.Keys, StringComparer.OrdinalIgnoreCase);
-
-                var settingsToReset = currentModified.Keys
-                    .Where(name => !incomingNames.Contains(name))
-                    .Select(name =>
-                    {
-                        allDescriptors.TryGetValue(name, out var desc);
-                        return desc != null
-                            ? new ObjectSettingEntry(desc) { ObjectType = tenantType, ObjectId = tenantId }
-                            : null;
-                    })
-                    .Where(x => x != null)
-                    .ToList();
+                var settingsToReset = await ResolveSettingsToResetAsync(tenantType, tenantId, allDescriptors, incomingNames);
 
                 if (settingsToReset.Count > 0)
                 {
@@ -213,6 +178,66 @@ namespace VirtoCommerce.Platform.Data.Settings
             {
                 await _settingsManager.SaveObjectSettingsAsync(settingsToSave);
             }
+        }
+
+        private static ObjectSettingEntry BuildSettingEntry(
+            string name,
+            object rawValue,
+            IReadOnlyDictionary<string, SettingDescriptor> allDescriptors,
+            IDictionary<string, string[]> typeAssignments,
+            string tenantType,
+            string tenantId)
+        {
+            if (!allDescriptors.TryGetValue(name, out var descriptor))
+            {
+                throw new InvalidOperationException($"Unknown setting: '{name}'");
+            }
+
+            // Validate scope: tenant-assigned settings should only be saved with a tenant scope,
+            // and global-only settings should not be saved with a tenant scope
+            if (!string.IsNullOrEmpty(tenantType) && !typeAssignments.ContainsKey(name))
+            {
+                throw new InvalidOperationException($"Setting '{name}' is not registered for tenant type '{tenantType}'");
+            }
+
+            var entry = new ObjectSettingEntry(descriptor)
+            {
+                ObjectType = tenantType,
+                ObjectId = tenantId
+            };
+
+            if (descriptor.IsDictionary)
+            {
+                entry.AllowedValues = ConvertArrayValue(rawValue, descriptor.ValueType);
+            }
+            else
+            {
+                entry.Value = ConvertValue(rawValue, descriptor.ValueType);
+            }
+
+            return entry;
+        }
+
+        private async Task<List<ObjectSettingEntry>> ResolveSettingsToResetAsync(
+            string tenantType,
+            string tenantId,
+            IReadOnlyDictionary<string, SettingDescriptor> allDescriptors,
+            HashSet<string> incomingNames)
+        {
+            var currentModified = await GetValuesAsync(tenantType, tenantId, modifiedOnly: true);
+            var settingsToReset = new List<ObjectSettingEntry>();
+
+            foreach (var name in currentModified.Keys)
+            {
+                if (incomingNames.Contains(name) || !allDescriptors.TryGetValue(name, out var descriptor))
+                {
+                    continue;
+                }
+
+                settingsToReset.Add(new ObjectSettingEntry(descriptor) { ObjectType = tenantType, ObjectId = tenantId });
+            }
+
+            return settingsToReset;
         }
 
         private IEnumerable<SettingDescriptor> GetDescriptors(string tenantType)

--- a/src/VirtoCommerce.Platform.Data/Settings/SettingsPropertyService.cs
+++ b/src/VirtoCommerce.Platform.Data/Settings/SettingsPropertyService.cs
@@ -183,7 +183,7 @@ namespace VirtoCommerce.Platform.Data.Settings
         private static ObjectSettingEntry BuildSettingEntry(
             string name,
             object rawValue,
-            IReadOnlyDictionary<string, SettingDescriptor> allDescriptors,
+            Dictionary<string, SettingDescriptor> allDescriptors,
             IDictionary<string, string[]> typeAssignments,
             string tenantType,
             string tenantId)
@@ -221,7 +221,7 @@ namespace VirtoCommerce.Platform.Data.Settings
         private async Task<List<ObjectSettingEntry>> ResolveSettingsToResetAsync(
             string tenantType,
             string tenantId,
-            IReadOnlyDictionary<string, SettingDescriptor> allDescriptors,
+            Dictionary<string, SettingDescriptor> allDescriptors,
             HashSet<string> incomingNames)
         {
             var currentModified = await GetValuesAsync(tenantType, tenantId, modifiedOnly: true);

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/settings/blades/setting-dictionary.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/settings/blades/setting-dictionary.js
@@ -1,9 +1,36 @@
-angular.module('platformWebApp').controller('platformWebApp.settingDictionaryController', ['$scope', 'platformWebApp.dialogService', 'platformWebApp.bladeNavigationService', 'platformWebApp.settings', function ($scope, dialogService, bladeNavigationService, settingsApi) {
+angular.module('platformWebApp').controller('platformWebApp.settingDictionaryController', ['$scope', 'platformWebApp.dialogService', 'platformWebApp.bladeNavigationService', 'platformWebApp.settings', 'platformWebApp.settingsV2', function ($scope, dialogService, bladeNavigationService, settingsApi, settingsV2) {
     var blade = $scope.blade;
     blade.updatePermission = 'platform:setting:update';
     var currentEntities;
 
+    function refreshViaTenantV2(parentRefresh) {
+        settingsV2.getTenantValues({ tenantType: blade.tenantType, tenantId: blade.tenantId }).$promise.then(function (values) {
+            var allowedValues = values[blade.currentEntityId] || [];
+
+            if (parentRefresh && blade.parentRefresh) {
+                blade.parentRefresh(allowedValues);
+            }
+
+            var settings = {
+                name: blade.currentEntityId,
+                valueType: blade.valueType,
+                isReadOnly: blade.isReadOnly,
+                allowedValues: _.map(allowedValues, function (x) { return { value: x }; })
+            };
+
+            initializeBlade(settings, { allowedValues: angular.copy(settings.allowedValues) });
+        }, function (error) {
+            blade.isLoading = false;
+            bladeNavigationService.setError('Error ' + error.status, $scope.blade);
+        });
+    }
+
     blade.refresh = function (parentRefresh) {
+        if (blade.tenantType && blade.tenantId) {
+            refreshViaTenantV2(parentRefresh);
+            return;
+        }
+
         settingsApi.get({ id: blade.currentEntityId }, function (settings) {
             if (parentRefresh && blade.parentRefresh) {
                 blade.parentRefresh(settings.allowedValues);
@@ -119,6 +146,17 @@ angular.module('platformWebApp').controller('platformWebApp.settingDictionaryCon
             blade.selectedAll = false;
             blade.isLoading = true;
             blade.currentEntity.allowedValues = _.pluck(blade.currentEntity.allowedValues, 'value');
+
+            if (blade.tenantType && blade.tenantId) {
+                var values = {};
+                values[blade.currentEntityId] = blade.currentEntity.allowedValues;
+
+                settingsV2.saveTenantValues({ tenantType: blade.tenantType, tenantId: blade.tenantId }, values, blade.refresh, function (error) {
+                    bladeNavigationService.setError('Error ' + error.status, $scope.blade);
+                });
+
+                return;
+            }
 
             settingsApi.update(null, [blade.currentEntity], blade.refresh, function (error) {
                 bladeNavigationService.setError('Error ' + error.status, $scope.blade);

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/settings/blades/setting-dictionary.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/settings/blades/setting-dictionary.js
@@ -1,4 +1,8 @@
-angular.module('platformWebApp').controller('platformWebApp.settingDictionaryController', ['$scope', 'platformWebApp.dialogService', 'platformWebApp.bladeNavigationService', 'platformWebApp.settings', 'platformWebApp.settingsV2', function ($scope, dialogService, bladeNavigationService, settingsApi, settingsV2) {
+angular.module('platformWebApp')
+    .controller('platformWebApp.settingDictionaryController', [
+        '$scope', 'platformWebApp.dialogService', 'platformWebApp.bladeNavigationService',
+        'platformWebApp.settings', 'platformWebApp.settingsV2',
+        function ($scope, dialogService, bladeNavigationService, settingsApi, settingsV2) {
     var blade = $scope.blade;
     blade.updatePermission = 'platform:setting:update';
     var currentEntities;

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/settings/blades/settings-unified.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/settings/blades/settings-unified.js
@@ -577,14 +577,15 @@ angular.module('platformWebApp')
                     valueType: node.valueType,
                     isReadOnly: node.isReadOnly,
                     parentRefresh: blade.refresh,
+                    // Pass tenant scope through regardless of isEntityMode: entity mode (opened from
+                    // an entity's own "Settings" widget, e.g. a Store) still has blade.tenantType/tenantId
+                    // set by the widget, and the child blade needs them to save to the right scope instead
+                    // of silently falling back to the legacy global-only v1 API.
+                    tenantType: blade.tenantType,
+                    tenantId: blade.tenantId,
                     controller: 'platformWebApp.settingDictionaryController',
                     template: '$(Platform)/Scripts/app/settings/blades/setting-dictionary.tpl.html'
                 };
-
-                if (!blade.isEntityMode) {
-                    newBlade.tenantType = blade.tenantType;
-                    newBlade.tenantId = blade.tenantId;
-                }
 
                 bladeNavigationService.showBlade(newBlade, blade);
             };

--- a/src/VirtoCommerce.Platform.Web/wwwroot/js/app/settings/blades/settings-unified.js
+++ b/src/VirtoCommerce.Platform.Web/wwwroot/js/app/settings/blades/settings-unified.js
@@ -568,13 +568,24 @@ angular.module('platformWebApp')
                 var newBlade = {
                     id: 'settingDetailChild',
                     currentEntityId: node.name,
-                    // isApiSave tells the dictionary controller to load/save via the v1 API
-                    // (settingsApi.get/update). Without this flag, it watches
-                    // parentBlade.currentEntities which doesn't exist in the unified blade.
+                    // isApiSave tells the dictionary controller to load/save via the API
+                    // (v2 tenant/global values when tenantType/tenantId are set below, else
+                    // the legacy v1 settingsApi.get/update global-only endpoints).
+                    // Without this flag, it watches parentBlade.currentEntities which
+                    // doesn't exist in the unified blade.
                     isApiSave: true,
+                    valueType: node.valueType,
+                    isReadOnly: node.isReadOnly,
+                    parentRefresh: blade.refresh,
                     controller: 'platformWebApp.settingDictionaryController',
                     template: '$(Platform)/Scripts/app/settings/blades/setting-dictionary.tpl.html'
                 };
+
+                if (!blade.isEntityMode) {
+                    newBlade.tenantType = blade.tenantType;
+                    newBlade.tenantId = blade.tenantId;
+                }
+
                 bladeNavigationService.showBlade(newBlade, blade);
             };
 

--- a/tests/VirtoCommerce.Platform.Tests/UnitTests/SettingsPropertyServiceTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/UnitTests/SettingsPropertyServiceTests.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
@@ -114,6 +115,91 @@ namespace VirtoCommerce.Platform.Tests.UnitTests
             result.Should().BeEmpty();
         }
 
+        [Fact]
+        public async Task GetValuesAsync_DictionarySetting_ReturnsAllowedValuesArray()
+        {
+            var descriptors = new[]
+            {
+                NewDictionaryDescriptor("VirtoCommerce.ModuleA.Roles", ModuleA, "role-a", "role-b"),
+            };
+
+            var service = NewService(descriptors);
+
+            var result = await service.GetValuesAsync();
+
+            result["VirtoCommerce.ModuleA.Roles"].Should().BeEquivalentTo(new object[] { "role-a", "role-b" });
+        }
+
+        [Fact]
+        public async Task GetValuesAsync_DictionarySetting_ModifiedOnly_ExcludesUnchangedFromDefault()
+        {
+            var descriptors = new[]
+            {
+                NewDictionaryDescriptor("VirtoCommerce.ModuleA.Roles", ModuleA, "role-a", "role-b"),
+            };
+
+            var service = NewService(descriptors);
+
+            var result = await service.GetValuesAsync(modifiedOnly: true);
+
+            result.Should().NotContainKey("VirtoCommerce.ModuleA.Roles");
+        }
+
+        [Fact]
+        public async Task GetValuesAsync_DictionarySetting_ModifiedOnly_ExcludesEquivalentButDistinctArrayInstance()
+        {
+            var descriptors = new[]
+            {
+                NewDictionaryDescriptor("VirtoCommerce.ModuleA.Roles", ModuleA, "role-a", "role-b"),
+            };
+
+            var service = NewService(
+                descriptors,
+                allowedValueOverrides: new Dictionary<string, object[]> { ["VirtoCommerce.ModuleA.Roles"] = ["role-b", "role-a"] });
+
+            var result = await service.GetValuesAsync(modifiedOnly: true);
+
+            result.Should().NotContainKey("VirtoCommerce.ModuleA.Roles");
+        }
+
+        [Fact]
+        public async Task GetValuesAsync_DictionarySetting_ModifiedOnly_IncludesOverriddenSubset()
+        {
+            var descriptors = new[]
+            {
+                NewDictionaryDescriptor("VirtoCommerce.ModuleA.Roles", ModuleA, "role-a", "role-b"),
+            };
+
+            var service = NewService(
+                descriptors,
+                allowedValueOverrides: new Dictionary<string, object[]> { ["VirtoCommerce.ModuleA.Roles"] = ["role-a"] });
+
+            var result = await service.GetValuesAsync(modifiedOnly: true);
+
+            result["VirtoCommerce.ModuleA.Roles"].Should().BeEquivalentTo(new object[] { "role-a" });
+        }
+
+        [Fact]
+        public async Task SaveValuesAsync_DictionarySetting_SavesAsAllowedValues_NotValue()
+        {
+            var descriptors = new[]
+            {
+                NewDictionaryDescriptor("VirtoCommerce.ModuleA.Roles", ModuleA, "role-a", "role-b"),
+            };
+
+            List<ObjectSettingEntry> savedEntries = null;
+            var service = NewService(descriptors, onSave: entries => savedEntries = entries.ToList());
+
+            await service.SaveValuesAsync(new Dictionary<string, object>
+            {
+                ["VirtoCommerce.ModuleA.Roles"] = new object[] { "role-a" },
+            });
+
+            savedEntries.Should().ContainSingle();
+            savedEntries[0].AllowedValues.Should().BeEquivalentTo(new object[] { "role-a" });
+            savedEntries[0].Value.Should().BeNull();
+        }
+
         // --- helpers ---
 
         private static SettingDescriptor NewDescriptor(string name, string moduleId, object defaultValue) => new()
@@ -130,6 +216,16 @@ namespace VirtoCommerce.Platform.Tests.UnitTests
             GroupName = $"{moduleId}|Default",
         };
 
+        private static SettingDescriptor NewDictionaryDescriptor(string name, string moduleId, params object[] allowedValues) => new()
+        {
+            Name = name,
+            ModuleId = moduleId,
+            ValueType = SettingValueType.ShortText,
+            IsDictionary = true,
+            AllowedValues = allowedValues,
+            GroupName = $"{moduleId}|Default",
+        };
+
         /// <summary>
         /// Build a <see cref="SettingsPropertyService"/> with the given
         /// descriptors as the registered universe. The settings manager
@@ -138,7 +234,15 @@ namespace VirtoCommerce.Platform.Tests.UnitTests
         /// which is the behaviour we need to assert the moduleId filter
         /// against without standing up a database.
         /// </summary>
-        private static SettingsPropertyService NewService(IEnumerable<SettingDescriptor> descriptors)
+        /// <param name="allowedValueOverrides">
+        /// Per-setting-name AllowedValues to return instead of the descriptor's own default —
+        /// simulates a saved per-object override for a dictionary setting.
+        /// </param>
+        /// <param name="onSave">Captures the entries passed to SaveObjectSettingsAsync, if set.</param>
+        private static SettingsPropertyService NewService(
+            IEnumerable<SettingDescriptor> descriptors,
+            Dictionary<string, object[]> allowedValueOverrides = null,
+            Action<IEnumerable<ObjectSettingEntry>> onSave = null)
         {
             var all = descriptors.ToList();
 
@@ -151,7 +255,8 @@ namespace VirtoCommerce.Platform.Tests.UnitTests
 
             // Materialise descriptors as ObjectSettingEntry copies — Value
             // unset, so SettingsPropertyService.GetValuesAsync falls back
-            // to DefaultValue (the path our tests exercise).
+            // to DefaultValue (the path our tests exercise), unless an
+            // AllowedValues override was supplied for that setting name.
             settingsManager
                 .Setup(x => x.GetObjectSettingsAsync(
                     It.IsAny<IEnumerable<string>>(),
@@ -161,8 +266,18 @@ namespace VirtoCommerce.Platform.Tests.UnitTests
                     names.Select(n =>
                     {
                         var d = all.First(x => x.Name == n);
-                        return new ObjectSettingEntry(d);
+                        var entry = new ObjectSettingEntry(d);
+                        if (allowedValueOverrides != null && allowedValueOverrides.TryGetValue(n, out var overrideValues))
+                        {
+                            entry.AllowedValues = overrideValues;
+                        }
+                        return entry;
                     }).ToList());
+
+            settingsManager
+                .Setup(x => x.SaveObjectSettingsAsync(It.IsAny<IEnumerable<ObjectSettingEntry>>()))
+                .Callback<IEnumerable<ObjectSettingEntry>>(entries => onSave?.Invoke(entries.ToList()))
+                .Returns(Task.CompletedTask);
 
             var overrideProvider = new Mock<ISettingsOverrideProvider>();
             object _ = null;


### PR DESCRIPTION
## Description
Infrastructure change enabling store-scoped dictionary (multi-value) settings in the Settings V2 API — a prerequisite for the customer module's per-store role whitelist, which needs to store/read a *list* of role names scoped to a specific store rather than a single scalar value.

## What was added
- **`SettingsPropertyService`**: `GetValuesAsync`/`SaveValuesAsync` now branch on `IsDictionary`, reading/writing the setting's `AllowedValues` array per tenant scope instead of assuming a single scalar `Value`; refactored into smaller resolve/build helper methods to keep Cognitive/Cyclomatic complexity within the repo's Sonar thresholds.
- **Backoffice `setting-dictionary.js`**: the dictionary-setting blade now supports store/tenant-scoped values (via `settingsV2`) in addition to existing global-only editing.
- **`settings-unified.js`**: routes dictionary-type settings through the same tenant-aware save path.

## Breaking changes
None — only internal/private helper methods were added or restructured; no public method signatures changed.

## Tests
- `SettingsPropertyServiceTests` extended to cover dictionary + tenant-scope read/write and default-value resolution

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5450
### Artifact URL:

Image tag:
ghcr.io/VirtoCommerce/platform:3.1063.0-pr-3098-057b-vcst-5450-057baf32