### PR TITLE
VCST-5566: One change per row

### DIFF
--- a/src/VirtoCommerce.Platform.Core/ChangeLog/LastChangesOptions.cs
+++ b/src/VirtoCommerce.Platform.Core/ChangeLog/LastChangesOptions.cs
@@ -1,0 +1,14 @@
+using System.Collections.Generic;
+
+namespace VirtoCommerce.Platform.Core.ChangeLog
+{
+    public class LastChangesOptions
+    {
+        /// <summary>
+        /// Full names of entity types not tracked by <see cref="ILastChangesService"/>, so that the change-log API
+        /// stops reporting them as changed. An entity is excluded when the list contains its own type name or the name
+        /// of any of its base types. Empty by default.
+        /// </summary>
+        public IList<string> IgnoredEntityTypes { get; set; } = [];
+    }
+}

--- a/src/VirtoCommerce.Platform.Core/ChangeLog/LastChangesOptions.cs
+++ b/src/VirtoCommerce.Platform.Core/ChangeLog/LastChangesOptions.cs
@@ -4,11 +4,6 @@ namespace VirtoCommerce.Platform.Core.ChangeLog
 {
     public class LastChangesOptions
     {
-        /// <summary>
-        /// Full names of entity types not tracked by <see cref="ILastChangesService"/>, so that the change-log API
-        /// stops reporting them as changed. An entity is excluded when the list contains its own type name or the name
-        /// of any of its base types. Empty by default.
-        /// </summary>
         public IList<string> IgnoredEntityTypes { get; set; } = [];
     }
 }

