### PR TITLE
fix: Preserve a command timeout configured through DbContext options

### DIFF
--- a/src/VirtoCommerce.Platform.Data/Infrastructure/DbContextRepositoryBase.cs
+++ b/src/VirtoCommerce.Platform.Data/Infrastructure/DbContextRepositoryBase.cs
@@ -24,15 +24,12 @@ namespace VirtoCommerce.Platform.Data.Infrastructure
 
             UnitOfWork = unitOfWork ?? AbstractTypeFactory<DbContextUnitOfWork>.TryCreateInstance(new DbContextUnitOfWork(dbContext), (DbContext)dbContext);
 
-            var connectionDb = dbContext.Database.GetDbConnection();
-            var connectionTimeout = connectionDb.ConnectionTimeout;
-
             // Runs on every repository resolution, so an unguarded set would overwrite whatever
             // a module configured through the DbContext options.
             var commandTimeout = dbContext.Database.GetCommandTimeout();
             if (commandTimeout is null)
             {
-                dbContext.Database.SetCommandTimeout(connectionTimeout);
+                dbContext.Database.SetCommandTimeout(dbContext.Database.GetDbConnection().ConnectionTimeout);
             }
         }
 

--- a/src/VirtoCommerce.Platform.Data/Infrastructure/DbContextRepositoryBase.cs
+++ b/src/VirtoCommerce.Platform.Data/Infrastructure/DbContextRepositoryBase.cs
@@ -26,7 +26,14 @@ namespace VirtoCommerce.Platform.Data.Infrastructure
 
             var connectionDb = dbContext.Database.GetDbConnection();
             var connectionTimeout = connectionDb.ConnectionTimeout;
-            dbContext.Database.SetCommandTimeout(connectionTimeout);
+
+            // Runs on every repository resolution, so an unguarded set would overwrite whatever
+            // a module configured through the DbContext options.
+            var commandTimeout = dbContext.Database.GetCommandTimeout();
+            if (commandTimeout is null)
+            {
+                dbContext.Database.SetCommandTimeout(connectionTimeout);
+            }
         }
 
 

--- a/tests/VirtoCommerce.Platform.Tests/UnitTests/DbContextRepositoryBaseTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/UnitTests/DbContextRepositoryBaseTests.cs
@@ -1,0 +1,75 @@
+using FluentAssertions;
+using Microsoft.EntityFrameworkCore;
+using VirtoCommerce.Platform.Data.Infrastructure;
+using Xunit;
+
+namespace VirtoCommerce.Platform.Tests.UnitTests
+{
+    public class DbContextRepositoryBaseTests
+    {
+        // No connection is opened by any of these tests: the command timeout lives on the facade.
+        private const string ConnectionString = "Server=localhost;Database=Test;Connect Timeout=300;";
+
+        [Fact]
+        public void Constructor_CommandTimeoutConfigured_KeepsConfiguredValue()
+        {
+            // Arrange
+            var options = new DbContextOptionsBuilder<TestDbContext>()
+                .UseSqlServer(ConnectionString, sqlServer => sqlServer.CommandTimeout(42))
+                .Options;
+
+            // Act
+            using var repository = new TestRepository(new TestDbContext(options));
+
+            // Assert
+            repository.DbContext.Database.GetCommandTimeout().Should().Be(42);
+        }
+
+        [Fact]
+        public void Constructor_NoCommandTimeoutConfigured_PropagatesConnectionTimeout()
+        {
+            // Arrange
+            var options = new DbContextOptionsBuilder<TestDbContext>()
+                .UseSqlServer(ConnectionString)
+                .Options;
+
+            // Act
+            using var repository = new TestRepository(new TestDbContext(options));
+
+            // Assert
+            repository.DbContext.Database.GetCommandTimeout().Should().Be(300);
+        }
+
+        [Fact]
+        public void Constructor_InfiniteCommandTimeoutConfigured_KeepsIt()
+        {
+            // Arrange — EF Core encodes an infinite command timeout as 0, not null, so widening
+            // the constructor's guard to "null or 0" would silently cap it.
+            var options = new DbContextOptionsBuilder<TestDbContext>()
+                .UseSqlServer(ConnectionString, sqlServer => sqlServer.CommandTimeout(0))
+                .Options;
+
+            // Act
+            using var repository = new TestRepository(new TestDbContext(options));
+
+            // Assert
+            repository.DbContext.Database.GetCommandTimeout().Should().Be(0);
+        }
+
+        private class TestDbContext : DbContext
+        {
+            public TestDbContext(DbContextOptions<TestDbContext> options)
+                : base(options)
+            {
+            }
+        }
+
+        private class TestRepository : DbContextRepositoryBase<TestDbContext>
+        {
+            public TestRepository(TestDbContext dbContext)
+                : base(dbContext)
+            {
+            }
+        }
+    }
+}

