### PR TITLE
VCST-5387: Add binary sidecar export/import contracts

### DIFF
--- a/src/VirtoCommerce.Platform.Core/ExportImport/IExportBinaryDataSupport.cs
+++ b/src/VirtoCommerce.Platform.Core/ExportImport/IExportBinaryDataSupport.cs
@@ -1,0 +1,25 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VirtoCommerce.Platform.Core.ExportImport
+{
+    /// <summary>
+    /// Extends module export with sidecar binary entries while keeping the primary module payload readable.
+    /// </summary>
+    /// <remarks>
+    /// Export orchestrators use this optional contract when they can expose binary entries separately from the
+    /// primary module stream. Modules must continue to implement <see cref="IExportSupport"/> for compatibility
+    /// with orchestrators that do not support sidecar entries.
+    /// </remarks>
+    public interface IExportBinaryDataSupport : IExportSupport
+    {
+        Task ExportAsync(
+            Stream outStream,
+            IExportBinaryDataWriter binaryDataWriter,
+            ExportImportOptions options,
+            Action<ExportImportProgressInfo> progressCallback,
+            CancellationToken cancellationToken);
+    }
+}

--- a/src/VirtoCommerce.Platform.Core/ExportImport/IExportBinaryDataSupport.cs
+++ b/src/VirtoCommerce.Platform.Core/ExportImport/IExportBinaryDataSupport.cs
@@ -3,23 +3,22 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace VirtoCommerce.Platform.Core.ExportImport
+namespace VirtoCommerce.Platform.Core.ExportImport;
+
+/// <summary>
+/// Extends module export with sidecar binary entries while keeping the primary module payload readable.
+/// </summary>
+/// <remarks>
+/// Export orchestrators use this optional contract when they can expose binary entries separately from the
+/// primary module stream. Modules must continue to implement <see cref="IExportSupport"/> for compatibility
+/// with orchestrators that do not support sidecar entries.
+/// </remarks>
+public interface IExportBinaryDataSupport : IExportSupport
 {
-    /// <summary>
-    /// Extends module export with sidecar binary entries while keeping the primary module payload readable.
-    /// </summary>
-    /// <remarks>
-    /// Export orchestrators use this optional contract when they can expose binary entries separately from the
-    /// primary module stream. Modules must continue to implement <see cref="IExportSupport"/> for compatibility
-    /// with orchestrators that do not support sidecar entries.
-    /// </remarks>
-    public interface IExportBinaryDataSupport : IExportSupport
-    {
-        Task ExportAsync(
-            Stream outStream,
-            IExportBinaryDataWriter binaryDataWriter,
-            ExportImportOptions options,
-            Action<ExportImportProgressInfo> progressCallback,
-            CancellationToken cancellationToken);
-    }
+    Task ExportAsync(
+        Stream outStream,
+        IExportBinaryDataWriter binaryDataWriter,
+        ExportImportOptions options,
+        Action<ExportImportProgressInfo> progressCallback,
+        CancellationToken cancellationToken);
 }

--- a/src/VirtoCommerce.Platform.Core/ExportImport/IExportBinaryDataWriter.cs
+++ b/src/VirtoCommerce.Platform.Core/ExportImport/IExportBinaryDataWriter.cs
@@ -2,21 +2,20 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace VirtoCommerce.Platform.Core.ExportImport
+namespace VirtoCommerce.Platform.Core.ExportImport;
+
+/// <summary>
+/// Writes binary sidecar data to the export container owned by the export orchestrator.
+/// </summary>
+public interface IExportBinaryDataWriter
 {
     /// <summary>
-    /// Writes binary sidecar data to the export container owned by the export orchestrator.
+    /// Writes <paramref name="sourceStream"/> to the package entry identified by <paramref name="reference"/>.
     /// </summary>
-    public interface IExportBinaryDataWriter
-    {
-        /// <summary>
-        /// Writes <paramref name="sourceStream"/> to the package entry identified by <paramref name="reference"/>.
-        /// </summary>
-        /// <remarks>
-        /// References identify entries package-wide and use forward-slash separators. The writer validates the
-        /// reference and controls the lifetime of the package entry. The caller retains ownership of
-        /// <paramref name="sourceStream"/>.
-        /// </remarks>
-        Task WriteAsync(string reference, Stream sourceStream, CancellationToken cancellationToken);
-    }
+    /// <remarks>
+    /// References identify entries package-wide and use forward-slash separators. The writer validates the
+    /// reference and controls the lifetime of the package entry. The caller retains ownership of
+    /// <paramref name="sourceStream"/>.
+    /// </remarks>
+    Task WriteAsync(string reference, Stream sourceStream, CancellationToken cancellationToken);
 }