--- a/src/VirtoCommerce.Platform.Data/ChangeLog/EntityTypeNames.cs
+++ b/src/VirtoCommerce.Platform.Data/ChangeLog/EntityTypeNames.cs
@@ -5,10 +5,6 @@ using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.Platform.Data.ChangeLog
 {
-    /// <summary>
-    /// Entity type names from the concrete type up to, but not including, <see cref="Entity"/>.
-    /// The chain is stable for a given type, so it is built once instead of on every saved row.
-    /// </summary>
     internal static class EntityTypeNames
     {
         private static readonly ConcurrentDictionary<Type, string[]> _namesByType = new();

--- a/src/VirtoCommerce.Platform.Data/ChangeLog/EntityTypeNames.cs
+++ b/src/VirtoCommerce.Platform.Data/ChangeLog/EntityTypeNames.cs
@@ -1,0 +1,34 @@
+using System;
+using System.Collections.Concurrent;
+using System.Collections.Generic;
+using VirtoCommerce.Platform.Core.Common;
+
+namespace VirtoCommerce.Platform.Data.ChangeLog
+{
+    /// <summary>
+    /// Entity type names from the concrete type up to, but not including, <see cref="Entity"/>.
+    /// The chain is stable for a given type, so it is built once instead of on every saved row.
+    /// </summary>
+    internal static class EntityTypeNames
+    {
+        private static readonly ConcurrentDictionary<Type, string[]> _namesByType = new();
+
+        public static string[] Get(Type entityType)
+        {
+            return _namesByType.GetOrAdd(entityType, BuildTypeNames);
+        }
+
+        private static string[] BuildTypeNames(Type entityType)
+        {
+            var typeNames = new List<string>();
+
+            while (entityType != null && entityType != typeof(Entity))
+            {
+                typeNames.Add(entityType.FullName);
+                entityType = entityType.BaseType;
+            }
+
+            return typeNames.ToArray();
+        }
+    }
+}

--- a/src/VirtoCommerce.Platform.Data/ChangeLog/ILastChangesNotifier.cs
+++ b/src/VirtoCommerce.Platform.Data/ChangeLog/ILastChangesNotifier.cs
@@ -4,9 +4,6 @@ using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.Platform.Data.ChangeLog
 {
-    /// <summary>
-    /// Invalidates <see cref="ILastChangesService"/> for entities saved by the global entity triggers.
-    /// </summary>
     public interface ILastChangesNotifier
     {
         void OnEntitySaving(DbContext context, IEntity entity);

--- a/src/VirtoCommerce.Platform.Data/ChangeLog/ILastChangesNotifier.cs
+++ b/src/VirtoCommerce.Platform.Data/ChangeLog/ILastChangesNotifier.cs
@@ -1,0 +1,14 @@
+using Microsoft.EntityFrameworkCore;
+using VirtoCommerce.Platform.Core.ChangeLog;
+using VirtoCommerce.Platform.Core.Common;
+
+namespace VirtoCommerce.Platform.Data.ChangeLog
+{
+    /// <summary>
+    /// Invalidates <see cref="ILastChangesService"/> for entities saved by the global entity triggers.
+    /// </summary>
+    public interface ILastChangesNotifier
+    {
+        void OnEntitySaving(DbContext context, IEntity entity);
+    }
+}

--- a/src/VirtoCommerce.Platform.Data/ChangeLog/LastChangesNotifier.cs
+++ b/src/VirtoCommerce.Platform.Data/ChangeLog/LastChangesNotifier.cs
@@ -1,0 +1,71 @@
+using System;
+using System.Collections.Generic;
+using System.Runtime.CompilerServices;
+using Microsoft.EntityFrameworkCore;
+using VirtoCommerce.Platform.Core.ChangeLog;
+using VirtoCommerce.Platform.Core.Common;
+
+namespace VirtoCommerce.Platform.Data.ChangeLog
+{
+    /// <summary>
+    /// Rows saved by the same SaveChanges are written at the same instant, so announcing a type name once per row
+    /// instead of once per unit of work invalidates the same cache key thousands of times and propagates every one of
+    /// them to the scale-out backplane. The duplicates are dropped here, before the cache region propagates anything,
+    /// leaving the propagation semantics untouched.
+    /// </summary>
+    public class LastChangesNotifier : ILastChangesNotifier
+    {
+        private readonly ConditionalWeakTable<DbContext, HashSet<string>> _announcedTypeNames = new();
+
+        private readonly ILastChangesService _lastChangesService;
+
+        public LastChangesNotifier(ILastChangesService lastChangesService)
+        {
+            _lastChangesService = lastChangesService;
+        }
+
+        public void OnEntitySaving(DbContext context, IEntity entity)
+        {
+            var typeNames = EntityTypeNames.Get(entity.GetType());
+
+            if (context is null)
+            {
+                Announce(typeNames);
+                return;
+            }
+
+            var announced = _announcedTypeNames.GetValue(context, CreateAnnouncedTypeNames);
+
+            foreach (var entityTypeName in typeNames)
+            {
+                if (announced.Add(entityTypeName))
+                {
+                    _lastChangesService.Reset(entityTypeName);
+                }
+            }
+        }
+
+        private void Announce(string[] typeNames)
+        {
+            foreach (var entityTypeName in typeNames)
+            {
+                _lastChangesService.Reset(entityTypeName);
+            }
+        }
+
+        /// <summary>
+        /// The set lives for one SaveChanges: a later save has new information to announce. DbContext raises these
+        /// events after every Inserting/Updating trigger of the batch has run, whatever its base class, and is not
+        /// thread safe, so the set is only ever touched by the thread running SaveChanges.
+        /// </summary>
+        private static HashSet<string> CreateAnnouncedTypeNames(DbContext context)
+        {
+            var announced = new HashSet<string>(StringComparer.OrdinalIgnoreCase);
+
+            context.SavedChanges += (_, _) => announced.Clear();
+            context.SaveChangesFailed += (_, _) => announced.Clear();
+
+            return announced;
+        }
+    }
+}

--- a/src/VirtoCommerce.Platform.Data/ChangeLog/LastChangesNotifier.cs
+++ b/src/VirtoCommerce.Platform.Data/ChangeLog/LastChangesNotifier.cs
@@ -8,12 +8,6 @@ using VirtoCommerce.Platform.Core.Common;
 
 namespace VirtoCommerce.Platform.Data.ChangeLog
 {
-    /// <summary>
-    /// Rows saved by the same SaveChanges are written at the same instant, so announcing a type name once per row
-    /// instead of once per unit of work invalidates the same cache key thousands of times and propagates every one of
-    /// them to the scale-out backplane. The duplicates are dropped here, before the cache region propagates anything,
-    /// leaving the propagation semantics untouched.
-    /// </summary>
     public class LastChangesNotifier : ILastChangesNotifier
     {
         private readonly ConditionalWeakTable<DbContext, HashSet<string>> _announcedTypeNames = new();
@@ -53,10 +47,6 @@ namespace VirtoCommerce.Platform.Data.ChangeLog
             }
         }
 
-        /// <summary>
-        /// Matching the whole chain keeps an entity excluded after it is overridden via AbstractTypeFactory, and
-        /// silences the base types an excluded entity would otherwise announce.
-        /// </summary>
         private bool IsIgnored(string[] typeNames)
         {
             if (_ignoredEntityTypes.Count == 0)
@@ -83,11 +73,6 @@ namespace VirtoCommerce.Platform.Data.ChangeLog
             }
         }
 
-        /// <summary>
-        /// The set lives for one SaveChanges: a later save has new information to announce. DbContext raises these
-        /// events after every Inserting/Updating trigger of the batch has run, whatever its base class, and is not
-        /// thread safe, so the set is only ever touched by the thread running SaveChanges.
-        /// </summary>
         private static HashSet<string> CreateAnnouncedTypeNames(DbContext context)
         {
             var announced = new HashSet<string>(StringComparer.OrdinalIgnoreCase);

--- a/src/VirtoCommerce.Platform.Data/ChangeLog/LastChangesNotifier.cs
+++ b/src/VirtoCommerce.Platform.Data/ChangeLog/LastChangesNotifier.cs
@@ -1,5 +1,6 @@
 using System;
 using System.Collections.Generic;
+using System.Linq;
 using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.Extensions.Options;
@@ -38,34 +39,15 @@ namespace VirtoCommerce.Platform.Data.ChangeLog
 
             var announced = _announcedTypeNames.GetValue(context, CreateAnnouncedTypeNames);
 
-            foreach (var entityTypeName in typeNames)
-            {
-                if (announced.Add(entityTypeName))
-                {
-                    _lastChangesService.Reset(entityTypeName);
-                }
-            }
+            Announce(typeNames.Where(announced.Add));
         }
 
         private bool IsIgnored(string[] typeNames)
         {
-            if (_ignoredEntityTypes.Count == 0)
-            {
-                return false;
-            }
-
-            foreach (var entityTypeName in typeNames)
-            {
-                if (_ignoredEntityTypes.Contains(entityTypeName))
-                {
-                    return true;
-                }
-            }
-
-            return false;
+            return _ignoredEntityTypes.Count > 0 && typeNames.Any(_ignoredEntityTypes.Contains);
         }
 
-        private void Announce(string[] typeNames)
+        private void Announce(IEnumerable<string> typeNames)
         {
             foreach (var entityTypeName in typeNames)
             {

--- a/src/VirtoCommerce.Platform.Data/ChangeLog/LastChangesNotifier.cs
+++ b/src/VirtoCommerce.Platform.Data/ChangeLog/LastChangesNotifier.cs
@@ -2,6 +2,7 @@ using System;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using VirtoCommerce.Platform.Core.ChangeLog;
 using VirtoCommerce.Platform.Core.Common;
 
@@ -18,15 +19,22 @@ namespace VirtoCommerce.Platform.Data.ChangeLog
         private readonly ConditionalWeakTable<DbContext, HashSet<string>> _announcedTypeNames = new();
 
         private readonly ILastChangesService _lastChangesService;
+        private readonly HashSet<string> _ignoredEntityTypes;
 
-        public LastChangesNotifier(ILastChangesService lastChangesService)
+        public LastChangesNotifier(ILastChangesService lastChangesService, IOptions<LastChangesOptions> options)
         {
             _lastChangesService = lastChangesService;
+            _ignoredEntityTypes = new HashSet<string>(options.Value.IgnoredEntityTypes ?? [], StringComparer.OrdinalIgnoreCase);
         }
 
         public void OnEntitySaving(DbContext context, IEntity entity)
         {
             var typeNames = EntityTypeNames.Get(entity.GetType());
+
+            if (IsIgnored(typeNames))
+            {
+                return;
+            }
 
             if (context is null)
             {
@@ -43,6 +51,28 @@ namespace VirtoCommerce.Platform.Data.ChangeLog
                     _lastChangesService.Reset(entityTypeName);
                 }
             }
+        }
+
+        /// <summary>
+        /// Matching the whole chain keeps an entity excluded after it is overridden via AbstractTypeFactory, and
+        /// silences the base types an excluded entity would otherwise announce.
+        /// </summary>
+        private bool IsIgnored(string[] typeNames)
+        {
+            if (_ignoredEntityTypes.Count == 0)
+            {
+                return false;
+            }
+
+            foreach (var entityTypeName in typeNames)
+            {
+                if (_ignoredEntityTypes.Contains(entityTypeName))
+                {
+                    return true;
+                }
+            }
+
+            return false;
         }
 
         private void Announce(string[] typeNames)

--- a/src/VirtoCommerce.Platform.Data/ChangeLog/LastChangesService.cs
+++ b/src/VirtoCommerce.Platform.Data/ChangeLog/LastChangesService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections.Generic;
 using Microsoft.Extensions.Caching.Memory;
 using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.ChangeLog;
@@ -31,17 +30,7 @@ namespace VirtoCommerce.Platform.Data.ChangeLog
 
         public void Reset(IEntity entity)
         {
-            var typeNames = new List<string>();
-
-            var entityType = entity.GetType();
-
-            while (entityType != null && entityType != typeof(Entity))
-            {
-                typeNames.Add(entityType.FullName);
-                entityType = entityType.BaseType;
-            }
-
-            foreach (var entityTypeName in typeNames)
+            foreach (var entityTypeName in EntityTypeNames.Get(entity.GetType()))
             {
                 Reset(entityTypeName);
             }

--- a/src/VirtoCommerce.Platform.Data/Extensions/ApplicationBuilderExtensions.cs
+++ b/src/VirtoCommerce.Platform.Data/Extensions/ApplicationBuilderExtensions.cs
@@ -2,9 +2,9 @@ using System;
 using EntityFrameworkCore.Triggers;
 using Microsoft.AspNetCore.Builder;
 using Microsoft.Extensions.DependencyInjection;
-using VirtoCommerce.Platform.Core.ChangeLog;
 using VirtoCommerce.Platform.Core.Common;
 using VirtoCommerce.Platform.Core.Security;
+using VirtoCommerce.Platform.Data.ChangeLog;
 
 namespace VirtoCommerce.Platform.Data.Extensions
 {
@@ -36,16 +36,17 @@ namespace VirtoCommerce.Platform.Data.Extensions
                 entry.Entity.ModifiedBy = userName;
             };
 
+            // Resolved once: the trigger fires for every saved row.
+            var lastChangesNotifier = appBuilder.ApplicationServices.GetRequiredService<ILastChangesNotifier>();
+
             Triggers<IEntity>.Inserting += entry =>
             {
-                var lastChangesService = appBuilder.ApplicationServices.GetRequiredService<ILastChangesService>();
-                lastChangesService.Reset(entry.Entity);
+                lastChangesNotifier.OnEntitySaving(entry.Context, entry.Entity);
             };
 
             Triggers<IEntity>.Updating += entry =>
             {
-                var lastChangesService = appBuilder.ApplicationServices.GetRequiredService<ILastChangesService>();
-                lastChangesService.Reset(entry.Entity);
+                lastChangesNotifier.OnEntitySaving(entry.Context, entry.Entity);
             };
 
             return appBuilder;

--- a/src/VirtoCommerce.Platform.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Data/Extensions/ServiceCollectionExtensions.cs
@@ -40,6 +40,7 @@ namespace VirtoCommerce.Platform.Data.Extensions
             services.AddTransient<IChangeLogService, ChangeLogService>();
             services.AddTransient<ILastModifiedDateTime, ChangeLogService>();
             services.AddSingleton<ILastChangesService, LastChangesService>();
+            services.AddOptions<LastChangesOptions>().Bind(configuration.GetSection("LastChanges"));
             services.AddSingleton<ILastChangesNotifier, LastChangesNotifier>();
 
             services.AddTransient<IChangeLogSearchService, ChangeLogSearchService>();

--- a/src/VirtoCommerce.Platform.Data/Extensions/ServiceCollectionExtensions.cs
+++ b/src/VirtoCommerce.Platform.Data/Extensions/ServiceCollectionExtensions.cs
@@ -39,7 +39,8 @@ namespace VirtoCommerce.Platform.Data.Extensions
             services.AddSingleton<IEventPublisher>(x => x.GetRequiredService<InProcessBus>());
             services.AddTransient<IChangeLogService, ChangeLogService>();
             services.AddTransient<ILastModifiedDateTime, ChangeLogService>();
-            services.AddTransient<ILastChangesService, LastChangesService>();
+            services.AddSingleton<ILastChangesService, LastChangesService>();
+            services.AddSingleton<ILastChangesNotifier, LastChangesNotifier>();
 
             services.AddTransient<IChangeLogSearchService, ChangeLogSearchService>();
 

--- a/tests/VirtoCommerce.Platform.Caching.Tests/LastChangesDeduplicationTests.cs
+++ b/tests/VirtoCommerce.Platform.Caching.Tests/LastChangesDeduplicationTests.cs
@@ -1,0 +1,197 @@
+using System;
+using System.Collections.Generic;
+using System.Threading.Tasks;
+using EntityFrameworkCore.Triggers;
+using Microsoft.EntityFrameworkCore;
+using VirtoCommerce.Platform.Core.Caching;
+using VirtoCommerce.Platform.Core.ChangeLog;
+using VirtoCommerce.Platform.Core.Common;
+using VirtoCommerce.Platform.Data.ChangeLog;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Caching.Tests
+{
+    /// <summary>
+    /// VCST-5566. Every token cancellation counted here becomes one Redis backplane message in a scale-out
+    /// deployment, so the count per SaveChanges is the thing under test, not just the resulting cache state.
+    /// </summary>
+    [Trait("Category", "Unit")]
+    [Collection(nameof(NotThreadSafeCollection))]
+    public class LastChangesDeduplicationTests : MemoryCacheTestsBase, IDisposable
+    {
+        private class TestBaseEntity : Entity
+        {
+        }
+
+        private class TestDerivedEntity : TestBaseEntity
+        {
+            public string Name { get; set; }
+        }
+
+        private class TestSiblingEntity : Entity
+        {
+        }
+
+        private class TestDbContext : DbContextWithTriggers
+        {
+            public TestDbContext(DbContextOptions options)
+                : base(options)
+            {
+            }
+
+            public DbSet<TestDerivedEntity> DerivedEntities { get; set; }
+
+            public DbSet<TestSiblingEntity> SiblingEntities { get; set; }
+        }
+
+        private static readonly string[] _expectedTypeNames =
+        [
+            typeof(TestDerivedEntity).FullName,
+            typeof(TestBaseEntity).FullName,
+        ];
+
+        private readonly ILastChangesService _lastChangesService;
+        private readonly List<string> _cancelledTokenKeys = [];
+        private readonly Action<TokenCancelledEventArgs> _originalOnTokenCancelled;
+        private readonly Action<IInsertingEntry<IEntity>> _trigger;
+
+        public LastChangesDeduplicationTests()
+        {
+            _lastChangesService = new LastChangesService(GetPlatformMemoryCache());
+
+            _originalOnTokenCancelled = CancellableCacheRegion.OnTokenCancelled;
+            CancellableCacheRegion.OnTokenCancelled = args => _cancelledTokenKeys.Add(args.TokenKey);
+
+            var notifier = new LastChangesNotifier(_lastChangesService);
+
+            // Mirrors the global trigger registered by ApplicationBuilderExtensions.UseDbTriggers.
+            _trigger = entry => notifier.OnEntitySaving(entry.Context, entry.Entity);
+            Triggers<IEntity>.Inserting += _trigger;
+        }
+
+        public void Dispose()
+        {
+            Triggers<IEntity>.Inserting -= _trigger;
+            CancellableCacheRegion.OnTokenCancelled = _originalOnTokenCancelled;
+            GC.SuppressFinalize(this);
+        }
+
+        [Fact]
+        public void SingleSaveChanges_ManyRowsOfSameType_CancelsEachTypeNameOnce()
+        {
+            // Arrange
+            using var context = CreateContext();
+            for (var i = 0; i < 10; i++)
+            {
+                context.DerivedEntities.Add(NewEntity($"row-{i}"));
+            }
+
+            // Act
+            context.SaveChanges();
+
+            // Assert
+            Assert.Equal(_expectedTypeNames.Length, _cancelledTokenKeys.Count);
+        }
+
+        [Fact]
+        public void EachSaveChanges_CancelsAgain()
+        {
+            // Arrange
+            using var context = CreateContext();
+
+            // Act
+            for (var save = 0; save < 3; save++)
+            {
+                context.DerivedEntities.Add(NewEntity($"save-{save}"));
+                context.SaveChanges();
+            }
+
+            // Assert
+            Assert.Equal(_expectedTypeNames.Length * 3, _cancelledTokenKeys.Count);
+        }
+
+        [Fact]
+        public void SingleSaveChanges_StillInvalidatesEveryTypeNameInTheChain()
+        {
+            // Arrange
+            using var context = CreateContext();
+            var initialDerived = _lastChangesService.GetLastModifiedDate(typeof(TestDerivedEntity).FullName);
+            var initialBase = _lastChangesService.GetLastModifiedDate(typeof(TestBaseEntity).FullName);
+            WaitForNextTick();
+
+            // Act
+            context.DerivedEntities.Add(NewEntity("row"));
+            context.SaveChanges();
+
+            // Assert
+            Assert.NotEqual(initialDerived, _lastChangesService.GetLastModifiedDate(typeof(TestDerivedEntity).FullName));
+            Assert.NotEqual(initialBase, _lastChangesService.GetLastModifiedDate(typeof(TestBaseEntity).FullName));
+        }
+
+        [Fact]
+        public async Task SingleSaveChangesAsync_ManyRowsOfSeveralTypes_CancelsEachTypeNameOnce()
+        {
+            // Arrange
+            using var context = CreateContext();
+            for (var i = 0; i < 50; i++)
+            {
+                context.DerivedEntities.Add(NewEntity($"field-{i}"));
+                context.SiblingEntities.Add(new TestSiblingEntity { Id = Guid.NewGuid().ToString("N") });
+            }
+
+            // Act
+            await context.SaveChangesAsync(TestContext.Current.CancellationToken);
+
+            // Assert
+            Assert.Equal(3, _cancelledTokenKeys.Count);
+            Assert.Contains(TokenKeyOf<TestDerivedEntity>(), _cancelledTokenKeys);
+            Assert.Contains(TokenKeyOf<TestBaseEntity>(), _cancelledTokenKeys);
+            Assert.Contains(TokenKeyOf<TestSiblingEntity>(), _cancelledTokenKeys);
+        }
+
+        [Fact]
+        public void DeduplicationIsScopedToOneContext()
+        {
+            // Arrange
+            using var firstContext = CreateContext();
+            using var secondContext = CreateContext();
+
+            // Act
+            firstContext.DerivedEntities.Add(NewEntity("first"));
+            secondContext.DerivedEntities.Add(NewEntity("second"));
+            firstContext.SaveChanges();
+            secondContext.SaveChanges();
+
+            // Assert
+            Assert.Equal(_expectedTypeNames.Length * 2, _cancelledTokenKeys.Count);
+        }
+
+        private static string TokenKeyOf<T>()
+        {
+            return LastChangesCacheRegion.GenerateRegionTokenKey(typeof(T).FullName);
+        }
+
+        private static TestDerivedEntity NewEntity(string name)
+        {
+            return new TestDerivedEntity { Id = Guid.NewGuid().ToString("N"), Name = name };
+        }
+
+        private static TestDbContext CreateContext()
+        {
+            var options = new DbContextOptionsBuilder()
+                .UseInMemoryDatabase($"VCST-5566-{Guid.NewGuid():N}")
+                .Options;
+
+            return new TestDbContext(options);
+        }
+
+        private static void WaitForNextTick()
+        {
+            var startTime = DateTime.Now;
+            while (startTime.Equals(DateTime.Now))
+            {
+                System.Threading.Thread.Sleep(10);
+            }
+        }
+    }
+}

--- a/tests/VirtoCommerce.Platform.Caching.Tests/LastChangesDeduplicationTests.cs
+++ b/tests/VirtoCommerce.Platform.Caching.Tests/LastChangesDeduplicationTests.cs
@@ -3,6 +3,7 @@ using System.Collections.Generic;
 using System.Threading.Tasks;
 using EntityFrameworkCore.Triggers;
 using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Options;
 using VirtoCommerce.Platform.Core.Caching;
 using VirtoCommerce.Platform.Core.ChangeLog;
 using VirtoCommerce.Platform.Core.Common;
@@ -51,6 +52,7 @@ namespace VirtoCommerce.Platform.Caching.Tests
         ];
 
         private readonly ILastChangesService _lastChangesService;
+        private readonly LastChangesOptions _options = new();
         private readonly List<string> _cancelledTokenKeys = [];
         private readonly Action<TokenCancelledEventArgs> _originalOnTokenCancelled;
         private readonly Action<IInsertingEntry<IEntity>> _trigger;
@@ -62,10 +64,11 @@ namespace VirtoCommerce.Platform.Caching.Tests
             _originalOnTokenCancelled = CancellableCacheRegion.OnTokenCancelled;
             CancellableCacheRegion.OnTokenCancelled = args => _cancelledTokenKeys.Add(args.TokenKey);
 
-            var notifier = new LastChangesNotifier(_lastChangesService);
+            var notifier = new Lazy<ILastChangesNotifier>(
+                () => new LastChangesNotifier(_lastChangesService, Options.Create(_options)));
 
             // Mirrors the global trigger registered by ApplicationBuilderExtensions.UseDbTriggers.
-            _trigger = entry => notifier.OnEntitySaving(entry.Context, entry.Entity);
+            _trigger = entry => notifier.Value.OnEntitySaving(entry.Context, entry.Entity);
             Triggers<IEntity>.Inserting += _trigger;
         }
 
@@ -164,6 +167,66 @@ namespace VirtoCommerce.Platform.Caching.Tests
 
             // Assert
             Assert.Equal(_expectedTypeNames.Length * 2, _cancelledTokenKeys.Count);
+        }
+
+        [Fact]
+        public void IgnoredEntityType_AnnouncesNothingAtAll()
+        {
+            // Arrange
+            _options.IgnoredEntityTypes.Add(typeof(TestDerivedEntity).FullName);
+            using var context = CreateContext();
+
+            // Act
+            context.DerivedEntities.Add(NewEntity("row"));
+            context.SaveChanges();
+
+            // Assert
+            Assert.Empty(_cancelledTokenKeys);
+        }
+
+        [Fact]
+        public void IgnoredEntityType_DoesNotSilenceOtherEntitiesSavedWithIt()
+        {
+            // Arrange
+            _options.IgnoredEntityTypes.Add(typeof(TestDerivedEntity).FullName);
+            using var context = CreateContext();
+
+            // Act
+            context.DerivedEntities.Add(NewEntity("ignored"));
+            context.SiblingEntities.Add(new TestSiblingEntity { Id = Guid.NewGuid().ToString("N") });
+            context.SaveChanges();
+
+            // Assert
+            Assert.Equal([TokenKeyOf<TestSiblingEntity>()], _cancelledTokenKeys);
+        }
+
+        [Fact]
+        public void IgnoredBaseType_AlsoExcludesEntitiesDerivedFromIt()
+        {
+            // Arrange
+            _options.IgnoredEntityTypes.Add(typeof(TestBaseEntity).FullName);
+            using var context = CreateContext();
+
+            // Act
+            context.DerivedEntities.Add(NewEntity("row"));
+            context.SaveChanges();
+
+            // Assert
+            Assert.Empty(_cancelledTokenKeys);
+        }
+
+        [Fact]
+        public void EmptyIgnoreList_TracksEverything()
+        {
+            // Arrange
+            using var context = CreateContext();
+
+            // Act
+            context.DerivedEntities.Add(NewEntity("row"));
+            context.SaveChanges();
+
+            // Assert
+            Assert.Equal(_expectedTypeNames.Length, _cancelledTokenKeys.Count);
         }
 
         private static string TokenKeyOf<T>()

--- a/tests/VirtoCommerce.Platform.Caching.Tests/LastChangesDeduplicationTests.cs
+++ b/tests/VirtoCommerce.Platform.Caching.Tests/LastChangesDeduplicationTests.cs
@@ -12,10 +12,6 @@ using Xunit;
 
 namespace VirtoCommerce.Platform.Caching.Tests
 {
-    /// <summary>
-    /// VCST-5566. Every token cancellation counted here becomes one Redis backplane message in a scale-out
-    /// deployment, so the count per SaveChanges is the thing under test, not just the resulting cache state.
-    /// </summary>
     [Trait("Category", "Unit")]
     [Collection(nameof(NotThreadSafeCollection))]
     public class LastChangesDeduplicationTests : MemoryCacheTestsBase, IDisposable
@@ -51,7 +47,7 @@ namespace VirtoCommerce.Platform.Caching.Tests
             typeof(TestBaseEntity).FullName,
         ];
 
-        private readonly ILastChangesService _lastChangesService;
+        private readonly LastChangesService _lastChangesService;
         private readonly LastChangesOptions _options = new();
         private readonly List<string> _cancelledTokenKeys = [];
         private readonly Action<TokenCancelledEventArgs> _originalOnTokenCancelled;

--- a/tests/VirtoCommerce.Platform.Caching.Tests/VirtoCommerce.Platform.Caching.Tests.csproj
+++ b/tests/VirtoCommerce.Platform.Caching.Tests/VirtoCommerce.Platform.Caching.Tests.csproj
@@ -10,6 +10,7 @@
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
       <PrivateAssets>all</PrivateAssets>
     </PackageReference>
+    <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="10.0.10" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Moq" Version="4.20.72" />
     <PackageReference Include="xunit.v3" Version="3.2.2" />


### PR DESCRIPTION
## Description

## References
### QA-test:
### Jira-link:
https://virtocommerce.atlassian.net/browse/VCST-5566
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Platform-wide change to when last-modified cache tokens expire; bulk saves behave differently (fewer invalidations), and misconfigured `IgnoredEntityTypes` could leave caches stale.
> 
> **Overview**
> Bulk EF saves no longer fire a **last-modified cache reset for every row**. Inserts/updates still run the existing `IEntity` triggers, but they now go through **`ILastChangesNotifier`**, which invalidates each entity type name in the inheritance chain **at most once per `DbContext` per `SaveChanges`** (state clears on `SavedChanges` / `SaveChangesFailed`).
> 
> **`LastChangesOptions`** (bound from config section `LastChanges`) adds **`IgnoredEntityTypes`** so specific type names (including base types) can be excluded from invalidation. Type-name resolution is centralized in cached **`EntityTypeNames`** and reused by **`LastChangesService`**.
> 
> DI updates: **`ILastChangesService`** is registered as a **singleton**, and **`ILastChangesNotifier`** is registered alongside options. Unit tests cover deduplication across sync/async saves, multiple contexts, and ignore-list behavior.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 11d3f289327c129fb5d3948ca930f3f84b80d4f3. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1064.0-pr-3105-11d3-vcst-5566-11d3f289