--- a/tests/VirtoCommerce.Platform.Tests/UnitTests/DbContextRepositoryBaseTests.cs
+++ b/tests/VirtoCommerce.Platform.Tests/UnitTests/DbContextRepositoryBaseTests.cs
@@ -3,73 +3,72 @@ using Microsoft.EntityFrameworkCore;
 using VirtoCommerce.Platform.Data.Infrastructure;
 using Xunit;
 
-namespace VirtoCommerce.Platform.Tests.UnitTests
+namespace VirtoCommerce.Platform.Tests.UnitTests;
+
+public class DbContextRepositoryBaseTests
 {
-    public class DbContextRepositoryBaseTests
+    // No connection is opened by any of these tests: the command timeout lives on the facade.
+    private const string ConnectionString = "Server=localhost;Database=Test;Connect Timeout=300;";
+
+    [Fact]
+    public void Constructor_CommandTimeoutConfigured_KeepsConfiguredValue()
     {
-        // No connection is opened by any of these tests: the command timeout lives on the facade.
-        private const string ConnectionString = "Server=localhost;Database=Test;Connect Timeout=300;";
+        // Arrange
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseSqlServer(ConnectionString, sqlServer => sqlServer.CommandTimeout(42))
+            .Options;
 
-        [Fact]
-        public void Constructor_CommandTimeoutConfigured_KeepsConfiguredValue()
+        // Act
+        using var repository = new TestRepository(new TestDbContext(options));
+
+        // Assert
+        repository.DbContext.Database.GetCommandTimeout().Should().Be(42);
+    }
+
+    [Fact]
+    public void Constructor_NoCommandTimeoutConfigured_PropagatesConnectionTimeout()
+    {
+        // Arrange
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseSqlServer(ConnectionString)
+            .Options;
+
+        // Act
+        using var repository = new TestRepository(new TestDbContext(options));
+
+        // Assert
+        repository.DbContext.Database.GetCommandTimeout().Should().Be(300);
+    }
+
+    [Fact]
+    public void Constructor_InfiniteCommandTimeoutConfigured_KeepsIt()
+    {
+        // Arrange — EF Core encodes an infinite command timeout as 0, not null, so widening
+        // the constructor's guard to "null or 0" would silently cap it.
+        var options = new DbContextOptionsBuilder<TestDbContext>()
+            .UseSqlServer(ConnectionString, sqlServer => sqlServer.CommandTimeout(0))
+            .Options;
+
+        // Act
+        using var repository = new TestRepository(new TestDbContext(options));
+
+        // Assert
+        repository.DbContext.Database.GetCommandTimeout().Should().Be(0);
+    }
+
+    private class TestDbContext : DbContext
+    {
+        public TestDbContext(DbContextOptions<TestDbContext> options)
+            : base(options)
         {
-            // Arrange
-            var options = new DbContextOptionsBuilder<TestDbContext>()
-                .UseSqlServer(ConnectionString, sqlServer => sqlServer.CommandTimeout(42))
-                .Options;
-
-            // Act
-            using var repository = new TestRepository(new TestDbContext(options));
-
-            // Assert
-            repository.DbContext.Database.GetCommandTimeout().Should().Be(42);
         }
+    }
 
-        [Fact]
-        public void Constructor_NoCommandTimeoutConfigured_PropagatesConnectionTimeout()
+    private class TestRepository : DbContextRepositoryBase<TestDbContext>
+    {
+        public TestRepository(TestDbContext dbContext)
+            : base(dbContext)
         {
-            // Arrange
-            var options = new DbContextOptionsBuilder<TestDbContext>()
-                .UseSqlServer(ConnectionString)
-                .Options;
-
-            // Act
-            using var repository = new TestRepository(new TestDbContext(options));
-
-            // Assert
-            repository.DbContext.Database.GetCommandTimeout().Should().Be(300);
-        }
-
-        [Fact]
-        public void Constructor_InfiniteCommandTimeoutConfigured_KeepsIt()
-        {
-            // Arrange — EF Core encodes an infinite command timeout as 0, not null, so widening
-            // the constructor's guard to "null or 0" would silently cap it.
-            var options = new DbContextOptionsBuilder<TestDbContext>()
-                .UseSqlServer(ConnectionString, sqlServer => sqlServer.CommandTimeout(0))
-                .Options;
-
-            // Act
-            using var repository = new TestRepository(new TestDbContext(options));
-
-            // Assert
-            repository.DbContext.Database.GetCommandTimeout().Should().Be(0);
-        }
-
-        private class TestDbContext : DbContext
-        {
-            public TestDbContext(DbContextOptions<TestDbContext> options)
-                : base(options)
-            {
-            }
-        }
-
-        private class TestRepository : DbContextRepositoryBase<TestDbContext>
-        {
-            public TestRepository(TestDbContext dbContext)
-                : base(dbContext)
-            {
-            }
         }
     }
 }


