### PR TITLE
VCST-5656: delete the entities loaded from the data source

### DIFF
--- a/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
+++ b/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
@@ -314,10 +314,14 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
             }
             else
             {
-                var keyMap = new PrimaryKeyResolvingMap();
-                foreach (var model in models)
+                // Remove the entities loaded from the data source rather than stubs built by FromModel. A stub can
+                // only carry what the model exposes, so any column the model doesn't map stays at its default —
+                // most importantly a concurrency token ([Timestamp]/rowversion). EF puts the unset token into the
+                // DELETE predicate (WHERE Id = @p0 AND RowVersion IS NULL), no row matches it, and the commit throws
+                // DbUpdateConcurrencyException while the row stays in the database.
+                var entities = await LoadEntities(repository, ids);
+                foreach (var entity in entities)
                 {
-                    var entity = FromModel(model, keyMap);
                     repository.Remove(entity);
                 }
                 await repository.UnitOfWork.CommitAsync();

--- a/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
+++ b/src/VirtoCommerce.Platform.Data/GenericCrud/CrudService.cs
@@ -314,11 +314,7 @@ namespace VirtoCommerce.Platform.Data.GenericCrud
             }
             else
             {
-                // Remove the entities loaded from the data source rather than stubs built by FromModel. A stub can
-                // only carry what the model exposes, so any column the model doesn't map stays at its default —
-                // most importantly a concurrency token ([Timestamp]/rowversion). EF puts the unset token into the
-                // DELETE predicate (WHERE Id = @p0 AND RowVersion IS NULL), no row matches it, and the commit throws
-                // DbUpdateConcurrencyException while the row stays in the database.
+                // An entity built by FromModel has no concurrency token, so the DELETE matches no row and throws DbUpdateConcurrencyException.
                 var entities = await LoadEntities(repository, ids);
                 foreach (var entity in entities)
                 {

--- a/tests/VirtoCommerce.Platform.Tests/GenericCrud/CrudServiceMock.cs
+++ b/tests/VirtoCommerce.Platform.Tests/GenericCrud/CrudServiceMock.cs
@@ -26,6 +26,12 @@ namespace VirtoCommerce.Platform.Tests.GenericCrud
                 .Select(x => AbstractTypeFactory<TestEntity>.TryCreateInstance().FromModel(new TestModel { Id = x }, new PrimaryKeyResolvingMap()))
                 .ToList();
 
+            // Only the data source sets the concurrency token, FromModel leaves it null.
+            foreach (var entity in entities)
+            {
+                entity.RowVersion = [1, 2, 3];
+            }
+
             return Task.FromResult(entities);
         }
 

--- a/tests/VirtoCommerce.Platform.Tests/GenericCrud/CrudServiceTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/GenericCrud/CrudServiceTests.cs
@@ -1,10 +1,8 @@
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MockQueryable.Moq;
 using Moq;
-using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Domain;
 using VirtoCommerce.Platform.Core.Events;
@@ -106,7 +104,7 @@ namespace VirtoCommerce.Platform.Tests.GenericCrud
         }
 
         [Fact]
-        public async Task DeleteAsync_RemovesEntitiesLoadedFromDataSource()
+        public async Task DeleteAsync_RemovesEntityWithValidConcurrencyToken()
         {
             // Arrange
             var ids = new List<string> { "1" };
@@ -116,17 +114,14 @@ namespace VirtoCommerce.Platform.Tests.GenericCrud
                 .Setup(x => x.Remove(It.IsAny<TestEntity>()))
                 .Callback((TestEntity entity) => removedEntities.Add(entity));
 
-            var service = GetLoadTrackingCrudServiceMock();
+            var service = GetCrudServiceMock();
 
             // Act
             await service.DeleteAsync(ids);
 
             // Assert
-            // The removed instance must be the one loaded from the data source: a stub built from the model carries
-            // no concurrency token, which makes EF delete nothing and throw DbUpdateConcurrencyException instead.
             var removedEntity = Assert.Single(removedEntities);
-            Assert.True(service.LoadedEntities.Any(x => ReferenceEquals(x, removedEntity)),
-                "The deleted entity was not loaded from the data source.");
+            Assert.NotNull(removedEntity.RowVersion);
         }
 
         [Fact]
