### PR TITLE
VCST-5623: Fixed null credential fields bug

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Controllers/Api/SecurityController.cs
+++ b/src/VirtoCommerce.Platform.Web/Controllers/Api/SecurityController.cs
@@ -136,6 +136,11 @@ namespace VirtoCommerce.Platform.Web.Controllers.Api
         [AllowAnonymous]
         public async Task<ActionResult<SignInResult>> Login([FromBody] LoginRequest request)
         {
+            if (request?.UserName == null || request.Password == null)
+            {
+                return BadRequest();
+            }
+
             // Measure the duration of a succeeded response and delay subsequent failed responses to prevent timing attacks
             var delayedResponse = DelayedResponse.Create(nameof(SecurityController), nameof(Login));
 

--- a/tests/VirtoCommerce.Platform.Web.Tests/Controllers/Api/SecurityControllerTests.cs
+++ b/tests/VirtoCommerce.Platform.Web.Tests/Controllers/Api/SecurityControllerTests.cs
@@ -8,6 +8,7 @@ using AutoFixture;
 using FluentAssertions;
 using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Identity;
+using Microsoft.AspNetCore.Mvc;
 using Microsoft.Extensions.Logging;
 using Microsoft.Extensions.Options;
 using Moq;
@@ -19,6 +20,7 @@ using VirtoCommerce.Platform.Security.ExternalSignIn;
 using VirtoCommerce.Platform.Web.Controllers.Api;
 using VirtoCommerce.Platform.Web.Model.Security;
 using Xunit;
+using SignInResult = Microsoft.AspNetCore.Identity.SignInResult;
 
 namespace VirtoCommerce.Platform.Web.Tests.Controllers.Api
 {
@@ -222,6 +224,45 @@ namespace VirtoCommerce.Platform.Web.Tests.Controllers.Api
             _eventPublisherMock.Verify(x => x.Publish(It.Is<UserLoginEvent>(e => e.User == user), default), Times.Once);
             result.Should().NotBeNull();
             result.IsNotAllowed.Should().BeTrue();
+        }
+
+        /// <summary>
+        /// If the request or its required fields are null we should return 400 Bad Request instead of throwing
+        /// </summary>
+        [Fact]
+        public async Task Login_NullRequest_ReturnsBadRequest()
+        {
+            // Act
+            var actual = await _controller.Login(null);
+
+            // Assert
+            actual.Result.Should().BeOfType<BadRequestResult>();
+        }
+
+        [Fact]
+        public async Task Login_NullUserName_ReturnsBadRequest()
+        {
+            // Arrange
+            var request = new LoginRequest { UserName = null, Password = "password" };
+
+            // Act
+            var actual = await _controller.Login(request);
+
+            // Assert
+            actual.Result.Should().BeOfType<BadRequestResult>();
+        }
+
+        [Fact]
+        public async Task Login_NullPassword_ReturnsBadRequest()
+        {
+            // Arrange
+            var request = new LoginRequest { UserName = "user", Password = null };
+
+            // Act
+            var actual = await _controller.Login(request);
+
+            // Assert
+            actual.Result.Should().BeOfType<BadRequestResult>();
         }
 
         #endregion Login


### PR DESCRIPTION
## Description
POST /api/platform/security/login returned an unhandled 500 Internal Server Error (instead of 400 Bad Request) whenever userName and/or password were null or missing from the request body. Since the endpoint is [AllowAnonymous], any unauthenticated caller could trigger this at will, polluting 5xx dashboards/alerting. Root cause: UserManager.FindByNameAsync and SignInManager.PasswordSignInAsync throw ArgumentNullException on null input, and ApiErrorWrappingMiddleware maps any unhandled exception to a blanket 500.

What's added
Added an explicit null check at the top of SecurityController.Login for request, request.UserName, and request.Password, returning 400 Bad Request before any downstream call can throw (SecurityController.cs).
Added unit tests covering null request body, null UserName, and null Password, verifying 400 Bad Request is returned; existing tests confirm empty-string userName and non-existent users still return 200 OK with succeeded: false (SecurityControllerTests.cs).
Breaking changes
None.

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5623
### Artifact URL:

Image tag:
ghcr.io/VirtoCommerce/platform:3.1059.0-pr-3100-1f33-vcst-5623-1f33fba0