### PR TITLE
fix: make the production error page reachable and renderable

### DIFF
--- a/src/VirtoCommerce.Platform.Web/Startup.cs
+++ b/src/VirtoCommerce.Platform.Web/Startup.cs
@@ -94,6 +94,9 @@ namespace VirtoCommerce.Platform.Web
 {
     public class Startup
     {
+        // Re-executed by UseExceptionHandler, so it must resolve through the default controller route below.
+        public const string ExceptionHandlingPath = "/Home/Error";
+
         public Startup(IConfiguration configuration, IWebHostEnvironment hostingEnvironment)
         {
             Configuration = configuration;
@@ -749,7 +752,7 @@ namespace VirtoCommerce.Platform.Web
             }
             else
             {
-                app.UseExceptionHandler("/Error");
+                app.UseExceptionHandler(ExceptionHandlingPath);
                 app.UseHsts();
             }
 

--- a/src/VirtoCommerce.Platform.Web/Views/Home/Error.cshtml
+++ b/src/VirtoCommerce.Platform.Web/Views/Home/Error.cshtml
@@ -1,22 +1,38 @@
 @model Model.Home.ErrorModel
 @{
     ViewData["Title"] = "Error";
+    // The shared layout is bound to the admin UI model and pulls in the Angular application bundles.
+    // This page renders while the application is already failing, so it has to stay self-contained.
+    Layout = null;
 }
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+    <title>Virto Commerce @ViewData["Title"]</title>
+    <style>
+        body { font-family: system-ui, sans-serif; margin: 2rem; }
+        .text-danger { color: #d9534f; }
+    </style>
+</head>
+<body>
+    <h1 class="text-danger">Error.</h1>
+    <h2 class="text-danger">An error occurred while processing your request.</h2>
 
-<h1 class="text-danger">Error.</h1>
-<h2 class="text-danger">An error occurred while processing your request.</h2>
+    @if (Model.ShowRequestId)
+    {
+        <p>
+            <strong>Request ID:</strong> <code>@Model.RequestId</code>
+        </p>
+    }
 
-@if (Model.ShowRequestId)
-{
+    <h3>Development Mode</h3>
     <p>
-        <strong>Request ID:</strong> <code>@Model.RequestId</code>
+        Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
     </p>
-}
-
-<h3>Development Mode</h3>
-<p>
-    Swapping to <strong>Development</strong> environment will display more detailed information about the error that occurred.
-</p>
-<p>
-    <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
-</p>
+    <p>
+        <strong>Development environment should not be enabled in deployed applications</strong>, as it can result in sensitive information from exceptions being displayed to end users. For local debugging, development environment can be enabled by setting the <strong>ASPNETCORE_ENVIRONMENT</strong> environment variable to <strong>Development</strong>, and restarting the application.
+    </p>
+</body>
+</html>

--- a/tests/VirtoCommerce.Platform.Web.Tests/Controllers/ErrorPageTests.cs
+++ b/tests/VirtoCommerce.Platform.Web.Tests/Controllers/ErrorPageTests.cs
@@ -1,0 +1,98 @@
+using System;
+using System.Net;
+using System.Net.Http;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Builder;
+using Microsoft.AspNetCore.Hosting;
+using Microsoft.AspNetCore.Http;
+using Microsoft.AspNetCore.Routing;
+using Microsoft.AspNetCore.TestHost;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+using Moq;
+using VirtoCommerce.Platform.Core.Settings;
+using VirtoCommerce.Platform.Data.Repositories;
+using VirtoCommerce.Platform.Web.Controllers;
+using VirtoCommerce.Platform.Web.Licensing;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Web.Tests.Controllers;
+
+/// <summary>
+/// Covers the production error page: the path handed to UseExceptionHandler must resolve to a real
+/// endpoint, and that endpoint must be able to render. The pipeline below mirrors the parts of
+/// <see cref="Startup"/> the error page depends on - the exception handler, the default controller
+/// route, and a middleware that only throws for one path, the way the authentication middleware does.
+/// </summary>
+public class ErrorPageTests
+{
+    private const string ThrowingPath = "/signin-oidc";
+
+    [Fact]
+    public async Task ExceptionHandler_UnhandledException_RendersErrorPageWithStatus500()
+    {
+        using var host = await CreateHostAsync();
+        using var client = host.GetTestClient();
+
+        using var response = await client.PostAsync(ThrowingPath, new StringContent(string.Empty), TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.InternalServerError);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.Should().Contain("An error occurred while processing your request.");
+    }
+
+    [Fact]
+    public async Task ExceptionHandlingPath_RequestedDirectly_RendersErrorPage()
+    {
+        using var host = await CreateHostAsync();
+        using var client = host.GetTestClient();
+
+        using var response = await client.GetAsync(Startup.ExceptionHandlingPath, TestContext.Current.CancellationToken);
+
+        response.StatusCode.Should().Be(HttpStatusCode.OK);
+        var body = await response.Content.ReadAsStringAsync(TestContext.Current.CancellationToken);
+        body.Should().Contain("An error occurred while processing your request.");
+    }
+
+    private static Task<IHost> CreateHostAsync()
+    {
+        return new HostBuilder()
+            .ConfigureWebHost(webBuilder => webBuilder
+                .UseTestServer()
+                .ConfigureServices(ConfigureServices)
+                .Configure(Configure))
+            .StartAsync();
+    }
+
+    private static void ConfigureServices(IServiceCollection services)
+    {
+        services.AddControllersWithViews()
+            .AddApplicationPart(typeof(HomeController).Assembly);
+
+        // HomeController is activated through DI, so every constructor dependency has to resolve even
+        // though the Error action touches none of them.
+        services.AddOptions();
+        services.AddSingleton<Func<IPlatformRepository>>(() => throw new NotSupportedException());
+        services.AddSingleton<LicenseProvider>();
+        services.AddSingleton(new Mock<ISettingsManager>().Object);
+    }
+
+    private static void Configure(IApplicationBuilder app)
+    {
+        app.UseExceptionHandler(Startup.ExceptionHandlingPath);
+
+        app.Use(async (context, next) =>
+        {
+            if (context.Request.Path.StartsWithSegments(ThrowingPath))
+            {
+                throw new InvalidOperationException("Simulated unhandled exception.");
+            }
+
+            await next();
+        });
+
+        app.UseRouting();
+        app.UseEndpoints(endpoints => endpoints.MapControllerRoute(name: "default", pattern: "{controller=Home}/{action=Index}/{id?}"));
+    }
+}

--- a/tests/VirtoCommerce.Platform.Web.Tests/VirtoCommerce.Platform.Web.Tests.csproj
+++ b/tests/VirtoCommerce.Platform.Web.Tests/VirtoCommerce.Platform.Web.Tests.csproj
@@ -15,6 +15,7 @@
     </PackageReference>
     <!--Don't update. FluentAssertions 8+ requires a paid license for commercial use.-->
     <PackageReference Include="FluentAssertions" Version="[7.2.2, 8.0.0)" />
+    <PackageReference Include="Microsoft.AspNetCore.TestHost" Version="10.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />


### PR DESCRIPTION
## Description

The platform error page is dead code in Production, and every unhandled exception outside `/api/` surfaces as a misleading `InvalidOperationException` that masks the real one. Two independent defects chain together.

**1. The exception handling path does not resolve to an endpoint.**

`Startup.Configure` passed `"/Error"` to `UseExceptionHandler`. The only route is the conventional `{controller=Home}/{action=Index}/{id?}`, and the error action lives on `HomeController`, so `/Error` resolves to a non-existent `Error` controller. The re-executed request returns 404 and, because `AllowStatusCode404Response` defaults to `false`, `ExceptionHandlerMiddlewareImpl` throws:

> The exception handler configured on ExceptionHandlerOptions produced a 404 status response. This InvalidOperationException containing the original exception was thrown since this is often due to a misconfigured ExceptionHandlingPath.

`ApiErrorWrappingMiddleware` only handles paths containing `/api/`, so everything else — the OIDC callback in particular — reaches this handler and is reported as the wrong exception.

**2. The page could not render even at the correct path.**

`Views/Home/Error.cshtml` inherits `_Layout` through `_ViewStart`. `_Layout` declares no `@model`, so `Model` is `dynamic`, and it reads `IndexModel` members (`SendDiagnosticData`, `PlatformVersion`, `License`, …). Rendering it with `ErrorModel` throws:

> Microsoft.CSharp.RuntimeBinder.RuntimeBinderException: 'VirtoCommerce.Platform.Web.Model.Home.ErrorModel' does not contain a definition for 'SendDiagnosticData'

When the handler itself throws, the middleware rethrows the original exception and the client still gets a bare 500 with no page.

### Changes

- `Startup`: the exception handling path now points at the route that exists, and moved into a `public const` so tests bind to the production value rather than to a literal of their own.
- `Views/Home/Error.cshtml`: self-contained document with `Layout = null`. The shared layout is bound to the admin UI model and pulls in the Angular bundles; this page renders while the application is already failing, so it must not depend on either.
- `ErrorPageTests`: a TestServer pipeline mirroring the parts of `Startup` the error page depends on — the exception handler, the default controller route, and a middleware that throws for a single path the way the authentication middleware does. Before the fix the first test failed with the exact `InvalidOperationException` above and the second with a 404.

### Verification

`dotnet test VirtoCommerce.Platform.sln` — Web.Tests 115/115 green (113 before, plus the two added).

One pre-existing failure is unrelated and reproduces on a clean `dev`: `CronSettingTests.Validator_Accepts_Valid_Cron(cron: "*/5 * * * *")` fails in a full-solution run and passes in isolation.

### Impact observed in Production

On one deployment this accounted for 41 failed `POST /signin-oidc` callbacks against 323 successes over 60 days, each logged twice — once as `AuthenticationFailureException: Correlation failed.` and once as the `InvalidOperationException` above. The underlying correlation failures are ordinary replayed or refreshed callbacks; the point of this change is that they stop being reported as something else.

## References
### QA-test:
### Jira-link:
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Narrow production error-handling and view changes with regression tests; no auth, data, or API contract changes.
> 
> **Overview**
> **Production unhandled exceptions** (e.g. OIDC callbacks outside `/api/`) no longer fail with a misleading `InvalidOperationException` from a misconfigured exception handler.
> 
> `UseExceptionHandler` now targets **`/Home/Error`** via `Startup.ExceptionHandlingPath`, matching the default `{controller=Home}/{action=Error}` route instead of the broken `/Error` path.
> 
> **`Views/Home/Error.cshtml`** is a self-contained HTML page (`Layout = null`) so it does not depend on the admin `_Layout` and `IndexModel`-bound Angular bundles that caused `RuntimeBinderException` when rendering `ErrorModel`.
> 
> **`ErrorPageTests`** (with `Microsoft.AspNetCore.TestHost`) assert the handler path resolves and that simulated middleware failures return HTTP 500 with the expected error message.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 93be10ee34683685d6b9a51a5345a915476e90a7. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1060.0-pr-3103-93be-error-page-not-reachable-93be10ee