--- a/src/VirtoCommerce.Platform.Core/ExportImport/IExportBinaryDataWriter.cs
+++ b/src/VirtoCommerce.Platform.Core/ExportImport/IExportBinaryDataWriter.cs
@@ -1,0 +1,22 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VirtoCommerce.Platform.Core.ExportImport
+{
+    /// <summary>
+    /// Writes binary sidecar data to the export container owned by the export orchestrator.
+    /// </summary>
+    public interface IExportBinaryDataWriter
+    {
+        /// <summary>
+        /// Writes <paramref name="sourceStream"/> to the package entry identified by <paramref name="reference"/>.
+        /// </summary>
+        /// <remarks>
+        /// References identify entries package-wide and use forward-slash separators. The writer validates the
+        /// reference and controls the lifetime of the package entry. The caller retains ownership of
+        /// <paramref name="sourceStream"/>.
+        /// </remarks>
+        Task WriteAsync(string reference, Stream sourceStream, CancellationToken cancellationToken);
+    }
+}

--- a/src/VirtoCommerce.Platform.Core/ExportImport/IImportBinaryDataReader.cs
+++ b/src/VirtoCommerce.Platform.Core/ExportImport/IImportBinaryDataReader.cs
@@ -1,0 +1,19 @@
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VirtoCommerce.Platform.Core.ExportImport
+{
+    /// <summary>
+    /// Reads binary sidecar data from the import container owned by the import orchestrator.
+    /// </summary>
+    public interface IImportBinaryDataReader
+    {
+        /// <summary>
+        /// Opens the package entry identified by <paramref name="reference"/> for reading.
+        /// </summary>
+        /// <remarks>The caller owns and must dispose the returned stream.</remarks>
+        /// <returns>The readable entry stream, or <see langword="null"/> when the entry does not exist.</returns>
+        Task<Stream> OpenReadAsync(string reference, CancellationToken cancellationToken);
+    }
+}

--- a/src/VirtoCommerce.Platform.Core/ExportImport/IImportBinaryDataReader.cs
+++ b/src/VirtoCommerce.Platform.Core/ExportImport/IImportBinaryDataReader.cs
@@ -2,18 +2,17 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace VirtoCommerce.Platform.Core.ExportImport
+namespace VirtoCommerce.Platform.Core.ExportImport;
+
+/// <summary>
+/// Reads binary sidecar data from the import container owned by the import orchestrator.
+/// </summary>
+public interface IImportBinaryDataReader
 {
     /// <summary>
-    /// Reads binary sidecar data from the import container owned by the import orchestrator.
+    /// Opens the package entry identified by <paramref name="reference"/> for reading.
     /// </summary>
-    public interface IImportBinaryDataReader
-    {
-        /// <summary>
-        /// Opens the package entry identified by <paramref name="reference"/> for reading.
-        /// </summary>
-        /// <remarks>The caller owns and must dispose the returned stream.</remarks>
-        /// <returns>The readable entry stream, or <see langword="null"/> when the entry does not exist.</returns>
-        Task<Stream> OpenReadAsync(string reference, CancellationToken cancellationToken);
-    }
+    /// <remarks>The caller owns and must dispose the returned stream.</remarks>
+    /// <returns>The readable entry stream, or <see langword="null"/> when the entry does not exist.</returns>
+    Task<Stream> OpenReadAsync(string reference, CancellationToken cancellationToken);
 }

--- a/src/VirtoCommerce.Platform.Core/ExportImport/IImportBinaryDataSupport.cs
+++ b/src/VirtoCommerce.Platform.Core/ExportImport/IImportBinaryDataSupport.cs
@@ -3,22 +3,21 @@ using System.IO;
 using System.Threading;
 using System.Threading.Tasks;
 