### PR DESCRIPTION
## Description

`DbContextRepositoryBase<TContext>`'s constructor propagated the connection's `ConnectionTimeout` to the
command timeout **unconditionally**. That constructor runs on every repository resolution, so a command
timeout a module configured at DbContext-options time — `CommandTimeout(n)` in the provider options
action — was overwritten the first time a repository deriving from this base was resolved, and nothing
reported it.

The propagation is now guarded on `GetCommandTimeout() is null`, the shape
`DatabaseFacadeExtensions.MigrateIfNotApplied` already uses in this repo. A module that configured no
command timeout sees no change; a module that configured one now keeps it.

This matters most where the connection string is not the consumer's to edit. Where connection strings are
issued by cloud infrastructure and are read-only to the team consuming them, the unguarded propagation
left a module with no way to bound its own command timeout at all.

No schema change, no migrations, no new settings, no new dependencies.

The consumer that surfaced this: `vc-module-audit-log` https://github.com/VirtoCommerce/vc-module-audit-log/pull/21 — a module whose connection string is issued by infrastructure, so the guard is its only way to bound a command timeout.

## New GraphQL queries and mutations

None — this PR adds no GraphQL surface.

## Changes to existing GraphQL queries and mutations

None.

## New public services / interfaces / methods

None. `DbContextRepositoryBase<TContext>`'s constructor signature is unchanged.

## New protected methods (extensibility)

None.

## Breaking changes

**Behaviour change, visible only at runtime.** A module carrying a `CommandTimeout(...)` that has been
inert until now will see it take effect. Previously the connection string's `Connection Timeout` replaced
it on every repository resolution; it is now applied only when no command timeout was configured, matching
the long-standing behaviour of `DatabaseFacadeExtensions.MigrateIfNotApplied`.

Nothing in the toolchain will flag this: there is no signature change and no removed member, so no API-diff
tool and no `[Obsolete]` shim applies. It belongs in the release notes for that reason.

A survey of this repository and the 48 `vc-module-*` repositories available to the author found no
production call site that configures a command timeout at options time, so no module is expected to change
behaviour on upgrade today. `vc-module-catalog`'s `CatalogRepositoryImpl.ExecuteInTransactionWithTimeoutAsync`
is the only code that manipulates a command timeout at runtime, and it is unaffected — it saves and restores
around its own call, and the value it saves is the same before and after this change.

## New dependencies

None.

> **Note (why `is null`, and not also zero or negative)** — EF Core represents "no command timeout
> configured" as `null`, and `0` as a deliberately **infinite** timeout:
> `RelationalDatabaseFacadeExtensions.SetCommandTimeout(TimeSpan)` maps `Timeout.InfiniteTimeSpan` to `0`.
> Widening the guard to `is null or 0` would therefore replace an intentionally unbounded timeout with the
> connection's, silently. A negative value cannot occur — `RelationalConnection.CommandTimeout`'s setter
> throws for one. There is a test pinning each of the three cases.

## References
### QA-test:
### Jira-link: https://virtocommerce.atlassian.net/browse/VCST-5852
### Artifact URL:

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Low Risk**
> Small behavioral fix on repository construction; default timeout propagation is unchanged, and only contexts with an explicit options-time command timeout gain different runtime behavior.
> 
> **Overview**
> **`DbContextRepositoryBase`** no longer overwrites the EF command timeout on every repository construction. It now calls **`SetCommandTimeout`** from the connection’s **`Connect Timeout`** only when **`GetCommandTimeout()`** is **`null`**, matching the guard already used in **`MigrateIfNotApplied`**.
> 
> Modules that set **`CommandTimeout(...)`** in SQL Server (or other provider) options keep that value instead of having it replaced by the connection string timeout. When no command timeout is configured, behavior is unchanged—the connection timeout is still applied.
> 
> Unit tests cover a configured timeout, the null fallback to connection timeout, and preserving EF’s infinite timeout (**`0`**), so the guard stays **`is null`** only.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 0ce6fab1c917904a277a281e64eaee8f69743541. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->

Image tag:
ghcr.io/VirtoCommerce/platform:3.1064.0-pr-3107-0ce6-preserve-configured-command-timeout-0ce6fab1