@@ -159,34 +154,6 @@ namespace VirtoCommerce.Platform.Tests.GenericCrud
         {
             _repositoryMock.Setup(x => x.UnitOfWork).Returns(_mockUnitOfWork.Object);
             return new CrudServiceMock(() => _repositoryMock.Object, MemoryCacheMockHelper.GetPlatformMemoryCache(), _eventPublisherMock.Object);
-        }
-
-        private LoadTrackingCrudServiceMock GetLoadTrackingCrudServiceMock()
-        {
-            _repositoryMock.Setup(x => x.UnitOfWork).Returns(_mockUnitOfWork.Object);
-            return new LoadTrackingCrudServiceMock(() => _repositoryMock.Object, MemoryCacheMockHelper.GetPlatformMemoryCache(), _eventPublisherMock.Object);
-        }
-
-        /// <summary>
-        /// Keeps every entity instance handed out by <see cref="LoadEntities"/>, so a test can tell an entity
-        /// loaded from the data source from a stub built out of a model.
-        /// </summary>
-        private sealed class LoadTrackingCrudServiceMock : CrudServiceMock
-        {
-            public LoadTrackingCrudServiceMock(Func<IRepository> repositoryFactory, IPlatformMemoryCache platformMemoryCache, IEventPublisher eventPublisher)
-                : base(repositoryFactory, platformMemoryCache, eventPublisher)
-            {
-            }
-
-            public List<TestEntity> LoadedEntities { get; } = [];
-
-            protected override async Task<IList<TestEntity>> LoadEntities(IRepository repository, IList<string> ids, string responseGroup)
-            {
-                var entities = await base.LoadEntities(repository, ids, responseGroup);
-                LoadedEntities.AddRange(entities);
-
-                return entities;
-            }
         }
     }
 }

--- a/tests/VirtoCommerce.Platform.Tests/GenericCrud/CrudServiceTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/GenericCrud/CrudServiceTests.cs
@@ -1,8 +1,10 @@
+using System;
 using System.Collections.Generic;
 using System.Linq;
 using System.Threading.Tasks;
 using MockQueryable.Moq;
 using Moq;
+using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Domain;
 using VirtoCommerce.Platform.Core.Events;
@@ -104,6 +106,30 @@ namespace VirtoCommerce.Platform.Tests.GenericCrud
         }
 
         [Fact]