-namespace VirtoCommerce.Platform.Core.ExportImport
+namespace VirtoCommerce.Platform.Core.ExportImport;
+
+/// <summary>
+/// Extends module import with access to binary sidecar entries stored next to the primary module payload.
+/// </summary>
+/// <remarks>
+/// Modules must continue to implement <see cref="IImportSupport"/> so legacy single-stream packages remain
+/// importable by orchestrators that do not support sidecar entries.
+/// </remarks>
+public interface IImportBinaryDataSupport : IImportSupport
 {
-    /// <summary>
-    /// Extends module import with access to binary sidecar entries stored next to the primary module payload.
-    /// </summary>
-    /// <remarks>
-    /// Modules must continue to implement <see cref="IImportSupport"/> so legacy single-stream packages remain
-    /// importable by orchestrators that do not support sidecar entries.
-    /// </remarks>
-    public interface IImportBinaryDataSupport : IImportSupport
-    {
-        Task ImportAsync(
-            Stream inputStream,
-            IImportBinaryDataReader binaryDataReader,
-            ExportImportOptions options,
-            Action<ExportImportProgressInfo> progressCallback,
-            CancellationToken cancellationToken);
-    }
+    Task ImportAsync(
+        Stream inputStream,
+        IImportBinaryDataReader binaryDataReader,
+        ExportImportOptions options,
+        Action<ExportImportProgressInfo> progressCallback,
+        CancellationToken cancellationToken);
 }

--- a/src/VirtoCommerce.Platform.Core/ExportImport/IImportBinaryDataSupport.cs
+++ b/src/VirtoCommerce.Platform.Core/ExportImport/IImportBinaryDataSupport.cs
@@ -1,0 +1,24 @@
+using System;
+using System.IO;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace VirtoCommerce.Platform.Core.ExportImport
+{
+    /// <summary>
+    /// Extends module import with access to binary sidecar entries stored next to the primary module payload.
+    /// </summary>
+    /// <remarks>
+    /// Modules must continue to implement <see cref="IImportSupport"/> so legacy single-stream packages remain
+    /// importable by orchestrators that do not support sidecar entries.
+    /// </remarks>
+    public interface IImportBinaryDataSupport : IImportSupport
+    {
+        Task ImportAsync(
+            Stream inputStream,
+            IImportBinaryDataReader binaryDataReader,
+            ExportImportOptions options,
+            Action<ExportImportProgressInfo> progressCallback,
+            CancellationToken cancellationToken);
+    }
+}


### PR DESCRIPTION
## Description

Adds optional streaming contracts to VirtoCommerce.Platform.Core.ExportImport for modules whose export contains a readable primary payload together with binary sidecar entries.

Previously an export module received only one output stream. A module that needed to include files therefore had to turn its <module>.json part into an opaque nested ZIP. That makes a backup difficult to inspect and prevents the archive owner, such as BackupRestore, from placing files in a normal top-level structure like assets/<sourceUrl>.

The new contracts preserve ownership of the export container:

- IExportBinaryDataSupport and IImportBinaryDataSupport let a module opt into the sidecar-aware flow.
- IExportBinaryDataWriter and IImportBinaryDataReader provide streaming access to individual entries without exposing the raw ZIP stream to a module.
- Existing IExportSupport and IImportSupport contracts remain unchanged, so existing modules and orchestrators remain compatible.

This API allows BackupRestore to keep VirtoCommerce.Catalog.json as readable JSON while storing Catalog files as regular top-level ZIP entries. Binary content is streamed through the contracts; the API does not require the archive, JSON payload, or asset files to be materialized in memory.

After the Platform.Core package is published, the corresponding BackupRestore and Catalog changes will consume these contracts.

## References
### QA-test:
End-to-end QA is covered by the consuming BackupRestore and Catalog changes after the Platform.Core package is published.

### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5387

### Artifact URL:

Image tag:
ghcr.io/VirtoCommerce/platform:3.1062.0-pr-3099-cb39-vcst-5387-top-level-catalog-assets-cb39a2db