### PR TITLE
fix: Resolve a user delete by id only, never by user name

### DIFF
--- a/src/VirtoCommerce.Platform.Security/CustomUserManager.cs
+++ b/src/VirtoCommerce.Platform.Security/CustomUserManager.cs
@@ -201,17 +201,28 @@ namespace VirtoCommerce.Platform.Security
 
         public override async Task<IdentityResult> DeleteAsync(ApplicationUser user)
         {
+            // Find* methods return detached copies, but the store's context may already track the same user
+            // (loaded there by the cache-miss path). Deleting the copy would make EF reject the operation
+            // ("another instance with the same key value is already being tracked"), so resolve and delete
+            // the store's own instance instead. Resolve by id only: the user-name fallback in
+            // LoadExistingUser was added for UpdateUserAsync, and applied to a delete it removes whichever
+            // account owns that name whenever the id belongs to no row.
+            var existentUser = await LoadExistingUserById(user);
+
+            //We cant delete not existing user
+            if (existentUser is null)
+            {
+                //The cached lookups keep answering for a row that is already gone, so drop that entry too.
+                SecurityCacheRegion.ExpireUser(user);
+
+                return IdentityResult.Failed(ErrorDescriber.ConcurrencyFailure());
+            }
+
             var changedEntries = new List<GenericChangedEntry<ApplicationUser>>
             {
                 new(user, EntryState.Deleted),
             };
             await _eventPublisher.Publish(new UserChangingEvent(changedEntries));
-
-            // Find* methods return detached copies, but the store's context may already track the same user
-            // (loaded there by the cache-miss path). Deleting the copy would make EF reject the operation
-            // ("another instance with the same key value is already being tracked"), so resolve and delete
-            // the store's own instance instead.
-            var existentUser = await LoadExistingUser(user) ?? user;
 
             var result = await base.DeleteAsync(existentUser);
             if (result.Succeeded)
@@ -426,17 +437,35 @@ namespace VirtoCommerce.Platform.Security
         /// <returns>Returns null, if no user found, otherwise user with details.</returns>
         protected virtual async Task<ApplicationUser> LoadExistingUser(ApplicationUser user)
         {
+            var result = await LoadExistingUserById(user);
+
+            if (result is null)
+            {
+                //It is important to call base.FindByNameAsync method to avoid of update a cached user.
+                result = await base.FindByNameAsync(user.UserName);
+
+                if (result is not null)
+                {
+                    await LoadUserDetailsAsync(result);
+                }
+            }
+
+            return result;
+        }
+
+        /// <summary>
+        /// Finds existing user by its id alone and loads its details
+        /// </summary>
+        /// <param name="user"></param>
+        /// <returns>Returns null, if no user found, otherwise user with details.</returns>
+        protected virtual async Task<ApplicationUser> LoadExistingUserById(ApplicationUser user)
+        {
             ApplicationUser result = null;
 
             if (!string.IsNullOrEmpty(user.Id))
             {
                 //It is important to call base.FindByIdAsync method to avoid of update a cached user.
                 result = await base.FindByIdAsync(user.Id);
-            }
-            if (result is null)
-            {
-                //It is important to call base.FindByNameAsync method to avoid of update a cached user.
-                result = await base.FindByNameAsync(user.UserName);
             }
 
             if (result is not null)

--- a/tests/VirtoCommerce.Platform.Web.Tests/Security/CustomUserManagerDeleteTests.cs
+++ b/tests/VirtoCommerce.Platform.Web.Tests/Security/CustomUserManagerDeleteTests.cs
@@ -1,0 +1,93 @@
+using System.Threading;
+using System.Threading.Tasks;
+using FluentAssertions;
+using Microsoft.AspNetCore.Identity;
+using Moq;
+using VirtoCommerce.Platform.Core.Security;
+using Xunit;
+using static VirtoCommerce.Platform.Web.Tests.Security.PlatformWebMockHelper;
+
+namespace VirtoCommerce.Platform.Web.Tests.Security
+{
+    public class CustomUserManagerDeleteTests
+    {
+        private const string UserName = "somebody@example.com";
+
+        [Fact]
+        public async Task Delete_UserIdNotFound_DoesNotResolveByUserName()
+        {
+            //Arrange
+            //The id of an entity that was never stored still looks valid, because IdentityUser assigns one
+            //in its constructor. Resolving such a delete by user name takes down the account owning the name.
+            var unsaved = new ApplicationUser { UserName = UserName };
+
+            var userStoreMock = new Mock<IUserStore<ApplicationUser>>();
+            userStoreMock.Setup(x => x.FindByIdAsync(unsaved.Id, CancellationToken.None))
+                .ReturnsAsync((ApplicationUser)null);
+            userStoreMock.Setup(x => x.FindByNameAsync(It.IsAny<string>(), CancellationToken.None))
+                .ReturnsAsync(new ApplicationUser { Id = "owner-id", UserName = UserName });
+            userStoreMock.Setup(x => x.DeleteAsync(It.IsAny<ApplicationUser>(), CancellationToken.None))
+                .ReturnsAsync(IdentityResult.Success);
+
+            var userManager = SecurityMockHelper.TestCustomUserManager(userStoreMock, new EventPublisherStub());
+
+            //Act
+            await userManager.DeleteAsync(unsaved);
+
+            //Assert
+            userStoreMock.Verify(x => x.DeleteAsync(It.IsAny<ApplicationUser>(), CancellationToken.None), Times.Never);
+        }
+
+        [Fact]
+        public async Task Delete_UserIdNotFound_FailsWithoutPublishingEvents()
+        {
+            //Arrange
+            var unsaved = new ApplicationUser { UserName = UserName };
+
+            var userStoreMock = new Mock<IUserStore<ApplicationUser>>();
+            userStoreMock.Setup(x => x.FindByIdAsync(unsaved.Id, CancellationToken.None))
+                .ReturnsAsync((ApplicationUser)null);
+            userStoreMock.Setup(x => x.FindByNameAsync(It.IsAny<string>(), CancellationToken.None))
+                .ReturnsAsync(new ApplicationUser { Id = "owner-id", UserName = UserName });
+            userStoreMock.Setup(x => x.DeleteAsync(It.IsAny<ApplicationUser>(), CancellationToken.None))
+                .ReturnsAsync(IdentityResult.Success);
+
+            var eventPublisher = new EventPublisherStub();
+            var userManager = SecurityMockHelper.TestCustomUserManager(userStoreMock, eventPublisher);
+
+            //Act
+            var result = await userManager.DeleteAsync(unsaved);
+
+            //Assert
+            //A refused delete must not announce itself: UserChangingEvent is a veto point, and a handler
+            //that saw it without a matching UserChangedEvent would record a deletion that never happened.
+            result.Succeeded.Should().BeFalse();
+            eventPublisher.Events.Should().BeEmpty();
+        }
+
+        [Fact]
+        public async Task Update_UserIdNotFound_ResolvesByUserName()
+        {
+            //Arrange
+            //The name fallback in LoadExistingUser was added for this path, and stays here: only the delete
+            //path stopped using it.
+            var incoming = new ApplicationUser { UserName = UserName };
+            var stored = new ApplicationUser { Id = "stored-id", UserName = UserName };
+
+            var userStoreMock = new Mock<IUserStore<ApplicationUser>>();
+            userStoreMock.Setup(x => x.FindByIdAsync(incoming.Id, CancellationToken.None))
+                .ReturnsAsync((ApplicationUser)null);
+            userStoreMock.Setup(x => x.FindByNameAsync(It.IsAny<string>(), CancellationToken.None))
+                .ReturnsAsync(stored);
+
+            var userManager = SecurityMockHelper.TestCustomUserManager(userStoreMock, new EventPublisherStub());
+
+            //Act
+            var result = await userManager.UpdateAsync(incoming);
+
+            //Assert
+            result.Succeeded.Should().BeTrue();
+            userStoreMock.Verify(x => x.UpdateAsync(stored, CancellationToken.None), Times.Once);
+        }
+    }
+}


### PR DESCRIPTION
## Description

`CustomUserManager.DeleteAsync` resolved the row to delete through `LoadExistingUser`, which falls back to `FindByNameAsync` when the id finds nothing. A user object that was never stored still carries an `Id` — `IdentityUser` assigns one in its constructor — so a caller passing one deleted whichever account owns that user name instead.

The fallback was added for `UpdateUserAsync` (VP-2593) and reached the delete path when `DeleteAsync` started reusing the helper in 3.1058.0. Delete now resolves by id alone and returns `ConcurrencyFailure` when the id matches no row — the code `UserStore.DeleteAsync` already returns for that condition, so no observable result changes. The refusal happens before `UserChangingEvent` is published, matching `UpdateUserAsync`, and evicts the cache entry that supplied the dead id. `LoadExistingUser` and the update path are unchanged; the id-only lookup is factored out into `LoadExistingUserById`.

The tracked-instance behaviour introduced in 3.1058.0 is preserved — the id lookup still returns the store's own instance — and the existing `CustomUserManagerCloneOnReadTests.DeleteAsync_DeletesTheStoreOwnInstance_NotTheDetachedCopy` stays green.

## References
### QA-test:
Three tests in `CustomUserManagerDeleteTests`, using the existing `SecurityMockHelper`: the first two fail without the change, the third pins the by-name resolution the update path still needs. Verified end to end on a local stand — an invite for an e-mail that already has a login no longer deletes that login.

Note `VirtoCommerce.Platform.Tests` has one unrelated failing test on current `dev`, `CronSettingTests.Validator_Accepts_Valid_Cron`, which this change does not touch.
### Jira-link:
### Artifact URL:

Image tag:
ghcr.io/VirtoCommerce/platform:3.1069.0-pr-3113-8e37-delete-resolves-by-user-name-8e374a2d