+        public async Task DeleteAsync_RemovesEntitiesLoadedFromDataSource()
+        {
+            // Arrange
+            var ids = new List<string> { "1" };
+            var removedEntities = new List<TestEntity>();
+
+            _repositoryMock
+                .Setup(x => x.Remove(It.IsAny<TestEntity>()))
+                .Callback((TestEntity entity) => removedEntities.Add(entity));
+
+            var service = GetLoadTrackingCrudServiceMock();
+
+            // Act
+            await service.DeleteAsync(ids);
+
+            // Assert
+            // The removed instance must be the one loaded from the data source: a stub built from the model carries
+            // no concurrency token, which makes EF delete nothing and throw DbUpdateConcurrencyException instead.
+            var removedEntity = Assert.Single(removedEntities);
+            Assert.True(service.LoadedEntities.Any(x => ReferenceEquals(x, removedEntity)),
+                "The deleted entity was not loaded from the data source.");
+        }
+
+        [Fact]
         public async Task GetByOuterIdAsync_ReturnsCorrectEntity()
         {
             // Arrange
@@ -133,6 +159,34 @@ namespace VirtoCommerce.Platform.Tests.GenericCrud
         {
             _repositoryMock.Setup(x => x.UnitOfWork).Returns(_mockUnitOfWork.Object);
             return new CrudServiceMock(() => _repositoryMock.Object, MemoryCacheMockHelper.GetPlatformMemoryCache(), _eventPublisherMock.Object);
+        }
+
+        private LoadTrackingCrudServiceMock GetLoadTrackingCrudServiceMock()
+        {
+            _repositoryMock.Setup(x => x.UnitOfWork).Returns(_mockUnitOfWork.Object);
+            return new LoadTrackingCrudServiceMock(() => _repositoryMock.Object, MemoryCacheMockHelper.GetPlatformMemoryCache(), _eventPublisherMock.Object);
+        }
+
+        /// <summary>
+        /// Keeps every entity instance handed out by <see cref="LoadEntities"/>, so a test can tell an entity
+        /// loaded from the data source from a stub built out of a model.
+        /// </summary>
+        private sealed class LoadTrackingCrudServiceMock : CrudServiceMock
+        {
+            public LoadTrackingCrudServiceMock(Func<IRepository> repositoryFactory, IPlatformMemoryCache platformMemoryCache, IEventPublisher eventPublisher)
+                : base(repositoryFactory, platformMemoryCache, eventPublisher)
+            {
+            }
+
+            public List<TestEntity> LoadedEntities { get; } = [];
+
+            protected override async Task<IList<TestEntity>> LoadEntities(IRepository repository, IList<string> ids, string responseGroup)
+            {
+                var entities = await base.LoadEntities(repository, ids, responseGroup);
+                LoadedEntities.AddRange(entities);
+
+                return entities;
+            }
         }
     }
 }

--- a/tests/VirtoCommerce.Platform.Tests/GenericCrud/TestEntity.cs
+++ b/tests/VirtoCommerce.Platform.Tests/GenericCrud/TestEntity.cs
@@ -1,4 +1,5 @@
 using System;
+using System.ComponentModel.DataAnnotations;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Domain;
 
@@ -8,6 +9,12 @@ namespace VirtoCommerce.Platform.Tests.GenericCrud
     {
         public string OuterId { get; set; }
         public string Name { get; set; }
+
+        /// <summary>
+        /// A column the model doesn't carry, so only the data source can fill it.
+        /// </summary>
+        [Timestamp]
+        public byte[] RowVersion { get; set; }
 
         public TestEntity FromModel(TestModel model, PrimaryKeyResolvingMap pkMap)
         {


### PR DESCRIPTION
CrudService.DeleteAsync removed stubs built by FromModel. A stub only carries what the model exposes, so any column the model does not map stays at its default - most importantly a concurrency token ([Timestamp]/rowversion). EF put the unset token into the DELETE predicate (WHERE Id = @p0 AND RowVersion IS NULL), nothing matched it, and the commit threw DbUpdateConcurrencyException while the row stayed in the database.

Removing the entities loaded from the data source keeps the token intact, and makes the delete idempotent: a row that is already gone no longer fails.

## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5656
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes shared `CrudService` hard-delete behavior for every derived service; fix is correct for EF concurrency but adds a load per delete and alters behavior when IDs are missing from the database.
> 
> **Overview**
> **Hard delete in `CrudService.DeleteAsync`** no longer builds EF entities via `FromModel` before `Remove`. It loads rows through `LoadEntities` so concurrency tokens (e.g. `[Timestamp]` / rowversion) and other DB-only columns are present on the entity EF deletes.
> 
> This fixes deletes that failed with `DbUpdateConcurrencyException` when EF generated `WHERE … AND RowVersion IS NULL`, and avoids treating “row already gone” as a hard failure when the loaded set is empty.
> 
> Tests add a `RowVersion` on `TestEntity`, simulate the token only on load in `CrudServiceMock`, and assert the entity passed to `Remove` has a non-null concurrency token.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit cae25d7208e9a1a7dc2bf25f6749235d1d61fbd9. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1061.0-pr-3101-67c6-vcst-5656-67c6706c